### PR TITLE
[Harbor 2/4] eval sidecar: verifier, token auth, HTTP API (Mode A)

### DIFF
--- a/vero/src/vero/harbor/__init__.py
+++ b/vero/src/vero/harbor/__init__.py
@@ -1,0 +1,19 @@
+"""Harbor integration: the sidecar-specific frontend over the shared
+EvaluationEngine, plus Mode B (Harbor-delegated eval). The `harbor` SDK is an
+optional extra, imported lazily (only registry enumeration / nested runs need it —
+config, dataset compilation, and the sidecar handlers do not).
+"""
+
+from vero.harbor.config import HarborConfig
+from vero.harbor.dataset import (
+    build_harbor_dataset,
+    enumerate_local_task_names,
+    validate_partition,
+)
+
+__all__ = [
+    "HarborConfig",
+    "build_harbor_dataset",
+    "enumerate_local_task_names",
+    "validate_partition",
+]

--- a/vero/src/vero/harbor/app.py
+++ b/vero/src/vero/harbor/app.py
@@ -1,0 +1,91 @@
+"""FastAPI app for the eval sidecar — the HTTP surface over the (transport-agnostic)
+EvaluationSidecar handlers + the admin `finalize` over the Verifier.
+
+Two roles over one app: agent (`/eval`, `/submit`, `/status`; unauthenticated, metered,
+redacted) and admin (`/finalize`; bearer-token gated). `vero harbor serve` runs
+this under uvicorn in the eval-sidecar container.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from vero.evaluation.engine import EvalRequest
+from vero.exceptions import ExperimentBudgetExceeded, InvalidSplitError
+from vero.harbor.auth import check_admin
+from vero.harbor.server import SubmitDisabledError
+from vero.harbor.verifier import NoCandidateError
+
+if TYPE_CHECKING:
+    from vero.harbor.server import EvaluationSidecar
+    from vero.harbor.verifier import Verifier
+
+
+class EvalBody(BaseModel):
+    dataset_id: str
+    split: str
+    commit: str | None = None
+    sample_ids: list[int] | None = None
+    num_samples: int | None = None
+
+
+class SubmitBody(BaseModel):
+    commit: str | None = None
+
+
+def create_app(
+    *,
+    sidecar: EvaluationSidecar,
+    verifier: Verifier,
+    admin_token: str,
+) -> FastAPI:
+    app = FastAPI(title="vero eval sidecar")
+
+    # Known errors -> agent-facing status codes.
+    app.add_exception_handler(
+        ExperimentBudgetExceeded,
+        lambda r, e: JSONResponse(status_code=429, content={"error": str(e)}),
+    )
+    app.add_exception_handler(
+        InvalidSplitError,
+        lambda r, e: JSONResponse(status_code=400, content={"error": str(e)}),
+    )
+    app.add_exception_handler(
+        SubmitDisabledError,
+        lambda r, e: JSONResponse(status_code=409, content={"error": str(e)}),
+    )
+    app.add_exception_handler(
+        NoCandidateError,
+        lambda r, e: JSONResponse(status_code=409, content={"error": str(e)}),
+    )
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    # --- agent endpoints (unauthenticated; metered + redacted) ---
+    @app.post("/eval")
+    async def eval_(body: EvalBody):
+        summary = await sidecar.evaluate(EvalRequest(**body.model_dump()), admin=False)
+        return summary.to_dict()
+
+    @app.post("/submit")
+    async def submit(body: SubmitBody):
+        return await sidecar.submit(commit=body.commit)
+
+    @app.get("/status")
+    async def status():
+        return sidecar.status().to_dict()
+
+    # --- admin endpoint (bearer-token gated) ---
+    @app.post("/finalize")
+    async def finalize(authorization: str | None = Header(default=None)):
+        if not check_admin(authorization, admin_token):
+            raise HTTPException(status_code=403, detail="admin token required")
+        return await verifier.finalize()
+
+    return app

--- a/vero/src/vero/harbor/auth.py
+++ b/vero/src/vero/harbor/auth.py
@@ -1,0 +1,39 @@
+"""Admin-token auth for the eval sidecar.
+
+The token gates the admin `finalize` endpoint. It is generated per trial by the
+sidecar and written `root:600` on a volume mounted into `main`, so the verifier
+(root, shared mode) can read it but the optimizer (`agent.user`) cannot. The
+optimizer therefore can only reach the agent endpoints, never `finalize`.
+"""
+
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+
+_BEARER = "Bearer "
+
+
+def generate_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def write_admin_token(path: Path | str, token: str, *, mode: int = 0o600) -> Path:
+    """Write the token to ``path`` with restrictive perms (caller runs as root so the
+    file is root-owned and unreadable by ``agent.user``)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(token)
+    p.chmod(mode)
+    return p
+
+
+def read_admin_token(path: Path | str) -> str:
+    return Path(path).read_text().strip()
+
+
+def check_admin(authorization: str | None, expected_token: str) -> bool:
+    """Constant-time check of an ``Authorization: Bearer <token>`` header."""
+    if not authorization or not authorization.startswith(_BEARER):
+        return False
+    return secrets.compare_digest(authorization[len(_BEARER):], expected_token)

--- a/vero/src/vero/harbor/cli.py
+++ b/vero/src/vero/harbor/cli.py
@@ -1,0 +1,127 @@
+"""`vero harbor` CLI.
+
+Thin clients the optimizer and verifier use inside the compiled task:
+  - agent (in `main`):    eval / submit / status  -> POST/GET the sidecar over VERO_EVAL_URL
+  - verifier (in `main`): finalize                -> POST /finalize with the admin token,
+                                                     write /logs/verifier/reward.json
+`serve` (sidecar entry) and `build`/`run` (host-side compiler) are added with stage (c).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import click
+
+
+def _base_url() -> str:
+    url = os.environ.get("VERO_EVAL_URL")
+    if not url:
+        raise click.ClickException("VERO_EVAL_URL is not set (the eval sidecar URL).")
+    return url.rstrip("/")
+
+
+def _request(method: str, path: str, *, payload: dict | None = None, headers: dict | None = None):
+    import httpx
+
+    resp = httpx.request(
+        method, f"{_base_url()}{path}", json=payload, headers=headers or {}, timeout=None
+    )
+    if resp.status_code >= 400:
+        raise click.ClickException(f"{method} {path} -> {resp.status_code}: {resp.text}")
+    return resp.json()
+
+
+@click.group()
+def harbor() -> None:
+    """Vero ⇄ Harbor: optimization-as-a-Harbor-task commands."""
+
+
+@harbor.command("serve")
+@click.option("--config", "config_path", required=True, help="Path to the ServeConfig JSON.")
+def serve_cmd(config_path):
+    """Eval-sidecar entrypoint: assemble the engine/sidecar/verifier and serve (uvicorn)."""
+    from vero.harbor.serve import serve
+
+    serve(config_path)
+
+
+@harbor.command("build")
+@click.option("-c", "--config", "config_path", required=True, help="Path to build.yaml.")
+@click.option("-o", "--out", required=True, help="Output task directory.")
+def build_cmd(config_path, out):
+    """Compile a build.yaml into a runnable Harbor optimization task directory."""
+    from vero.harbor.build import BuildConfig, compile_task
+
+    task_dir = compile_task(BuildConfig.from_file(config_path), out)
+    click.echo(f"Compiled task -> {task_dir}")
+
+
+@harbor.command("run", context_settings={"ignore_unknown_options": True})
+@click.option("-c", "--config", "config_path", required=True, help="Path to build.yaml.")
+@click.option("-a", "--agent", required=True, help="Optimizer agent (passed to harbor run).")
+@click.option("-m", "--model", default=None, help="Model for the optimizer agent.")
+@click.option("-e", "--environment", "provider", default="docker", show_default=True)
+@click.argument("extra", nargs=-1, type=click.UNPROCESSED)
+def run_cmd(config_path, agent, model, provider, extra):
+    """Build to a temp dir, then `harbor run` it (build + run convenience)."""
+    import subprocess
+    import tempfile
+
+    from vero.harbor.build import BuildConfig, compile_task
+
+    task_dir = compile_task(BuildConfig.from_file(config_path), Path(tempfile.mkdtemp()) / "task")
+    cmd = ["uvx", "harbor", "run", "-p", str(task_dir), "-a", agent, "-e", provider]
+    if model:
+        cmd += ["-m", model]
+    cmd += list(extra)
+    click.echo(f"$ {' '.join(cmd)}")
+    raise SystemExit(subprocess.call(cmd))
+
+
+@harbor.command("eval")
+@click.option("--dataset-id", required=True)
+@click.option("--split", required=True)
+@click.option("--commit", default=None, help="Defaults to the agent repo HEAD.")
+@click.option("--num-samples", type=int, default=None)
+@click.option("--sample-ids", default=None, help="Comma-separated sample ids.")
+def eval_cmd(dataset_id, split, commit, num_samples, sample_ids):
+    """Spend one evaluation of your commit on a split (agent)."""
+    payload: dict = {"dataset_id": dataset_id, "split": split}
+    if commit:
+        payload["commit"] = commit
+    if num_samples is not None:
+        payload["num_samples"] = num_samples
+    if sample_ids:
+        payload["sample_ids"] = [int(x) for x in sample_ids.split(",")]
+    click.echo(json.dumps(_request("POST", "/eval", payload=payload), indent=2))
+
+
+@harbor.command("submit")
+@click.option("--commit", default=None, help="Defaults to the agent repo HEAD.")
+def submit_cmd(commit):
+    """Nominate a commit and end the optimization run (agent; if enabled)."""
+    click.echo(json.dumps(_request("POST", "/submit", payload={"commit": commit}), indent=2))
+
+
+@harbor.command("status")
+def status_cmd():
+    """Show remaining budget, evaluable splits, and whether submit is enabled (agent)."""
+    click.echo(json.dumps(_request("GET", "/status"), indent=2))
+
+
+@harbor.command("finalize")
+@click.option("--token-file", required=True, help="Path to the admin token (root:600).")
+@click.option("--output", default="/logs/verifier/reward.json", show_default=True)
+def finalize_cmd(token_file, output):
+    """Verifier: select the best/submitted commit, score on the test split, write reward.json (admin)."""
+    from vero.harbor.auth import read_admin_token
+
+    token = read_admin_token(token_file)
+    reward = _request("POST", "/finalize", headers={"Authorization": f"Bearer {token}"})
+    out = Path(output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(reward))
+    click.echo(json.dumps(reward, indent=2))

--- a/vero/src/vero/harbor/config.py
+++ b/vero/src/vero/harbor/config.py
@@ -1,0 +1,35 @@
+"""HarborConfig — the Mode-B configuration.
+
+User-facing config that turns "evaluate my agent on a set of Harbor tasks" into a
+`harbor run` invocation. A typed projection of the user-controllable `harbor run`
+flags; the per-eval-derived flags (task selection, jobs dir, source/agent resolution)
+are filled in by the runner, not here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class HarborConfig:
+    task_source: str  # registry ref "org/name[@ver]" OR a local path to a task dir/dataset
+    agent_import_path: str  # module path to the candidate agent, e.g. "pkg.mod:Class"
+    model: str | None = None
+    environment: str = "modal"  # cloud provider (docker allowed for local testing)
+    n_attempts: int = 1
+    max_retries: int = 2
+    reward_key: str | None = None  # primary reward; default pass -> reward -> mean
+    extra_args: list[str] = field(default_factory=list)  # passthrough harbor run flags
+
+    @property
+    def is_registry(self) -> bool:
+        """Local if the source resolves to an existing path; otherwise a registry ref."""
+        return not Path(self.task_source).expanduser().exists()
+
+    def source_args(self) -> list[str]:
+        """`harbor run` source selector: `-d <ref>` (registry) or `-p <path>` (local)."""
+        if self.is_registry:
+            return ["-d", self.task_source]
+        return ["-p", str(Path(self.task_source).expanduser())]

--- a/vero/src/vero/harbor/dataset.py
+++ b/vero/src/vero/harbor/dataset.py
@@ -1,0 +1,80 @@
+"""Build the vero dataset (task-name references + split partition) for Mode B.
+
+A Mode-B vero dataset has no labels — each "sample" is a Harbor task name. A local
+task's name is its subdirectory name (the dir containing ``task.toml``), matching what
+``harbor run -i/--include-task-name`` filters on; registry task names come from the
+registry's task configs.
+
+The split partition is a ``dict[str, list[str]]`` (e.g. ``{"train": [...], "test": [...]}``)
+supplied by the benchmark author; this module compiles + validates it into a DatasetDict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datasets import DatasetDict
+
+
+def build_harbor_dataset(partition: dict[str, list[str]]) -> DatasetDict:
+    """Compile a ``{split: [task_names]}`` partition into a vero DatasetDict.
+
+    Each split is a single-column (`task_name`) Dataset — the label-free sample
+    references Mode B evaluates.
+    """
+    from datasets import Dataset, DatasetDict
+
+    if not partition:
+        raise ValueError("Harbor dataset partition is empty.")
+    return DatasetDict(
+        {split: Dataset.from_dict({"task_name": list(names)}) for split, names in partition.items()}
+    )
+
+
+def enumerate_local_task_names(task_source: str | Path) -> list[str]:
+    """Task names available in a local Harbor task source.
+
+    If the path is itself a task dir (contains ``task.toml``), returns ``[dir_name]``;
+    otherwise returns the names of immediate subdirectories that contain ``task.toml``.
+    """
+    path = Path(task_source).expanduser()
+    if (path / "task.toml").exists():
+        return [path.name]
+    if not path.is_dir():
+        raise ValueError(f"Local task source is not a directory: {path}")
+    return sorted(
+        d.name for d in path.iterdir() if d.is_dir() and (d / "task.toml").exists()
+    )
+
+
+async def enumerate_registry_task_names(
+    ref: str, *, registry_url: str | None = None
+) -> list[str]:
+    """Task names in a registry dataset (``org/name[@version]``).
+
+    Lazy-imports the ``harbor`` SDK (the ``harbor`` extra) — registry resolution is a
+    build-time concern, not a sidecar-runtime one. Integration-verified.
+    """
+    from harbor.models.job.config import RegistryDatasetConfig
+    from harbor.models.registry import RemoteRegistryInfo
+
+    name, _, version = ref.partition("@")
+    config = RegistryDatasetConfig(
+        registry=RemoteRegistryInfo(url=registry_url) if registry_url else None,
+        name=name,
+        version=version or None,
+    )
+    return sorted(tc.path.name for tc in await config.get_task_configs())
+
+
+def validate_partition(partition: dict[str, list[str]], available: list[str]) -> None:
+    """Raise if the partition references task names not in ``available``."""
+    avail = set(available)
+    referenced = {name for names in partition.values() for name in names}
+    unknown = referenced - avail
+    if unknown:
+        raise ValueError(
+            f"Partition references task names not found in the source: {sorted(unknown)}"
+        )

--- a/vero/src/vero/harbor/protocol.py
+++ b/vero/src/vero/harbor/protocol.py
@@ -9,11 +9,14 @@ delivered as files on the agent-readable volume, gated by split tier.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict, dataclass, field
 
 from vero.core.budget import SplitBudget
 from vero.core.dataset.base import SplitAccess, SplitAccessLevel
 from vero.core.db.database import Experiment
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -54,11 +57,22 @@ class StatusSummary:
 
 
 def tier_for_split(split: str, split_accesses: list[SplitAccess]) -> SplitAccessLevel:
-    """Resolve a split's visibility tier (default: viewable when unlisted)."""
+    """Resolve a split's visibility tier.
+
+    Fails CLOSED: an unlisted split is treated as ``no_access`` (not
+    agent-evaluable, nothing written to the agent volume). A split with no
+    declared access is a misconfiguration, not an invitation to expose labels,
+    so we log a warning and deny rather than default to the most permissive tier.
+    """
     for sa in split_accesses:
         if sa.split == split:
             return sa.access
-    return SplitAccessLevel.viewable
+    logger.warning(
+        "Split %r has no declared access level; failing closed to no_access. "
+        "Declare it explicitly in split_accesses if the agent should see it.",
+        split,
+    )
+    return SplitAccessLevel.no_access
 
 
 def summarize_experiment(

--- a/vero/src/vero/harbor/protocol.py
+++ b/vero/src/vero/harbor/protocol.py
@@ -1,0 +1,106 @@
+"""Wire types for the eval sidecar's HTTP frontend, and the redaction that
+projects a full Experiment down to what the agent may see.
+
+`EvalRequest` (the request) lives in `vero.evaluation.engine` — it is shared with
+the in-process tool. The *response* types here are sidecar-specific: they are
+aggregate-safe by construction (never per-sample), because per-sample detail is
+delivered as files on the agent-readable volume, gated by split tier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+from vero.core.budget import SplitBudget
+from vero.core.dataset.base import SplitAccess, SplitAccessLevel
+from vero.core.db.database import Experiment
+
+
+@dataclass
+class EvalSummary:
+    """Aggregate-safe response to an agent evaluate call.
+
+    Carries no per-sample data. Per-sample detail (for visible splits) and
+    summary stats (for partial splits) are written to the agent-readable volume
+    at `result_path`; nothing is written there for no_access splits.
+    """
+
+    commit: str
+    split: str
+    dataset_id: str
+    n_samples: int
+    mean_score: float | None
+    result_path: str | None  # where on the agent volume to read detail (None if nothing written)
+    budget_remaining: SplitBudget | None = None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        if self.budget_remaining is not None:
+            d["budget_remaining"] = asdict(self.budget_remaining)
+        return d
+
+
+@dataclass
+class StatusSummary:
+    """Response to a status call. `submit_enabled` (not the verifier-internal
+    selection strategy) is what the agent needs to know."""
+
+    submit_enabled: bool
+    # per (split, dataset_id): tier + whether the agent may evaluate it + remaining budget
+    splits: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def tier_for_split(split: str, split_accesses: list[SplitAccess]) -> SplitAccessLevel:
+    """Resolve a split's visibility tier (default: viewable when unlisted)."""
+    for sa in split_accesses:
+        if sa.split == split:
+            return sa.access
+    return SplitAccessLevel.viewable
+
+
+def summarize_experiment(
+    experiment: Experiment,
+    *,
+    result_path: str | None,
+    budget_remaining: SplitBudget | None = None,
+) -> EvalSummary:
+    """Project a full Experiment to an aggregate-safe EvalSummary."""
+    return EvalSummary(
+        commit=experiment.run.candidate.commit,
+        split=experiment.run.dataset_subset.split,
+        dataset_id=experiment.run.dataset_subset.dataset_id,
+        n_samples=len(experiment.result.sample_results),
+        mean_score=experiment.result.score(),
+        result_path=result_path,
+        budget_remaining=budget_remaining,
+    )
+
+
+def build_status(
+    *,
+    submit_enabled: bool,
+    budget: dict[tuple[str, str], SplitBudget],
+    split_accesses: list[SplitAccess],
+) -> StatusSummary:
+    """Build the agent-facing status from the budget ledger + split tiers.
+
+    Only budgeted (split, dataset_id) pairs are listed — those are exactly what
+    the agent may evaluate. no_access splits are not in the agent ledger.
+    """
+    splits = []
+    for (split, dataset_id), b in budget.items():
+        tier = tier_for_split(split, split_accesses)
+        splits.append(
+            {
+                "split": split,
+                "dataset_id": dataset_id,
+                "tier": str(tier),
+                "agent_evaluable": tier != SplitAccessLevel.no_access,
+                "remaining_sample_budget": b.remaining_sample_budget,
+                "remaining_run_budget": b.remaining_run_budget,
+            }
+        )
+    return StatusSummary(submit_enabled=submit_enabled, splits=splits)

--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -8,8 +8,10 @@ contract.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -60,7 +62,7 @@ class ServeConfig(BaseModel):
     harbor: dict | None = None  # HarborConfig kwargs
 
     # selection / reward
-    reward_mode: str = "auto_best"
+    reward_mode: Literal["submit", "auto_best"] = "auto_best"
     selection_split: str = "validation"
     targets: list[_TargetCfg] = Field(default_factory=list)
     base_commit: str | None = None
@@ -85,15 +87,73 @@ class ServeConfig(BaseModel):
         return cls.model_validate_json(Path(path).read_text())
 
 
+def _load_or_build_ledger(
+    budget_cfgs: list[dict], persist_path: Path
+) -> BudgetLedger:
+    """Build the durable ledger, reloading spent budget from ``persist_path`` if present.
+
+    The ledger flushes every mutation to ``persist_path``; without reloading it,
+    a sidecar restart would reset all spent budget to full, letting the agent
+    regain its full evaluation budget by triggering a restart. On startup we
+    reconstruct each SplitBudget and restore its persisted ``remaining_*`` values.
+    Falls back to the configured budgets if the file is missing or unreadable
+    (fail-safe to the configured budget, never to unlimited).
+    """
+    if persist_path.exists():
+        try:
+            persisted = json.loads(persist_path.read_text())
+            budgets: list[SplitBudget] = []
+            for entry in persisted:
+                b = SplitBudget(
+                    split=entry["split"],
+                    dataset_id=entry.get("dataset_id", ""),
+                    total_sample_budget=entry.get("total_sample_budget"),
+                    total_run_budget=entry.get("total_run_budget"),
+                    max_samples_per_run=entry.get("max_samples_per_run"),
+                )
+                # __post_init__ reset remaining_* to total_*; restore spent state.
+                b.remaining_sample_budget = entry.get("remaining_sample_budget")
+                b.remaining_run_budget = entry.get("remaining_run_budget")
+                budgets.append(b)
+            logger.info(
+                "Reloaded persisted budget ledger from %s (%d splits).",
+                persist_path,
+                len(budgets),
+            )
+            return BudgetLedger(budgets, persist_path=persist_path)
+        except (json.JSONDecodeError, KeyError, OSError) as e:
+            logger.warning(
+                "Could not reload persisted ledger %s (%s); using configured budgets.",
+                persist_path,
+                e,
+            )
+    return BudgetLedger(
+        [SplitBudget(**b) for b in budget_cfgs], persist_path=persist_path
+    )
+
+
 async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Verifier, str]:
     """Assemble the sidecar + verifier (sharing one engine) and the admin token."""
     vero_home = get_vero_home_dir()
+
+    # Integrity guard: in Mode A the vero scorer (@task.evaluation()) is resolved
+    # and executed by the Evaluator. With task_project unset, that scorer would be
+    # discovered from the AGENT's committed repo, so a committed scorer returning
+    # 1.0 would win the hidden-split/admin reward. Require a sidecar-baked task
+    # project so the scorer is trusted (agent code is layered as --with-editable,
+    # never the scorer's source). Mode B (config.harbor set) uses an eval_strategy
+    # that ignores the vero scorer and is exempt.
+    if config.harbor is None and not config.task_project:
+        raise ValueError(
+            "Mode A requires `task_project` so the scorer is loaded from the "
+            "sidecar-baked task project, not the agent's committed repo. Refusing "
+            "to start: with task_project unset the agent controls its own scoring."
+        )
+
     workspace = await GitWorkspace.create(config.repo_path)
 
-    budget = BudgetLedger(
-        [SplitBudget(**b) for b in config.budgets],
-        persist_path=Path(config.admin_volume) / "ledger.json",
-    )
+    persist_path = Path(config.admin_volume) / "ledger.json"
+    budget = _load_or_build_ledger(config.budgets, persist_path)
 
     eval_strategy = None
     if config.harbor is not None:
@@ -142,10 +202,12 @@ async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Veri
     verifier = Verifier(
         engine=engine,
         admin_volume=Path(config.admin_volume),
-        reward_mode=config.reward_mode,  # type: ignore[arg-type]
+        reward_mode=config.reward_mode,
         targets=[VerificationTarget(**t.model_dump()) for t in config.targets],
         selection_split=config.selection_split,
         base_commit=config.base_commit,
+        selection_task=config.task,
+        selection_dataset_id=config.dataset_id,
     )
 
     token = generate_token()

--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -1,0 +1,170 @@
+"""`vero harbor serve` — the eval-sidecar entrypoint.
+
+Assembles the EvaluationEngine + EvaluationSidecar + Verifier from a ServeConfig
+(written by the compiler, baked into the sidecar image), generates the per-trial admin
+token, and serves the FastAPI app under uvicorn. ServeConfig is the compiler↔serve
+contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from vero.core.budget import BudgetLedger, SplitBudget
+from vero.core.dataset.base import SplitAccess, SplitAccessLevel
+from vero.core.db.database import ExperimentDatabase
+from vero.core.evaluation import BaseEvaluationParameters
+from vero.core.sessions import get_vero_home_dir
+from vero.evaluation.engine import EvaluationEngine
+from vero.evaluation.evaluator import Evaluator
+from vero.harbor.app import create_app
+from vero.harbor.auth import generate_token, write_admin_token
+from vero.harbor.server import EvaluationSidecar
+from vero.harbor.verifier import VerificationTarget, Verifier
+from vero.workspace.git import GitWorkspace
+
+logger = logging.getLogger(__name__)
+
+
+class _SplitAccessCfg(BaseModel):
+    split: str
+    access: str  # "viewable" | "non_viewable" | "no_access"
+
+
+class _TargetCfg(BaseModel):
+    task: str | None = None
+    dataset_id: str
+    split: str
+    reward_key: str = "reward"
+    sample_ids: list[int] | None = None
+
+
+class ServeConfig(BaseModel):
+    """Everything the sidecar needs to assemble itself. Baked by the compiler."""
+
+    repo_path: str            # sidecar's own repo (baseline target) = the engine workspace
+    agent_repo_path: str      # mounted agent workspace (commit-transfer source)
+    session_id: str
+    dataset_id: str           # already registered in the sidecar's VERO_HOME
+    split_accesses: list[_SplitAccessCfg]
+    budgets: list[dict]       # SplitBudget kwargs
+
+    # Mode A
+    task: str | None = None
+    task_project: str | None = None
+    task_module: str | None = None
+    # Mode B
+    harbor: dict | None = None  # HarborConfig kwargs
+
+    # selection / reward
+    reward_mode: str = "auto_best"
+    selection_split: str = "validation"
+    targets: list[_TargetCfg] = Field(default_factory=list)
+    base_commit: str | None = None
+    submit_enabled: bool = False
+
+    # volumes / token
+    agent_volume: str
+    admin_volume: str
+    admin_token_path: str
+
+    # eval params
+    timeout: int = 600
+    sample_timeout: int = 180
+    max_concurrency: int = 20
+    use_copy: bool = True  # isolate each eval in a temp copy (clean tree, concurrency-safe)
+
+    host: str = "0.0.0.0"
+    port: int = 8000
+
+    @classmethod
+    def from_file(cls, path: Path | str) -> ServeConfig:
+        return cls.model_validate_json(Path(path).read_text())
+
+
+async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Verifier, str]:
+    """Assemble the sidecar + verifier (sharing one engine) and the admin token."""
+    vero_home = get_vero_home_dir()
+    workspace = await GitWorkspace.create(config.repo_path)
+
+    budget = BudgetLedger(
+        [SplitBudget(**b) for b in config.budgets],
+        persist_path=Path(config.admin_volume) / "ledger.json",
+    )
+
+    eval_strategy = None
+    if config.harbor is not None:
+        from vero.harbor.runner import HarborRunner
+        from vero.harbor.config import HarborConfig
+
+        eval_strategy = HarborRunner(HarborConfig(**config.harbor))
+
+    evaluator = Evaluator(
+        workspace,
+        config.session_id,
+        vero_home=vero_home,
+        use_copy=config.use_copy,
+        task_project=Path(config.task_project) if config.task_project else None,
+        task_module=config.task_module,
+        eval_strategy=eval_strategy,
+    )
+
+    db = ExperimentDatabase(id=config.session_id)  # shared by engine (writes) + verifier (reads)
+    engine = EvaluationEngine(
+        evaluator=evaluator,
+        budget=budget,
+        default_task=config.task,
+        db=db,
+        run_constraints=BaseEvaluationParameters(
+            timeout=config.timeout,
+            sample_timeout=config.sample_timeout,
+            max_concurrency=config.max_concurrency,
+        ),
+        session_id=config.session_id,
+        vero_home=vero_home,
+    )
+
+    split_accesses = [
+        SplitAccess(split=s.split, access=SplitAccessLevel(s.access))
+        for s in config.split_accesses
+    ]
+    sidecar = EvaluationSidecar(
+        engine=engine,
+        split_accesses=split_accesses,
+        agent_repo_path=Path(config.agent_repo_path),
+        agent_volume=Path(config.agent_volume),
+        admin_volume=Path(config.admin_volume),
+        submit_enabled=config.submit_enabled,
+    )
+    verifier = Verifier(
+        engine=engine,
+        admin_volume=Path(config.admin_volume),
+        reward_mode=config.reward_mode,  # type: ignore[arg-type]
+        targets=[VerificationTarget(**t.model_dump()) for t in config.targets],
+        selection_split=config.selection_split,
+        base_commit=config.base_commit,
+    )
+
+    token = generate_token()
+    write_admin_token(config.admin_token_path, token)
+    return sidecar, verifier, token
+
+
+async def build_app(config: ServeConfig):
+    sidecar, verifier, token = await build_components(config)
+    return create_app(sidecar=sidecar, verifier=verifier, admin_token=token)
+
+
+def serve(config_path: Path | str) -> None:
+    """Sidecar entrypoint: build the app and run it under uvicorn."""
+    import asyncio
+
+    import uvicorn
+
+    config = ServeConfig.from_file(config_path)
+    app = asyncio.run(build_app(config))
+    logger.info(f"Serving eval sidecar on {config.host}:{config.port}")
+    uvicorn.run(app, host=config.host, port=config.port)

--- a/vero/src/vero/harbor/server.py
+++ b/vero/src/vero/harbor/server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 from dataclasses import replace
 from pathlib import Path
 
@@ -163,6 +164,12 @@ class EvaluationSidecar:
 
         commit = experiment.run.candidate.commit
         dest = self.agent_volume / "results" / f"{split}__{commit[:12]}"
+        # Recreate the dir so it reflects exactly this metered run. The dir is keyed
+        # only on (split, commit[:12]); a prior eval of the same commit on a larger
+        # sample set would otherwise leave stale per-sample files behind that this
+        # run did not produce, and result_path would surface them as if they were.
+        if dest.exists():
+            shutil.rmtree(dest)
         dest.mkdir(parents=True, exist_ok=True)
 
         # Aggregate summary is label-safe for both visible and partial tiers.

--- a/vero/src/vero/harbor/server.py
+++ b/vero/src/vero/harbor/server.py
@@ -1,0 +1,186 @@
+"""EvaluationSidecar: the privileged, transport-agnostic frontend over the
+EvaluationEngine, plus the trust-boundary mechanics that only exist in the Harbor
+sidecar — commit transfer from the mounted agent repo and tier-gated
+write-routing of results across the two volumes.
+
+The HTTP binding (`serve()`) is a thin shell added when the `vero harbor serve`
+CLI lands; these handlers are framework-agnostic and unit-testable on their own.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import replace
+from pathlib import Path
+
+from vero.core.dataset.base import SplitAccess, SplitAccessLevel
+from vero.core.db.database import Experiment
+from vero.evaluation.engine import EvalRequest, EvaluationEngine
+from vero.exceptions import InvalidSplitError
+from vero.harbor.protocol import (
+    EvalSummary,
+    StatusSummary,
+    build_status,
+    summarize_experiment,
+    tier_for_split,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CommitTransferError(RuntimeError):
+    """Raised when a commit cannot be fetched from the agent's mounted repo."""
+
+
+class SubmitDisabledError(RuntimeError):
+    """Raised when submit() is called but the task does not use submit selection."""
+
+
+class EvaluationSidecar:
+    """Agent-facing handlers over the EvaluationEngine.
+
+    Wraps the engine with: commit transfer (mounted agent repo -> sidecar repo),
+    result write-routing by split tier, and aggregate-safe responses. The engine
+    meters agent calls (admin calls bypass).
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: EvaluationEngine,
+        split_accesses: list[SplitAccess],
+        agent_repo_path: Path,
+        agent_volume: Path,
+        admin_volume: Path,
+        submit_enabled: bool = False,
+    ):
+        self.engine = engine
+        self.split_accesses = split_accesses
+        self.agent_repo_path = Path(agent_repo_path)
+        self.agent_volume = Path(agent_volume)
+        self.admin_volume = Path(admin_volume)
+        self.submit_enabled = submit_enabled
+
+    # ------------------------------------------------------------------
+    # Handlers (the HTTP layer resolves `admin` from auth and calls these)
+    # ------------------------------------------------------------------
+
+    async def evaluate(self, req: EvalRequest, *, admin: bool = False) -> EvalSummary:
+        sha = await self._transfer_commit(req.commit)
+        exp = await self.engine.evaluate(replace(req, commit=sha), admin=admin)
+        result_path = self._route_results(exp, admin=admin)
+        budget_remaining = None
+        if not admin:
+            try:
+                budget_remaining = self.engine.budget.get(req.dataset_id, req.split)
+            except InvalidSplitError:
+                pass
+        return summarize_experiment(
+            exp, result_path=result_path, budget_remaining=budget_remaining
+        )
+
+    async def submit(self, commit: str | None = None) -> dict:
+        """Record the agent's nominated commit; terminal. No score returned."""
+        if not self.submit_enabled:
+            raise SubmitDisabledError(
+                "This task does not use submit-based selection; submit is disabled."
+            )
+        sha = await self._transfer_commit(commit)
+        self.admin_volume.mkdir(parents=True, exist_ok=True)
+        (self.admin_volume / "submission.json").write_text(
+            json.dumps({"commit": sha}, indent=2)
+        )
+        return {"submitted_commit": sha}
+
+    def status(self) -> StatusSummary:
+        return build_status(
+            submit_enabled=self.submit_enabled,
+            budget=self.engine.budget.status(),
+            split_accesses=self.split_accesses,
+        )
+
+    # ------------------------------------------------------------------
+    # Trust-boundary mechanics
+    # ------------------------------------------------------------------
+
+    async def _transfer_commit(self, ref: str | None) -> str:
+        """Fetch ``ref`` (default agent HEAD) from the mounted agent repo into the
+        sidecar's own repo and return its resolved sha.
+
+        The agent repo is untrusted: hooks are disabled and ``file://`` forces an
+        object copy (no hardlink/alternates) so the fetched commit is fully owned
+        by the sidecar repo and tamper-evident.
+        """
+        workspace = self.engine.evaluator.workspace
+        root = workspace.root
+        target = ref or "HEAD"
+        fetch = await workspace.sandbox.run(
+            [
+                "git",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "protocol.file.allow=always",
+                "-C",
+                root,
+                "fetch",
+                "--no-tags",
+                "--no-recurse-submodules",
+                f"file://{self.agent_repo_path}",
+                target,
+            ],
+            timeout=120,
+        )
+        if fetch.returncode != 0:
+            raise CommitTransferError(
+                f"git fetch of {target!r} from agent repo failed: {fetch.stderr}"
+            )
+        rev = await workspace.sandbox.run(
+            ["git", "-C", root, "rev-parse", "FETCH_HEAD"], timeout=30
+        )
+        if rev.returncode != 0:
+            raise CommitTransferError(f"rev-parse FETCH_HEAD failed: {rev.stderr}")
+        return rev.stdout.strip()
+
+    def _route_results(self, experiment: Experiment, *, admin: bool) -> str | None:
+        """Write the agent-visible projection of an experiment by split tier.
+
+        Full per-sample results always live admin-side (the session store). Here we
+        write only what the agent may see:
+          - visible:      aggregate summary + full per-sample results
+          - non_viewable: aggregate summary only (no per-sample / no labels)
+          - no_access:    nothing
+        Admin/verifier evals never write to the agent volume.
+        Returns the agent-volume path written, or None.
+        """
+        if admin:
+            return None
+        split = experiment.run.dataset_subset.split
+        tier = tier_for_split(split, self.split_accesses)
+        if tier == SplitAccessLevel.no_access:
+            return None
+
+        commit = experiment.run.candidate.commit
+        dest = self.agent_volume / "results" / f"{split}__{commit[:12]}"
+        dest.mkdir(parents=True, exist_ok=True)
+
+        # Aggregate summary is label-safe for both visible and partial tiers.
+        (dest / "summary.json").write_text(
+            json.dumps(
+                {
+                    "split": split,
+                    "commit": commit,
+                    "n_samples": len(experiment.result.sample_results),
+                    "mean_score": experiment.result.score(),
+                    "status": str(experiment.result.status),
+                },
+                indent=2,
+            )
+        )
+        if tier == SplitAccessLevel.viewable:
+            for sample_id, sample_result in experiment.result.sample_results.items():
+                (dest / f"{sample_id}.json").write_text(
+                    sample_result.model_dump_json(indent=2)
+                )
+        return str(dest)

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -1,0 +1,114 @@
+"""Verifier: admin-side commit selection + hidden-split scoring -> reward.
+
+Runs at trial end. In the shared-verifier deployment the eval sidecar is still
+up, so the verifier (root, in the `main` container) reaches this logic through
+the sidecar's token-gated ``finalize`` endpoint, sharing the engine's state
+(repo, dataset, scoring, ledger, submission record). It selects the candidate
+commit (submit: the agent's nominated commit | auto_best: the best commit on the
+selection split, excluding the baseline) and scores it on a configured battery
+of targets, emitting a multi-key reward dict that the wiring writes to Harbor's
+reward.json.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from vero.core.constants import default_minimum_score
+from vero.evaluation.engine import EvaluationEngine
+
+logger = logging.getLogger(__name__)
+
+
+class NoCandidateError(RuntimeError):
+    """Raised when no commit can be selected (no submission / no experiments)."""
+
+
+@dataclass
+class VerificationTarget:
+    """One scoring target -> one named reward in reward.json."""
+
+    task: str | None  # None in Mode B (the nested harbor strategy ignores the vero task)
+    dataset_id: str
+    split: str
+    reward_key: str
+    sample_ids: list[int] | None = None  # None = full split
+
+
+class Verifier:
+    def __init__(
+        self,
+        *,
+        engine: EvaluationEngine,
+        admin_volume: Path,
+        reward_mode: Literal["submit", "auto_best"],
+        targets: list[VerificationTarget],
+        selection_split: str = "validation",
+        base_commit: str | None = None,
+    ):
+        self.engine = engine
+        self.admin_volume = Path(admin_volume)
+        self.reward_mode = reward_mode
+        self.targets = targets
+        self.selection_split = selection_split
+        self.base_commit = base_commit
+
+    async def finalize(self) -> dict[str, float]:
+        """Select the commit and score it on every target -> {reward_key: score}."""
+        sha = self._select_commit()
+        logger.info(f"Verifier selected commit {sha} (mode={self.reward_mode})")
+        rewards: dict[str, float] = {}
+        for target in self.targets:
+            exp = await self.engine.evaluate_admin(
+                task=target.task,
+                dataset_id=target.dataset_id,
+                split=target.split,
+                commit=sha,
+                sample_ids=target.sample_ids,
+            )
+            score = exp.result.score()
+            rewards[target.reward_key] = (
+                float(score) if score is not None else default_minimum_score
+            )
+        return rewards
+
+    def _select_commit(self) -> str:
+        if self.reward_mode == "submit":
+            return self._submitted_commit()
+        return self._best_from_db()
+
+    def _submitted_commit(self) -> str:
+        path = self.admin_volume / "submission.json"
+        if not path.exists():
+            raise NoCandidateError(
+                "submit mode but no submission.json — the agent never submitted a commit."
+            )
+        commit = json.loads(path.read_text()).get("commit")
+        if not commit:
+            raise NoCandidateError("submission.json has no commit.")
+        return commit
+
+    def _best_from_db(self) -> str:
+        """Best candidate by recorded score on the selection split (excludes baseline)."""
+        if self.engine.db is None:
+            raise NoCandidateError("auto_best mode but no experiment database.")
+        df = self.engine.db.get_experiments_df(fill_score=default_minimum_score)
+        if df.empty or "dataset_subset_split" not in df.columns:
+            raise NoCandidateError("auto_best mode but no experiments recorded.")
+
+        split_df = df[df["dataset_subset_split"] == self.selection_split]
+        if self.base_commit is not None:
+            split_df = split_df[split_df["candidate_commit"] != self.base_commit]
+        if len(split_df) == 0:
+            raise NoCandidateError(
+                f"auto_best mode but no candidate experiments on split "
+                f"'{self.selection_split}'."
+            )
+        best = split_df.sort_values(
+            by=["mean_score", "candidate_created_at"], ascending=[False, False]
+        ).iloc[0]
+        return best["candidate_commit"]

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -49,6 +49,9 @@ class Verifier:
         targets: list[VerificationTarget],
         selection_split: str = "validation",
         base_commit: str | None = None,
+        selection_task: str | None = None,
+        selection_dataset_id: str | None = None,
+        rescore_top_k: int = 3,
     ):
         self.engine = engine
         self.admin_volume = Path(admin_volume)
@@ -56,10 +59,16 @@ class Verifier:
         self.targets = targets
         self.selection_split = selection_split
         self.base_commit = base_commit
+        # auto_best re-scores the top-K shortlist admin-side; selection_task is the
+        # task to score the selection split with (the trusted, sidecar-baked scorer),
+        # and selection_dataset_id constrains ranking to the intended dataset.
+        self.selection_task = selection_task
+        self.selection_dataset_id = selection_dataset_id
+        self.rescore_top_k = rescore_top_k
 
     async def finalize(self) -> dict[str, float]:
         """Select the commit and score it on every target -> {reward_key: score}."""
-        sha = self._select_commit()
+        sha = await self._select_commit()
         logger.info(f"Verifier selected commit {sha} (mode={self.reward_mode})")
         rewards: dict[str, float] = {}
         for target in self.targets:
@@ -76,10 +85,10 @@ class Verifier:
             )
         return rewards
 
-    def _select_commit(self) -> str:
+    async def _select_commit(self) -> str:
         if self.reward_mode == "submit":
             return self._submitted_commit()
-        return self._best_from_db()
+        return await self._best_from_db()
 
     def _submitted_commit(self) -> str:
         path = self.admin_volume / "submission.json"
@@ -92,8 +101,16 @@ class Verifier:
             raise NoCandidateError("submission.json has no commit.")
         return commit
 
-    def _best_from_db(self) -> str:
-        """Best candidate by recorded score on the selection split (excludes baseline)."""
+    async def _best_from_db(self) -> str:
+        """Best candidate on the selection split, chosen by an admin re-score.
+
+        The recorded ``mean_score`` is agent-influenced (the agent ran those
+        selection-split evals), so it is used only to shortlist the top-K
+        candidates. The winner is then decided by re-running ``evaluate_admin``
+        on the selection split with the trusted (sidecar-baked) scorer and
+        ranking by the admin score. This fails closed: an agent that inflated
+        its recorded score cannot win unless the admin scorer agrees.
+        """
         if self.engine.db is None:
             raise NoCandidateError("auto_best mode but no experiment database.")
         df = self.engine.db.get_experiments_df(fill_score=default_minimum_score)
@@ -101,6 +118,13 @@ class Verifier:
             raise NoCandidateError("auto_best mode but no experiments recorded.")
 
         split_df = df[df["dataset_subset_split"] == self.selection_split]
+        if self.selection_dataset_id is not None and "dataset_subset_dataset_id" in split_df.columns:
+            # Only rank candidates scored on the intended selection dataset: a
+            # shared experiment DB may hold same-named splits across datasets, and
+            # a high score from a foreign dataset must not select the winner.
+            split_df = split_df[
+                split_df["dataset_subset_dataset_id"] == self.selection_dataset_id
+            ]
         if self.base_commit is not None:
             split_df = split_df[split_df["candidate_commit"] != self.base_commit]
         if len(split_df) == 0:
@@ -108,7 +132,36 @@ class Verifier:
                 f"auto_best mode but no candidate experiments on split "
                 f"'{self.selection_split}'."
             )
-        best = split_df.sort_values(
+        # Shortlist by recorded score (cheap, agent-influenced -> not trusted as
+        # final), one row per candidate (highest recorded score wins the slot).
+        ranked = split_df.sort_values(
             by=["mean_score", "candidate_created_at"], ascending=[False, False]
-        ).iloc[0]
-        return best["candidate_commit"]
+        )
+        ranked = ranked.drop_duplicates(subset=["candidate_commit"], keep="first")
+        shortlist = ranked.head(max(1, self.rescore_top_k))
+
+        rescored: list[tuple[float, int, str]] = []
+        for idx, (_, row) in enumerate(shortlist.iterrows()):
+            commit = row["candidate_commit"]
+            dataset_id = row.get("dataset_subset_dataset_id")
+            exp = await self.engine.evaluate_admin(
+                task=self.selection_task,
+                dataset_id=dataset_id,
+                split=self.selection_split,
+                commit=commit,
+            )
+            score = exp.result.score()
+            admin_score = float(score) if score is not None else default_minimum_score
+            # Tie-break by shortlist position (already ordered by recorded score
+            # then recency), so ties resolve deterministically without depending on
+            # the type of candidate_created_at (a datetime in the real DB).
+            rescored.append((admin_score, idx, commit))
+            logger.info(
+                "auto_best re-score: commit=%s admin_score=%s (recorded=%s)",
+                commit,
+                admin_score,
+                row["mean_score"],
+            )
+        # Highest admin score wins; ties break to the earliest shortlist position.
+        rescored.sort(key=lambda t: (-t[0], t[1]))
+        return rescored[0][2]

--- a/vero/tests/test_harbor_app.py
+++ b/vero/tests/test_harbor_app.py
@@ -1,0 +1,85 @@
+"""Tests for vero.harbor.app — FastAPI routes + agent/admin auth."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from vero.exceptions import ExperimentBudgetExceeded
+from vero.harbor.app import create_app
+from vero.harbor.auth import check_admin, generate_token, read_admin_token, write_admin_token
+from vero.harbor.protocol import EvalSummary, StatusSummary
+from vero.harbor.server import SubmitDisabledError
+
+TOKEN = "secret-admin-token"
+
+
+def _client(sidecar=None, verifier=None):
+    sidecar = sidecar or MagicMock()
+    verifier = verifier or MagicMock()
+    return TestClient(create_app(sidecar=sidecar, verifier=verifier, admin_token=TOKEN))
+
+
+class TestAuthHelpers:
+    def test_token_roundtrip_and_perms(self, tmp_path):
+        tok = generate_token()
+        p = write_admin_token(tmp_path / "t", tok)
+        assert read_admin_token(p) == tok
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+    def test_check_admin(self):
+        assert check_admin(f"Bearer {TOKEN}", TOKEN) is True
+        assert check_admin("Bearer wrong", TOKEN) is False
+        assert check_admin(None, TOKEN) is False
+        assert check_admin(TOKEN, TOKEN) is False  # missing "Bearer "
+
+
+class TestAgentEndpoints:
+    def test_eval(self):
+        sidecar = MagicMock()
+        sidecar.evaluate = AsyncMock(
+            return_value=EvalSummary(
+                commit="c1", split="train", dataset_id="ds", n_samples=2,
+                mean_score=0.5, result_path="/r", budget_remaining=None,
+            )
+        )
+        r = _client(sidecar=sidecar).post(
+            "/eval", json={"dataset_id": "ds", "split": "train", "num_samples": 2}
+        )
+        assert r.status_code == 200
+        assert r.json()["mean_score"] == 0.5
+        assert sidecar.evaluate.await_args.kwargs["admin"] is False
+
+    def test_status(self):
+        sidecar = MagicMock()
+        sidecar.status = MagicMock(
+            return_value=StatusSummary(submit_enabled=True, splits=[{"split": "train"}])
+        )
+        r = _client(sidecar=sidecar).get("/status")
+        assert r.status_code == 200 and r.json()["submit_enabled"] is True
+
+    def test_submit_disabled_maps_to_409(self):
+        sidecar = MagicMock()
+        sidecar.submit = AsyncMock(side_effect=SubmitDisabledError("disabled"))
+        r = _client(sidecar=sidecar).post("/submit", json={"commit": "c1"})
+        assert r.status_code == 409
+
+    def test_budget_exceeded_maps_to_429(self):
+        sidecar = MagicMock()
+        sidecar.evaluate = AsyncMock(side_effect=ExperimentBudgetExceeded("no budget"))
+        r = _client(sidecar=sidecar).post("/eval", json={"dataset_id": "ds", "split": "train"})
+        assert r.status_code == 429
+
+
+class TestAdminEndpoint:
+    def test_finalize_requires_token(self):
+        verifier = MagicMock()
+        verifier.finalize = AsyncMock(return_value={"reward": 1.0})
+        client = _client(verifier=verifier)
+
+        assert client.post("/finalize").status_code == 403  # no token
+        assert client.post("/finalize", headers={"Authorization": "Bearer wrong"}).status_code == 403
+        verifier.finalize.assert_not_awaited()
+
+        r = client.post("/finalize", headers={"Authorization": f"Bearer {TOKEN}"})
+        assert r.status_code == 200 and r.json() == {"reward": 1.0}
+        verifier.finalize.assert_awaited_once()

--- a/vero/tests/test_harbor_app.py
+++ b/vero/tests/test_harbor_app.py
@@ -1,7 +1,9 @@
 """Tests for vero.harbor.app — FastAPI routes + agent/admin auth."""
 
+import os
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from vero.exceptions import ExperimentBudgetExceeded
@@ -83,3 +85,71 @@ class TestAdminEndpoint:
         r = client.post("/finalize", headers={"Authorization": f"Bearer {TOKEN}"})
         assert r.status_code == 200 and r.json() == {"reward": 1.0}
         verifier.finalize.assert_awaited_once()
+
+
+class TestServeIntegrityGuards:
+    @pytest.mark.asyncio
+    async def test_mode_a_without_task_project_rejected(self, tmp_path):
+        # Mode A (no `harbor`) with task_project unset would load the scorer from
+        # the agent repo. build_components must refuse to start.
+        from vero.harbor.serve import ServeConfig, build_components
+
+        cfg = ServeConfig(
+            repo_path=str(tmp_path / "repo"),
+            agent_repo_path=str(tmp_path / "agent"),
+            session_id="s",
+            dataset_id="ds",
+            split_accesses=[{"split": "test", "access": "no_access"}],
+            budgets=[{"split": "validation", "dataset_id": "ds", "total_run_budget": 1}],
+            task="math",
+            task_project=None,  # the vulnerability
+            agent_volume=str(tmp_path / "agent_vol"),
+            admin_volume=str(tmp_path / "admin_vol"),
+            admin_token_path=str(tmp_path / "admin_vol" / "token"),
+        )
+        with pytest.raises(ValueError, match="task_project"):
+            await build_components(cfg)
+
+
+class TestNoAccessRejection:
+    def test_eval_on_no_access_split_maps_to_400(self):
+        # A no_access split is rejected in the engine (InvalidSplitError); the app
+        # must surface that as 400 so the agent can never evaluate it. Mirrors the
+        # 429 budget-exceeded mapping. The end-to-end engine guarantee (the gate
+        # fires before any scoring) is covered by the no_access gate test in
+        # test_engine.py on the core PR.
+        from vero.exceptions import InvalidSplitError
+
+        sidecar = MagicMock()
+        sidecar.evaluate = AsyncMock(side_effect=InvalidSplitError("no_access split"))
+        r = _client(sidecar=sidecar).post(
+            "/eval", json={"dataset_id": "ds", "split": "test"}
+        )
+        assert r.status_code == 400
+        sidecar.evaluate.assert_awaited_once()
+
+
+class TestTokenFilePermissions:
+    def test_token_file_not_world_or_group_readable(self, tmp_path):
+        # The admin token gates /finalize; agent.user (a different uid) must not be
+        # able to read it. The portable OS guarantee is the 0o600 mode bit.
+        tok = generate_token()
+        p = write_admin_token(tmp_path / "token", tok)
+        mode = p.stat().st_mode & 0o777
+        assert mode == 0o600
+        assert mode & 0o077 == 0, "token must not be group/other readable"
+
+    @pytest.mark.skipif(
+        os.geteuid() != 0,
+        reason="uid-drop read test requires running as root to seteuid to a non-owner",
+    )
+    def test_non_owner_uid_cannot_read_token(self, tmp_path):
+        tok = generate_token()
+        p = write_admin_token(tmp_path / "token", tok)
+        os.chown(p, 0, 0)  # root-owned, like the real sidecar
+        try:
+            os.seteuid(65534)  # nobody
+            with pytest.raises(PermissionError):
+                read_admin_token(p)
+        finally:
+            os.seteuid(0)

--- a/vero/tests/test_harbor_cli.py
+++ b/vero/tests/test_harbor_cli.py
@@ -1,0 +1,82 @@
+"""Tests for vero.harbor.cli — the agent/verifier CLI clients (mocked httpx)."""
+
+import json
+
+from click.testing import CliRunner
+
+from vero.harbor.cli import harbor
+
+
+class _Resp:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self._data = data
+        self.text = json.dumps(data)
+
+    def json(self):
+        return self._data
+
+
+def _patch_httpx(monkeypatch, resp, capture):
+    import httpx
+
+    def fake_request(method, url, *, json=None, headers=None, timeout=None):
+        capture.update(method=method, url=url, json=json, headers=headers)
+        return resp
+
+    monkeypatch.setattr(httpx, "request", fake_request)
+
+
+def test_eval_posts_and_prints(monkeypatch):
+    monkeypatch.setenv("VERO_EVAL_URL", "http://sidecar:8000")
+    cap: dict = {}
+    _patch_httpx(monkeypatch, _Resp(200, {"mean_score": 0.5}), cap)
+
+    result = CliRunner().invoke(
+        harbor, ["eval", "--dataset-id", "ds", "--split", "train", "--num-samples", "3"]
+    )
+    assert result.exit_code == 0
+    assert cap["method"] == "POST" and cap["url"].endswith("/eval")
+    assert cap["json"] == {"dataset_id": "ds", "split": "train", "num_samples": 3}
+    assert json.loads(result.output)["mean_score"] == 0.5
+
+
+def test_eval_error_status_raises(monkeypatch):
+    monkeypatch.setenv("VERO_EVAL_URL", "http://sidecar:8000")
+    _patch_httpx(monkeypatch, _Resp(429, {"error": "no budget"}), {})
+    result = CliRunner().invoke(harbor, ["eval", "--dataset-id", "ds", "--split", "train"])
+    assert result.exit_code != 0
+    assert "429" in result.output
+
+
+def test_eval_missing_url_errors():
+    result = CliRunner(env={"VERO_EVAL_URL": ""}).invoke(
+        harbor, ["eval", "--dataset-id", "ds", "--split", "train"]
+    )
+    assert result.exit_code != 0
+    assert "VERO_EVAL_URL" in result.output
+
+
+def test_status_get(monkeypatch):
+    monkeypatch.setenv("VERO_EVAL_URL", "http://sidecar:8000")
+    cap: dict = {}
+    _patch_httpx(monkeypatch, _Resp(200, {"submit_enabled": True}), cap)
+    result = CliRunner().invoke(harbor, ["status"])
+    assert result.exit_code == 0 and cap["method"] == "GET" and cap["url"].endswith("/status")
+
+
+def test_finalize_uses_token_and_writes_reward(monkeypatch, tmp_path):
+    monkeypatch.setenv("VERO_EVAL_URL", "http://sidecar:8000")
+    token_file = tmp_path / "tok"
+    token_file.write_text("T0KEN")
+    out = tmp_path / "reward.json"
+    cap: dict = {}
+    _patch_httpx(monkeypatch, _Resp(200, {"reward": 1.0}), cap)
+
+    result = CliRunner().invoke(
+        harbor, ["finalize", "--token-file", str(token_file), "--output", str(out)]
+    )
+    assert result.exit_code == 0
+    assert cap["url"].endswith("/finalize")
+    assert cap["headers"]["Authorization"] == "Bearer T0KEN"
+    assert json.loads(out.read_text()) == {"reward": 1.0}

--- a/vero/tests/test_harbor_dataset.py
+++ b/vero/tests/test_harbor_dataset.py
@@ -1,0 +1,49 @@
+"""Tests for vero.harbor.dataset — partition compile + local task enumeration."""
+
+import pytest
+
+from vero.harbor.dataset import (
+    build_harbor_dataset,
+    enumerate_local_task_names,
+    validate_partition,
+)
+
+
+def _make_task_dir(root, name):
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "task.toml").write_text("[task]\nname='x'\n")
+    return d
+
+
+class TestBuildDataset:
+    def test_partition_to_datasetdict(self):
+        ds = build_harbor_dataset({"train": ["a", "b"], "test": ["c"]})
+        assert set(ds.keys()) == {"train", "test"}
+        assert ds["train"]["task_name"] == ["a", "b"]
+        assert ds["test"]["task_name"] == ["c"]
+
+    def test_empty_partition_raises(self):
+        with pytest.raises(ValueError):
+            build_harbor_dataset({})
+
+
+class TestEnumerateLocal:
+    def test_dataset_dir_of_tasks(self, tmp_path):
+        _make_task_dir(tmp_path, "task_b")
+        _make_task_dir(tmp_path, "task_a")
+        (tmp_path / "not_a_task").mkdir()  # no task.toml -> excluded
+        assert enumerate_local_task_names(tmp_path) == ["task_a", "task_b"]
+
+    def test_single_task_dir(self, tmp_path):
+        d = _make_task_dir(tmp_path, "solo")
+        assert enumerate_local_task_names(d) == ["solo"]
+
+
+class TestValidatePartition:
+    def test_ok_when_subset(self):
+        validate_partition({"train": ["a"], "test": ["b"]}, ["a", "b", "c"])
+
+    def test_unknown_names_raise(self):
+        with pytest.raises(ValueError, match="not found"):
+            validate_partition({"test": ["a", "zzz"]}, ["a", "b"])

--- a/vero/tests/test_harbor_protocol.py
+++ b/vero/tests/test_harbor_protocol.py
@@ -1,0 +1,86 @@
+"""Tests for vero.harbor.protocol — sidecar wire types + redaction/summary."""
+
+from vero.core.budget import SplitBudget
+from vero.core.dataset.base import SplitAccess, SplitAccessLevel
+from vero.core.db.candidate import Candidate
+from vero.core.db.dataset import DatasetSubset
+from vero.core.db.result import (
+    ExperimentResult,
+    ExperimentResultStatus,
+    SampleResult,
+)
+from vero.core.db.run import ExperimentRun
+from vero.harbor.protocol import (
+    build_status,
+    summarize_experiment,
+    tier_for_split,
+)
+
+
+def _experiment(scores: list[float]) -> "object":
+    from vero.core.db.database import Experiment
+    from vero.core.db.dataset import DatasetSample
+
+    run = ExperimentRun(
+        candidate=Candidate(commit="abc123", repo_name="r"),
+        dataset_subset=DatasetSubset(split="validation", dataset_id="ds1"),
+    )
+    sample_results = {
+        i: SampleResult(
+            dataset_sample=DatasetSample(sample_id=i, split="validation", dataset_id="ds1"),
+            score=s,
+        )
+        for i, s in enumerate(scores)
+    }
+    result = ExperimentResult(
+        run_id=run.id, status=ExperimentResultStatus.SUCCESS, sample_results=sample_results
+    )
+    return Experiment(run=run, result=result)
+
+
+class TestTier:
+    def test_listed_split_tier(self):
+        accesses = [SplitAccess.no_access("test"), SplitAccess.non_viewable("validation")]
+        assert tier_for_split("test", accesses) == SplitAccessLevel.no_access
+        assert tier_for_split("validation", accesses) == SplitAccessLevel.non_viewable
+
+    def test_unlisted_defaults_viewable(self):
+        assert tier_for_split("train", []) == SplitAccessLevel.viewable
+
+
+class TestSummarize:
+    def test_aggregate_only_no_per_sample(self):
+        exp = _experiment([1.0, 0.0, 1.0])
+        summary = summarize_experiment(exp, result_path="/x/y")
+        assert summary.commit == "abc123"
+        assert summary.split == "validation"
+        assert summary.dataset_id == "ds1"
+        assert summary.n_samples == 3
+        assert summary.mean_score is not None
+        # no per-sample field exists on the summary at all
+        assert not any("sample" in k for k in summary.to_dict() if k != "n_samples")
+
+    def test_budget_serialized(self):
+        exp = _experiment([1.0])
+        b = SplitBudget(split="validation", dataset_id="ds1", total_run_budget=5)
+        d = summarize_experiment(exp, result_path=None, budget_remaining=b).to_dict()
+        assert d["budget_remaining"]["remaining_run_budget"] == 5
+        assert d["result_path"] is None
+
+
+class TestBuildStatus:
+    def test_lists_budgeted_splits_with_tier(self):
+        budget = {
+            ("train", "ds1"): SplitBudget(split="train", dataset_id="ds1", total_run_budget=10),
+            ("validation", "ds1"): SplitBudget(split="validation", dataset_id="ds1", total_run_budget=3),
+        }
+        accesses = [SplitAccess.non_viewable("validation")]  # train defaults viewable
+        status = build_status(submit_enabled=True, budget=budget, split_accesses=accesses)
+
+        assert status.submit_enabled is True
+        by_split = {s["split"]: s for s in status.splits}
+        assert by_split["train"]["tier"] == str(SplitAccessLevel.viewable)
+        assert by_split["train"]["agent_evaluable"] is True
+        assert by_split["validation"]["tier"] == str(SplitAccessLevel.non_viewable)
+        assert by_split["validation"]["agent_evaluable"] is True
+        assert by_split["validation"]["remaining_run_budget"] == 3

--- a/vero/tests/test_harbor_protocol.py
+++ b/vero/tests/test_harbor_protocol.py
@@ -44,8 +44,13 @@ class TestTier:
         assert tier_for_split("test", accesses) == SplitAccessLevel.no_access
         assert tier_for_split("validation", accesses) == SplitAccessLevel.non_viewable
 
-    def test_unlisted_defaults_viewable(self):
-        assert tier_for_split("train", []) == SplitAccessLevel.viewable
+    def test_unlisted_fails_closed_to_no_access(self):
+        # An undeclared split must fail CLOSED, never default to viewable.
+        assert tier_for_split("train", []) == SplitAccessLevel.no_access
+        assert (
+            tier_for_split("train", [SplitAccess.no_access("test")])
+            == SplitAccessLevel.no_access
+        )
 
 
 class TestSummarize:
@@ -74,13 +79,15 @@ class TestBuildStatus:
             ("train", "ds1"): SplitBudget(split="train", dataset_id="ds1", total_run_budget=10),
             ("validation", "ds1"): SplitBudget(split="validation", dataset_id="ds1", total_run_budget=3),
         }
-        accesses = [SplitAccess.non_viewable("validation")]  # train defaults viewable
+        accesses = [SplitAccess.non_viewable("validation")]  # train left unlisted -> fails closed
         status = build_status(submit_enabled=True, budget=budget, split_accesses=accesses)
 
         assert status.submit_enabled is True
         by_split = {s["split"]: s for s in status.splits}
-        assert by_split["train"]["tier"] == str(SplitAccessLevel.viewable)
-        assert by_split["train"]["agent_evaluable"] is True
+        # An unlisted split now fails CLOSED (no_access), not open (viewable): a
+        # budgeted split must be tiered explicitly or the sidecar denies it.
+        assert by_split["train"]["tier"] == str(SplitAccessLevel.no_access)
+        assert by_split["train"]["agent_evaluable"] is False
         assert by_split["validation"]["tier"] == str(SplitAccessLevel.non_viewable)
         assert by_split["validation"]["agent_evaluable"] is True
         assert by_split["validation"]["remaining_run_budget"] == 3

--- a/vero/tests/test_harbor_serve.py
+++ b/vero/tests/test_harbor_serve.py
@@ -1,0 +1,143 @@
+"""Integration test for vero.harbor.serve — assemble the sidecar/verifier from a
+ServeConfig and run a real (deterministic, no-LLM) Mode-A eval + finalize.
+
+Reuses the external-task project pattern: a trivial agent + a separate task project,
+scored deterministically. Validates that `build_components` produces a working engine,
+and that a real eval flows into verifier selection + scoring.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from vero.core.dataset.store import resolve_and_save_dataset
+from vero.evaluation.engine import EvalRequest
+from vero.harbor.serve import ServeConfig, build_components
+
+
+def _git(path: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=path, capture_output=True, check=True, text=True,
+    ).stdout.strip()
+
+
+def _create_agent(root: Path) -> tuple[Path, str]:
+    d = root / "my-agent"
+    (d / "src" / "my_agent").mkdir(parents=True)
+    (d / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "my-agent"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/my_agent"]
+    """))
+    (d / "src" / "my_agent" / "__init__.py").write_text('def solve(q): return "42"\n')
+    _git(d, "init")
+    _git(d, "add", ".")
+    _git(d, "commit", "-m", "init")
+    return d, _git(d, "rev-parse", "HEAD")
+
+
+def _create_task_project(root: Path, vero_path: Path) -> Path:
+    d = root / "my-eval-tasks"
+    vt = d / "src" / "my_eval_tasks" / "vero_tasks"
+    vt.mkdir(parents=True)
+    (d / "pyproject.toml").write_text(textwrap.dedent(f"""\
+        [project]
+        name = "my-eval-tasks"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        dependencies = ["scale-vero[optimize]"]
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/my_eval_tasks"]
+        [tool.uv.sources]
+        scale-vero = {{ path = "{vero_path}", editable = true }}
+    """))
+    (vt / "__init__.py").write_text("from my_eval_tasks.vero_tasks import math_task  # noqa\n")
+    (vt / "math_task.py").write_text(textwrap.dedent("""\
+        from my_agent import solve
+        from vero.core.db.result import TaskOutput, TaskResult
+        from vero.core.evaluation import EvaluationParameters
+        from vero.core.task import create_task
+        math_task = create_task("math")
+        @math_task.inference()
+        async def run_inference(task, evaluation_parameters):
+            return TaskOutput(output=solve(task["question"]))
+        @math_task.evaluation()
+        async def evaluate(task, output, evaluation_parameters):
+            return TaskResult(output=output.output, score=1.0 if output.output == task["expected"] else 0.0)
+    """))
+    subprocess.run(["uv", "sync"], cwd=d, capture_output=True, check=True)
+    return d
+
+
+@pytest.fixture
+def fixture(tmp_path, monkeypatch):
+    from vero.core.constants import PACKAGE_DIR
+    from datasets import Dataset, DatasetDict
+
+    vh = tmp_path / "vero_home"
+    (vh / "sessions").mkdir(parents=True)
+    (vh / "datasets").mkdir(parents=True)
+    monkeypatch.setenv("VERO_HOME_DIR", str(vh))
+
+    agent_dir, head = _create_agent(tmp_path)
+    task_dir = _create_task_project(tmp_path, PACKAGE_DIR)
+    ds = DatasetDict({"test": Dataset.from_dict(
+        {"question": ["6*7?", "2+2?"], "expected": ["42", "4"]})})
+    ds_path = tmp_path / "ds"
+    ds.save_to_disk(str(ds_path))
+    dataset_id = resolve_and_save_dataset(str(ds_path), vh / "sessions", vh / "datasets", "sess")
+    return agent_dir, head, task_dir, dataset_id, tmp_path
+
+
+def _serve_config(agent_dir, head, task_dir, dataset_id, tmp) -> ServeConfig:
+    return ServeConfig(
+        repo_path=str(agent_dir),
+        agent_repo_path=str(agent_dir),
+        session_id="sess",
+        dataset_id=dataset_id,
+        split_accesses=[{"split": "test", "access": "non_viewable"}],
+        budgets=[{"split": "test", "dataset_id": dataset_id, "total_run_budget": 5}],
+        task="math",
+        task_project=str(task_dir),
+        task_module="my_eval_tasks.vero_tasks",
+        reward_mode="auto_best",
+        selection_split="test",
+        targets=[{"task": "math", "dataset_id": dataset_id, "split": "test", "reward_key": "reward", "sample_ids": [0]}],
+        agent_volume=str(tmp / "agent_vol"),
+        admin_volume=str(tmp / "admin_vol"),
+        admin_token_path=str(tmp / "admin_vol" / "token"),
+        timeout=300,
+    )
+
+
+@pytest.mark.asyncio
+async def test_serve_assembles_and_evaluates_and_finalizes(fixture):
+    agent_dir, head, task_dir, dataset_id, tmp = fixture
+    config = _serve_config(agent_dir, head, task_dir, dataset_id, tmp)
+
+    sidecar, verifier, token = await build_components(config)
+    assert token and (tmp / "admin_vol" / "token").read_text() == token
+
+    # real eval (no LLM): sample 0 expects "42", agent solves -> "42" -> score 1.0
+    exp = await sidecar.engine.evaluate(
+        EvalRequest(dataset_id=dataset_id, split="test", commit=head, sample_ids=[0])
+    )
+    assert exp.result.sample_results[0].score == 1.0
+
+    # verifier selects the (only) candidate on "test" and scores it on the test target
+    rewards = await verifier.finalize()
+    assert rewards["reward"] == 1.0

--- a/vero/tests/test_harbor_serve.py
+++ b/vero/tests/test_harbor_serve.py
@@ -141,3 +141,81 @@ async def test_serve_assembles_and_evaluates_and_finalizes(fixture):
     # verifier selects the (only) candidate on "test" and scores it on the test target
     rewards = await verifier.finalize()
     assert rewards["reward"] == 1.0
+
+
+def _create_cheating_agent(root: Path) -> tuple[Path, str]:
+    """An agent whose committed repo ALSO ships a vero_tasks scorer that returns 1.0
+    for everything, and whose solve() returns a wrong answer. If the verifier ran
+    the agent's scorer, reward would be 1.0; with the sidecar-baked task project it
+    must reflect the real (0.0) score."""
+    d = root / "cheating-agent"
+    vt = d / "src" / "my_agent" / "vero_tasks"
+    vt.mkdir(parents=True)
+    (d / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "my-agent"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/my_agent"]
+    """))
+    (d / "src" / "my_agent" / "__init__.py").write_text('def solve(q): return "WRONG"\n')
+    # Adversarial scorer baked into the AGENT repo: always 1.0.
+    (vt / "__init__.py").write_text("from my_agent.vero_tasks import math_task  # noqa\n")
+    (vt / "math_task.py").write_text(textwrap.dedent("""\
+        from vero.core.db.result import TaskOutput, TaskResult
+        from vero.core.task import create_task
+        math_task = create_task("math")
+        @math_task.inference()
+        async def run_inference(task, evaluation_parameters):
+            return TaskOutput(output="WRONG")
+        @math_task.evaluation()
+        async def evaluate(task, output, evaluation_parameters):
+            return TaskResult(output=output.output, score=1.0)  # always passes
+    """))
+    _git(d, "init")
+    _git(d, "add", ".")
+    _git(d, "commit", "-m", "init")
+    return d, _git(d, "rev-parse", "HEAD")
+
+
+@pytest.mark.asyncio
+async def test_finalize_does_not_run_agent_supplied_scorer(fixture):
+    # Reuse the trusted task project from the fixture; swap in a cheating agent
+    # whose committed repo carries a 1.0 scorer and a wrong solve().
+    _, _, task_dir, dataset_id, tmp = fixture
+    agent_dir, head = _create_cheating_agent(tmp)
+    config = _serve_config(agent_dir, head, task_dir, dataset_id, tmp)
+
+    sidecar, verifier, _ = await build_components(config)
+    # Real eval: agent answers "WRONG" for sample 0 (expects "42"); trusted scorer -> 0.0
+    exp = await sidecar.engine.evaluate(
+        EvalRequest(dataset_id=dataset_id, split="test", commit=head, sample_ids=[0])
+    )
+    assert exp.result.sample_results[0].score == 0.0
+    # Finalize must reflect the TRUSTED score, not the agent's 1.0 scorer.
+    rewards = await verifier.finalize()
+    assert rewards["reward"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_ledger_reloads_spent_budget_across_restart(fixture):
+    agent_dir, head, task_dir, dataset_id, tmp = fixture
+    config = _serve_config(agent_dir, head, task_dir, dataset_id, tmp)
+
+    # First boot: spend one run on the test split.
+    sidecar, _, _ = await build_components(config)
+    before = sidecar.engine.budget.get(dataset_id, "test").remaining_run_budget
+    await sidecar.engine.evaluate(
+        EvalRequest(dataset_id=dataset_id, split="test", commit=head, sample_ids=[0])
+    )
+    after = sidecar.engine.budget.get(dataset_id, "test").remaining_run_budget
+    assert after == before - 1
+
+    # Restart: rebuild from the SAME config + admin_volume; spent budget must persist.
+    sidecar2, _, _ = await build_components(config)
+    reloaded = sidecar2.engine.budget.get(dataset_id, "test").remaining_run_budget
+    assert reloaded == after, "sidecar restart must not refill spent budget"

--- a/vero/tests/test_harbor_server.py
+++ b/vero/tests/test_harbor_server.py
@@ -1,0 +1,124 @@
+"""Tests for vero.harbor.server.EvaluationSidecar — handlers, tier-routing, submit."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vero.core.budget import BudgetLedger, SplitBudget
+from vero.core.dataset.base import SplitAccess
+from vero.core.db.candidate import Candidate
+from vero.core.db.dataset import DatasetSample, DatasetSubset
+from vero.core.db.database import Experiment
+from vero.core.db.result import (
+    ExperimentResult,
+    ExperimentResultStatus,
+    SampleResult,
+)
+from vero.core.db.run import ExperimentRun
+from vero.harbor.server import EvaluationSidecar, SubmitDisabledError
+from vero.evaluation.engine import EvalRequest
+
+
+def _experiment(split: str, commit: str = "abcdef123456") -> Experiment:
+    run = ExperimentRun(
+        candidate=Candidate(commit=commit, repo_name="r"),
+        dataset_subset=DatasetSubset(split=split, dataset_id="ds1"),
+    )
+    sample_results = {
+        i: SampleResult(
+            dataset_sample=DatasetSample(sample_id=i, split=split, dataset_id="ds1"),
+            score=float(i % 2),
+            feedback=f"Expected: secret-{i}",  # label-bearing: must NOT reach agent on partial
+        )
+        for i in range(3)
+    }
+    return Experiment(
+        run=run,
+        result=ExperimentResult(
+            run_id=run.id, status=ExperimentResultStatus.SUCCESS, sample_results=sample_results
+        ),
+    )
+
+
+def _sidecar(tmp_path, *, split, submit_enabled=False):
+    engine = MagicMock()
+    engine.evaluate = AsyncMock(return_value=_experiment(split))
+    engine.budget = BudgetLedger(
+        [SplitBudget(split=split, dataset_id="ds1", total_run_budget=5, total_sample_budget=100)]
+    )
+    sidecar = EvaluationSidecar(
+        engine=engine,
+        split_accesses=[SplitAccess.non_viewable("validation"), SplitAccess.no_access("test")],
+        agent_repo_path=tmp_path / "agent_repo",
+        agent_volume=tmp_path / "agent_vol",
+        admin_volume=tmp_path / "admin_vol",
+        submit_enabled=submit_enabled,
+    )
+    # Stub the git transfer (integration-tested separately); pin the sha.
+    sidecar._transfer_commit = AsyncMock(return_value="abcdef123456")
+    return sidecar
+
+
+class TestRouting:
+    @pytest.mark.asyncio
+    async def test_visible_split_writes_full_per_sample(self, tmp_path):
+        sidecar = _sidecar(tmp_path, split="train")  # train defaults to viewable
+        summary = await sidecar.evaluate(EvalRequest(dataset_id="ds1", split="train"))
+
+        dest = tmp_path / "agent_vol" / "results" / "train__abcdef123456"
+        assert (dest / "summary.json").exists()
+        assert {(dest / f"{i}.json").exists() for i in range(3)} == {True}
+        assert summary.result_path == str(dest)
+        assert summary.n_samples == 3
+
+    @pytest.mark.asyncio
+    async def test_partial_split_writes_summary_only_no_labels(self, tmp_path):
+        sidecar = _sidecar(tmp_path, split="validation")  # non_viewable -> partial
+        summary = await sidecar.evaluate(EvalRequest(dataset_id="ds1", split="validation"))
+
+        dest = tmp_path / "agent_vol" / "results" / "validation__abcdef123456"
+        assert (dest / "summary.json").exists()
+        # NO per-sample files -> the label-bearing feedback never reaches the agent
+        assert not list(dest.glob("[0-9]*.json"))
+        blob = (dest / "summary.json").read_text()
+        assert "secret-" not in blob
+        assert summary.result_path == str(dest)
+
+    @pytest.mark.asyncio
+    async def test_admin_eval_writes_nothing_to_agent_volume(self, tmp_path):
+        sidecar = _sidecar(tmp_path, split="test")  # no_access; admin only
+        summary = await sidecar.evaluate(
+            EvalRequest(dataset_id="ds1", split="test"), admin=True
+        )
+        assert not (tmp_path / "agent_vol").exists() or not list(
+            (tmp_path / "agent_vol").rglob("*.json")
+        )
+        assert summary.result_path is None
+        # admin call bypasses metering
+        assert summary.budget_remaining is None
+
+
+class TestSubmit:
+    @pytest.mark.asyncio
+    async def test_submit_records_nomination(self, tmp_path):
+        sidecar = _sidecar(tmp_path, split="train", submit_enabled=True)
+        out = await sidecar.submit(commit="deadbeef")
+        rec = json.loads((tmp_path / "admin_vol" / "submission.json").read_text())
+        assert rec["commit"] == "abcdef123456"  # the transferred sha
+        assert out["submitted_commit"] == "abcdef123456"
+
+    @pytest.mark.asyncio
+    async def test_submit_disabled_raises(self, tmp_path):
+        sidecar = _sidecar(tmp_path, split="train", submit_enabled=False)
+        with pytest.raises(SubmitDisabledError):
+            await sidecar.submit(commit="x")
+
+
+class TestStatus:
+    def test_status_reports_submit_and_splits(self, tmp_path):
+        sidecar = _sidecar(tmp_path, split="train", submit_enabled=True)
+        status = sidecar.status()
+        assert status.submit_enabled is True
+        assert status.splits[0]["split"] == "train"
+        assert status.splits[0]["remaining_run_budget"] == 5

--- a/vero/tests/test_harbor_server.py
+++ b/vero/tests/test_harbor_server.py
@@ -49,7 +49,11 @@ def _sidecar(tmp_path, *, split, submit_enabled=False):
     )
     sidecar = EvaluationSidecar(
         engine=engine,
-        split_accesses=[SplitAccess.non_viewable("validation"), SplitAccess.no_access("test")],
+        split_accesses=[
+            SplitAccess.viewable("train"),
+            SplitAccess.non_viewable("validation"),
+            SplitAccess.no_access("test"),
+        ],
         agent_repo_path=tmp_path / "agent_repo",
         agent_volume=tmp_path / "agent_vol",
         admin_volume=tmp_path / "admin_vol",
@@ -63,7 +67,7 @@ def _sidecar(tmp_path, *, split, submit_enabled=False):
 class TestRouting:
     @pytest.mark.asyncio
     async def test_visible_split_writes_full_per_sample(self, tmp_path):
-        sidecar = _sidecar(tmp_path, split="train")  # train defaults to viewable
+        sidecar = _sidecar(tmp_path, split="train")  # train is declared viewable
         summary = await sidecar.evaluate(EvalRequest(dataset_id="ds1", split="train"))
 
         dest = tmp_path / "agent_vol" / "results" / "train__abcdef123456"

--- a/vero/tests/test_harbor_transfer.py
+++ b/vero/tests/test_harbor_transfer.py
@@ -1,0 +1,85 @@
+"""Integration test for EvaluationSidecar._transfer_commit (real git repos).
+
+Validates that a commit is fetched from the (untrusted) mounted agent repo into
+the sidecar's own repo and resolved to its sha — the one server.py piece
+that can't be unit-tested with mocks.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from vero.harbor.server import EvaluationSidecar
+from vero.sandbox import LocalSandbox
+from vero.workspace.git import GitWorkspace
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo(path: Path, content: str) -> str:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    (path / "f.txt").write_text(content)
+    _git(path, "add", "f.txt")
+    _git(path, "commit", "-q", "-m", "c")
+    return _git(path, "rev-parse", "HEAD")
+
+
+async def _sidecar_for(sidecar_repo: Path, agent_repo: Path, tmp_path: Path):
+    sandbox = await LocalSandbox.create(root=tmp_path)
+    workspace = await GitWorkspace.from_path(sandbox, str(sidecar_repo))
+    engine = MagicMock()
+    engine.evaluator.workspace = workspace
+    return EvaluationSidecar(
+        engine=engine,
+        split_accesses=[],
+        agent_repo_path=agent_repo,
+        agent_volume=tmp_path / "av",
+        admin_volume=tmp_path / "adv",
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_fetches_agent_head_into_sidecar_repo(tmp_path):
+    agent_repo = tmp_path / "agent"
+    sidecar_repo = tmp_path / "sidecar"
+    agent_head = _init_repo(agent_repo, "agent work")
+    _init_repo(sidecar_repo, "sidecar base")
+
+    sidecar = await _sidecar_for(sidecar_repo, agent_repo, tmp_path)
+    sha = await sidecar._transfer_commit(None)  # default = agent HEAD
+
+    assert sha == agent_head
+    # the fetched commit object now lives in the sidecar's own repo (tamper-evident copy)
+    assert (
+        subprocess.run(
+            ["git", "-C", str(sidecar_repo), "cat-file", "-e", sha], capture_output=True
+        ).returncode
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_explicit_ref(tmp_path):
+    agent_repo = tmp_path / "agent"
+    sidecar_repo = tmp_path / "sidecar"
+    _init_repo(agent_repo, "first")
+    # a second commit; transfer the first by explicit sha
+    first = _git(agent_repo, "rev-parse", "HEAD")
+    (agent_repo / "f.txt").write_text("second")
+    _git(agent_repo, "commit", "-aqm", "second")
+    _init_repo(sidecar_repo, "sidecar base")
+
+    sidecar = await _sidecar_for(sidecar_repo, agent_repo, tmp_path)
+    sha = await sidecar._transfer_commit(first)
+    assert sha == first

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -1,0 +1,112 @@
+"""Tests for vero.harbor.verifier.Verifier — selection + multi-target scoring."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from vero.harbor.verifier import NoCandidateError, VerificationTarget, Verifier
+
+
+def _engine(scores_by_call):
+    engine = MagicMock()
+    engine.evaluate_admin = AsyncMock(
+        side_effect=[MagicMock(result=MagicMock(score=MagicMock(return_value=s))) for s in scores_by_call]
+    )
+    return engine
+
+
+class TestSubmitSelection:
+    @pytest.mark.asyncio
+    async def test_finalize_submit_scores_nominated_commit(self, tmp_path):
+        (tmp_path / "submission.json").write_text(json.dumps({"commit": "deadbeef"}))
+        engine = _engine([0.8])
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"reward": 0.8}
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "deadbeef"
+        assert engine.evaluate_admin.await_args.kwargs["split"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_finalize_submit_no_submission_raises(self, tmp_path):
+        v = Verifier(
+            engine=_engine([]),
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+        )
+        with pytest.raises(NoCandidateError):
+            await v.finalize()
+
+
+class TestMultiTarget:
+    @pytest.mark.asyncio
+    async def test_finalize_emits_multiple_reward_keys(self, tmp_path):
+        (tmp_path / "submission.json").write_text(json.dumps({"commit": "c1"}))
+        engine = _engine([0.9, 0.4])
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            targets=[
+                VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="in_domain"),
+                VerificationTarget(task="t2", dataset_id="ds2", split="test", reward_key="held_out"),
+            ],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"in_domain": 0.9, "held_out": 0.4}
+        assert engine.evaluate_admin.await_count == 2
+
+
+class TestAutoBestSelection:
+    @pytest.mark.asyncio
+    async def test_finalize_auto_best_picks_top_validation_score(self, tmp_path):
+        engine = _engine([0.95])
+        engine.db.get_experiments_df.return_value = pd.DataFrame(
+            {
+                "dataset_subset_split": ["validation", "validation", "train"],
+                "candidate_commit": ["lo", "hi", "ignored"],
+                "mean_score": [0.5, 0.9, 1.0],
+                "candidate_created_at": [1, 2, 3],
+            }
+        )
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="validation",
+            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"reward": 0.95}
+        # selected the highest validation score ("hi"), not the train row
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_finalize_auto_best_excludes_baseline(self, tmp_path):
+        engine = _engine([0.7])
+        engine.db.get_experiments_df.return_value = pd.DataFrame(
+            {
+                "dataset_subset_split": ["validation", "validation"],
+                "candidate_commit": ["base", "agent"],
+                "mean_score": [0.99, 0.6],
+                "candidate_created_at": [1, 2],
+            }
+        )
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="validation",
+            base_commit="base",
+            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+        )
+        await v.finalize()
+        # baseline excluded even though it scored higher
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -66,47 +66,70 @@ class TestMultiTarget:
 
 class TestAutoBestSelection:
     @pytest.mark.asyncio
-    async def test_finalize_auto_best_picks_top_validation_score(self, tmp_path):
-        engine = _engine([0.95])
+    async def test_auto_best_reranks_by_admin_score(self, tmp_path):
+        # 'hi' has the best RECORDED score (agent-influenced) but the admin re-score
+        # rates 'lo' higher; selection must follow the admin score.
+        engine = MagicMock()
         engine.db.get_experiments_df.return_value = pd.DataFrame(
             {
                 "dataset_subset_split": ["validation", "validation", "train"],
+                "dataset_subset_dataset_id": ["ds1", "ds1", "ds1"],
                 "candidate_commit": ["lo", "hi", "ignored"],
                 "mean_score": [0.5, 0.9, 1.0],
                 "candidate_created_at": [1, 2, 3],
             }
         )
+        admin_scores = {"hi": 0.1, "lo": 0.95}
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(
+                result=MagicMock(score=MagicMock(return_value=admin_scores.get(commit, 0.99)))
+            )
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
         v = Verifier(
             engine=engine,
             admin_volume=tmp_path,
             reward_mode="auto_best",
             selection_split="validation",
-            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="test", reward_key="reward")],
         )
         rewards = await v.finalize()
-        assert rewards == {"reward": 0.95}
-        # selected the highest validation score ("hi"), not the train row
-        assert engine.evaluate_admin.await_args.kwargs["commit"] == "hi"
+        # the final (target) eval is on the WINNER 'lo', chosen by admin re-score
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "lo"
+        assert engine.evaluate_admin.await_args.kwargs["split"] == "test"
+        # reward is the winner 'lo' scored on the target split -> its admin score
+        assert rewards["reward"] == 0.95
 
     @pytest.mark.asyncio
-    async def test_finalize_auto_best_excludes_baseline(self, tmp_path):
-        engine = _engine([0.7])
+    async def test_auto_best_excludes_baseline_after_rescore(self, tmp_path):
+        engine = MagicMock()
         engine.db.get_experiments_df.return_value = pd.DataFrame(
             {
                 "dataset_subset_split": ["validation", "validation"],
+                "dataset_subset_dataset_id": ["ds1", "ds1"],
                 "candidate_commit": ["base", "agent"],
                 "mean_score": [0.99, 0.6],
                 "candidate_created_at": [1, 2],
             }
         )
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=0.7)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
         v = Verifier(
             engine=engine,
             admin_volume=tmp_path,
             reward_mode="auto_best",
             selection_split="validation",
             base_commit="base",
-            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="test", reward_key="reward")],
         )
         await v.finalize()
-        # baseline excluded even though it scored higher
+        # baseline 'base' was never re-scored; 'agent' is selected + target-scored
+        rescored_commits = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
+        assert "base" not in rescored_commits
         assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"


### PR DESCRIPTION
**Draft · Stack 2 of 4** — targets `harbor-1-core` (review [1/4] first; its diff is the base here).

The evaluation engine run in a sidecar container, plus the trust boundary that makes a run leaderboard-gradeable. **This is the security-critical PR** — a focused/security review is worthwhile here.

- **`EvaluationSidecar`** (server.py): commit transfer from the untrusted agent repo (git fetch, hooks off, object copy) + tier-gated result write-routing across the agent-readable and admin volumes.
- **`Verifier`** (verifier.py): commit selection (submit | auto_best) + hidden-split scoring.
- **Admin token** (auth.py): per-trial, written `root:600` — unreadable by the de-privileged optimizer, readable by the verifier (root, shared mode).
- **FastAPI** (app.py): `/eval` `/submit` `/status` (agent; metered, redacted) and `/finalize` (verifier; token-gated). `vero harbor serve` assembles engine+sidecar+verifier from a `ServeConfig`.
- CLI clients (cli.py) + `HarborConfig`/partition helpers so the package imports cleanly (`build`/`run` light up in [3/4]).

Stack: [1/4] core → **this** → [3/4] compiler → [4/4] docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the eval sidecar layer for Harbor: `EvaluationSidecar` (commit transfer + tier-gated result routing), `Verifier` (commit selection + hidden-split scoring), per-trial admin token auth, a FastAPI HTTP surface, and the `vero harbor serve` entrypoint that wires everything together from a `ServeConfig`. The three previously-flagged issues (stale result dirs, auto_best dataset scoping, reward_mode validation) are addressed in this revision.

- **`server.py`**: git fetch from the untrusted agent repo uses hooks-off + `file://` object copy; result write-routing is tier-gated (viewable / non_viewable / no_access) with the stale-directory fix (`shutil.rmtree` before re-writing).
- **`verifier.py`**: `auto_best` shortlists by agent-recorded score then re-ranks with a trusted admin re-score, filtering by `selection_dataset_id` when the column is present; `reward_mode` is now `Literal[\"submit\", \"auto_best\"]` in `ServeConfig`.
- **`auth.py` / `app.py`**: admin token is generated with `secrets.token_urlsafe`, bearer-token check uses `secrets.compare_digest`, but the token file is written then chmod'd (TOCTOU window) and concurrent transfers share `FETCH_HEAD` (race on concurrent `/eval` calls).

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Three defects in the security-critical paths need fixes before merging: a FETCH_HEAD race in concurrent commit transfers, a write-then-chmod window on the admin token file, and a missing fallback for dataset_id in the verifier re-score loop.

The FETCH_HEAD file is overwritten by whichever git fetch completes last; with uvicorn serving concurrent /eval requests, two in-flight _transfer_commit calls can race and one resolves the other's SHA — breaking the commit-attribution invariant the trust boundary rests on. The token write-then-chmod window leaves the admin token briefly readable with default umask permissions. The verifier dataset_id fallback passes None to evaluate_admin when the column is absent, which can load the wrong dataset or raise at runtime.

vero/src/vero/harbor/server.py (_transfer_commit FETCH_HEAD race), vero/src/vero/harbor/auth.py (write_admin_token TOCTOU), vero/src/vero/harbor/verifier.py (_best_from_db dataset_id fallback)
</details>

<details open><summary><h3>Security Review</h3></summary>

- **FETCH_HEAD race (`server.py:118–145`)**: Concurrent `_transfer_commit` calls share the single `FETCH_HEAD` file in the sidecar's git repo. With `max_concurrency=20` and uvicorn serving concurrent `/eval` requests, two in-flight fetches can race: one call reads the other's SHA, causing an evaluation to run on the wrong commit while attributing the result to the original request. This breaks the commit-attribution trust boundary.
- **Token write TOCTOU (`auth.py:24–28`)**: `write_admin_token` creates the file with the default umask (typically 0o644) then calls `chmod(0o600)`. During the window between the two syscalls the admin token — which gates the reward-writing `/finalize` endpoint — is world-readable on a filesystem accessible to the agent process.
- No hardcoded secrets, no SQL injection surfaces, no deserialization of untrusted data beyond the agent's commit ref (passed as a list argument to git, not through a shell). Bearer-token comparison in `check_admin` correctly uses `secrets.compare_digest`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/server.py | Core sidecar handler: commit transfer via git fetch + tier-gated result routing. FETCH_HEAD is shared across concurrent transfers — a race condition that can assign the wrong commit SHA to an evaluation. |
| vero/src/vero/harbor/auth.py | Per-trial admin token generation and validation. write_admin_token creates the file with default umask permissions then chmod's, leaving a brief window where the token is readable before permissions are tightened. |
| vero/src/vero/harbor/verifier.py | Commit selection (submit | auto_best with admin re-scoring) and hidden-split reward computation. dataset_id falls back to None instead of selection_dataset_id when the column is absent from the experiment DataFrame. |
| vero/src/vero/harbor/app.py | FastAPI routes: unauthenticated agent endpoints (/eval, /submit, /status) and token-gated /finalize. Bearer-token check uses constant-time comparison; exception-to-status-code mapping is correct. |
| vero/src/vero/harbor/serve.py | ServeConfig + build_components: assembles engine, sidecar, verifier; enforces Mode-A task_project guard; durable budget ledger with restart-safe reload. reward_mode is now a Literal type, closing the silent-fallback gap. |
| vero/src/vero/harbor/protocol.py | Wire types and projection logic: EvalSummary (aggregate-safe), StatusSummary, tier_for_split (fails closed to no_access for unlisted splits). Redaction invariants look correct. |
| vero/src/vero/harbor/cli.py | CLI clients for agent (eval/submit/status) and verifier (finalize). Token is read from file and forwarded via Authorization header. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent as Agent (agent.user)
    participant App as FastAPI App
    participant Sidecar as EvaluationSidecar
    participant AgentRepo as Agent Repo (mounted)
    participant SidecarRepo as Sidecar Repo
    participant Engine as EvaluationEngine
    participant AgentVol as Agent Volume
    participant AdminVol as Admin Volume

    Note over App,AdminVol: Startup
    App->>AdminVol: write_admin_token (root:600)

    Note over Agent,AgentVol: Agent eval loop
    Agent->>App: "POST /eval {commit, split}"
    App->>Sidecar: "evaluate(req, admin=False)"
    Sidecar->>AgentRepo: git fetch file:// (hooks off)
    AgentRepo-->>SidecarRepo: "object copy -> FETCH_HEAD"
    SidecarRepo-->>Sidecar: "rev-parse FETCH_HEAD -> sha"
    Sidecar->>Engine: "evaluate(commit=sha)"
    Engine-->>Sidecar: Experiment result
    Sidecar->>Sidecar: _route_results (tier_for_split)
    alt "tier = viewable"
        Sidecar->>AgentVol: summary.json + per-sample files
    else "tier = non_viewable"
        Sidecar->>AgentVol: summary.json only
    else "tier = no_access"
        Note over AgentVol: nothing written
    end
    App-->>Agent: EvalSummary (aggregate only)

    Note over Agent,AdminVol: Optional submit
    Agent->>App: "POST /submit {commit}"
    App->>Sidecar: submit(commit)
    Sidecar->>AdminVol: submission.json (sha)

    Note over App,AdminVol: Verifier finalizes (admin only)
    App->>App: POST /finalize (Bearer token)
    App->>App: check_admin (constant-time)
    App->>Verifier: finalize()
    alt "reward_mode = submit"
        Verifier->>AdminVol: "read submission.json -> sha"
    else "reward_mode = auto_best"
        Verifier->>Engine: get_experiments_df
        Verifier->>Engine: evaluate_admin (top-K re-score)
        Engine-->>Verifier: "admin scores -> winner sha"
    end
    loop each VerificationTarget
        Verifier->>Engine: evaluate_admin(hidden split)
        Engine-->>Verifier: score
    end
    Verifier-->>App: "{reward_key: score}"
    App-->>Verifier CLI: reward dict -> reward.json
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent as Agent (agent.user)
    participant App as FastAPI App
    participant Sidecar as EvaluationSidecar
    participant AgentRepo as Agent Repo (mounted)
    participant SidecarRepo as Sidecar Repo
    participant Engine as EvaluationEngine
    participant AgentVol as Agent Volume
    participant AdminVol as Admin Volume

    Note over App,AdminVol: Startup
    App->>AdminVol: write_admin_token (root:600)

    Note over Agent,AgentVol: Agent eval loop
    Agent->>App: "POST /eval {commit, split}"
    App->>Sidecar: "evaluate(req, admin=False)"
    Sidecar->>AgentRepo: git fetch file:// (hooks off)
    AgentRepo-->>SidecarRepo: "object copy -> FETCH_HEAD"
    SidecarRepo-->>Sidecar: "rev-parse FETCH_HEAD -> sha"
    Sidecar->>Engine: "evaluate(commit=sha)"
    Engine-->>Sidecar: Experiment result
    Sidecar->>Sidecar: _route_results (tier_for_split)
    alt "tier = viewable"
        Sidecar->>AgentVol: summary.json + per-sample files
    else "tier = non_viewable"
        Sidecar->>AgentVol: summary.json only
    else "tier = no_access"
        Note over AgentVol: nothing written
    end
    App-->>Agent: EvalSummary (aggregate only)

    Note over Agent,AdminVol: Optional submit
    Agent->>App: "POST /submit {commit}"
    App->>Sidecar: submit(commit)
    Sidecar->>AdminVol: submission.json (sha)

    Note over App,AdminVol: Verifier finalizes (admin only)
    App->>App: POST /finalize (Bearer token)
    App->>App: check_admin (constant-time)
    App->>Verifier: finalize()
    alt "reward_mode = submit"
        Verifier->>AdminVol: "read submission.json -> sha"
    else "reward_mode = auto_best"
        Verifier->>Engine: get_experiments_df
        Verifier->>Engine: evaluate_admin (top-K re-score)
        Engine-->>Verifier: "admin scores -> winner sha"
    end
    loop each VerificationTarget
        Verifier->>Engine: evaluate_admin(hidden split)
        Engine-->>Verifier: score
    end
    Verifier-->>App: "{reward_key: score}"
    App-->>Verifier CLI: reward dict -> reward.json
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Avero%2Fsrc%2Fvero%2Fharbor%2Fserver.py%3A118-145%0A**FETCH_HEAD%20shared%20across%20concurrent%20transfers**%0A%0A%60FETCH_HEAD%60%20is%20a%20single%20file%20inside%20the%20sidecar's%20repo%3B%20with%20%60max_concurrency%3D20%60%20and%20uvicorn%20handling%20concurrent%20%60%2Feval%60%20requests%2C%20two%20in-flight%20%60_transfer_commit%60%20calls%20can%20race%3A%20fetch%20B%20overwrites%20%60FETCH_HEAD%60%20after%20fetch%20A%20finishes%20but%20before%20A's%20%60rev-parse%20FETCH_HEAD%60%20runs.%20A%20then%20resolves%20B's%20SHA%20and%20evaluates%20B's%20commit%20while%20attributing%20the%20result%20to%20A's%20request%20%E2%80%94%20a%20trust-boundary%20violation%20where%20one%20agent%20can%20inadvertently%20%28or%20deliberately%20via%20rapid%20concurrent%20calls%29%20evaluate%20a%20different%20commit.%0A%0AThe%20fix%20is%20to%20write%20each%20transfer%20to%20a%20unique%20local%20ref%20%28%60%3Ctarget%3E%3A%3Cunique-local-ref%3E%60%29%20and%20resolve%20that%20ref%2C%20then%20delete%20it%2C%20so%20concurrent%20transfers%20never%20share%20state.%0A%0A%23%23%23%20Issue%202%20of%202%0Avero%2Fsrc%2Fvero%2Fharbor%2Fauth.py%3A24-28%0A**Token%20readable%20during%20write-then-chmod%20window**%0A%0A%60write_text%60%20creates%20the%20file%20with%20the%20process%20umask%20%28commonly%200o644%29%2C%20then%20%60chmod%60%20restricts%20it.%20In%20the%20window%20between%20the%20two%20syscalls%20the%20token%20is%20world-readable%20%E2%80%94%20any%20process%20sharing%20the%20same%20filesystem%20can%20race%20to%20read%20it.%20Since%20this%20token%20gates%20%60%2Ffinalize%60%20%28the%20reward-writing%20endpoint%29%2C%20a%20leak%20lets%20%60agent.user%60%20call%20%60%2Ffinalize%60%20directly.%0A%0AThe%20fix%20is%20to%20open%20the%20file%20with%20the%20target%20mode%20in%20a%20single%20atomic%20step%20so%20it%20is%20never%20created%20with%20wider%20permissions.%0A%0A%60%60%60suggestion%0A%20%20%20%20import%20os%0A%0A%20%20%20%20p%20%3D%20Path%28path%29%0A%20%20%20%20p.parent.mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue%29%0A%20%20%20%20fd%20%3D%20os.open%28p%2C%20os.O_WRONLY%20%7C%20os.O_CREAT%20%7C%20os.O_TRUNC%2C%20mode%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20os.write%28fd%2C%20token.encode%28%29%29%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20os.close%28fd%29%0A%20%20%20%20return%20p%0A%60%60%60%0A%0A&pr=4&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Avero%2Fsrc%2Fvero%2Fharbor%2Fserver.py%3A118-145%0A**FETCH_HEAD%20shared%20across%20concurrent%20transfers**%0A%0A%60FETCH_HEAD%60%20is%20a%20single%20file%20inside%20the%20sidecar's%20repo%3B%20with%20%60max_concurrency%3D20%60%20and%20uvicorn%20handling%20concurrent%20%60%2Feval%60%20requests%2C%20two%20in-flight%20%60_transfer_commit%60%20calls%20can%20race%3A%20fetch%20B%20overwrites%20%60FETCH_HEAD%60%20after%20fetch%20A%20finishes%20but%20before%20A's%20%60rev-parse%20FETCH_HEAD%60%20runs.%20A%20then%20resolves%20B's%20SHA%20and%20evaluates%20B's%20commit%20while%20attributing%20the%20result%20to%20A's%20request%20%E2%80%94%20a%20trust-boundary%20violation%20where%20one%20agent%20can%20inadvertently%20%28or%20deliberately%20via%20rapid%20concurrent%20calls%29%20evaluate%20a%20different%20commit.%0A%0AThe%20fix%20is%20to%20write%20each%20transfer%20to%20a%20unique%20local%20ref%20%28%60%3Ctarget%3E%3A%3Cunique-local-ref%3E%60%29%20and%20resolve%20that%20ref%2C%20then%20delete%20it%2C%20so%20concurrent%20transfers%20never%20share%20state.%0A%0A%23%23%23%20Issue%202%20of%202%0Avero%2Fsrc%2Fvero%2Fharbor%2Fauth.py%3A24-28%0A**Token%20readable%20during%20write-then-chmod%20window**%0A%0A%60write_text%60%20creates%20the%20file%20with%20the%20process%20umask%20%28commonly%200o644%29%2C%20then%20%60chmod%60%20restricts%20it.%20In%20the%20window%20between%20the%20two%20syscalls%20the%20token%20is%20world-readable%20%E2%80%94%20any%20process%20sharing%20the%20same%20filesystem%20can%20race%20to%20read%20it.%20Since%20this%20token%20gates%20%60%2Ffinalize%60%20%28the%20reward-writing%20endpoint%29%2C%20a%20leak%20lets%20%60agent.user%60%20call%20%60%2Ffinalize%60%20directly.%0A%0AThe%20fix%20is%20to%20open%20the%20file%20with%20the%20target%20mode%20in%20a%20single%20atomic%20step%20so%20it%20is%20never%20created%20with%20wider%20permissions.%0A%0A%60%60%60suggestion%0A%20%20%20%20import%20os%0A%0A%20%20%20%20p%20%3D%20Path%28path%29%0A%20%20%20%20p.parent.mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue%29%0A%20%20%20%20fd%20%3D%20os.open%28p%2C%20os.O_WRONLY%20%7C%20os.O_CREAT%20%7C%20os.O_TRUNC%2C%20mode%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20os.write%28fd%2C%20token.encode%28%29%29%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20os.close%28fd%29%0A%20%20%20%20return%20p%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=4&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-2-sidecar%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-2-sidecar%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Avero%2Fsrc%2Fvero%2Fharbor%2Fserver.py%3A118-145%0A**FETCH_HEAD%20shared%20across%20concurrent%20transfers**%0A%0A%60FETCH_HEAD%60%20is%20a%20single%20file%20inside%20the%20sidecar's%20repo%3B%20with%20%60max_concurrency%3D20%60%20and%20uvicorn%20handling%20concurrent%20%60%2Feval%60%20requests%2C%20two%20in-flight%20%60_transfer_commit%60%20calls%20can%20race%3A%20fetch%20B%20overwrites%20%60FETCH_HEAD%60%20after%20fetch%20A%20finishes%20but%20before%20A's%20%60rev-parse%20FETCH_HEAD%60%20runs.%20A%20then%20resolves%20B's%20SHA%20and%20evaluates%20B's%20commit%20while%20attributing%20the%20result%20to%20A's%20request%20%E2%80%94%20a%20trust-boundary%20violation%20where%20one%20agent%20can%20inadvertently%20%28or%20deliberately%20via%20rapid%20concurrent%20calls%29%20evaluate%20a%20different%20commit.%0A%0AThe%20fix%20is%20to%20write%20each%20transfer%20to%20a%20unique%20local%20ref%20%28%60%3Ctarget%3E%3A%3Cunique-local-ref%3E%60%29%20and%20resolve%20that%20ref%2C%20then%20delete%20it%2C%20so%20concurrent%20transfers%20never%20share%20state.%0A%0A%23%23%23%20Issue%202%20of%202%0Avero%2Fsrc%2Fvero%2Fharbor%2Fauth.py%3A24-28%0A**Token%20readable%20during%20write-then-chmod%20window**%0A%0A%60write_text%60%20creates%20the%20file%20with%20the%20process%20umask%20%28commonly%200o644%29%2C%20then%20%60chmod%60%20restricts%20it.%20In%20the%20window%20between%20the%20two%20syscalls%20the%20token%20is%20world-readable%20%E2%80%94%20any%20process%20sharing%20the%20same%20filesystem%20can%20race%20to%20read%20it.%20Since%20this%20token%20gates%20%60%2Ffinalize%60%20%28the%20reward-writing%20endpoint%29%2C%20a%20leak%20lets%20%60agent.user%60%20call%20%60%2Ffinalize%60%20directly.%0A%0AThe%20fix%20is%20to%20open%20the%20file%20with%20the%20target%20mode%20in%20a%20single%20atomic%20step%20so%20it%20is%20never%20created%20with%20wider%20permissions.%0A%0A%60%60%60suggestion%0A%20%20%20%20import%20os%0A%0A%20%20%20%20p%20%3D%20Path%28path%29%0A%20%20%20%20p.parent.mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue%29%0A%20%20%20%20fd%20%3D%20os.open%28p%2C%20os.O_WRONLY%20%7C%20os.O_CREAT%20%7C%20os.O_TRUNC%2C%20mode%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20os.write%28fd%2C%20token.encode%28%29%29%0A%20%20%20%20finally%3A%0A%20%20%20%20%20%20%20%20os.close%28fd%29%0A%20%20%20%20return%20p%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=4&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vero/src/vero/harbor/server.py:118-145
**FETCH_HEAD shared across concurrent transfers**

`FETCH_HEAD` is a single file inside the sidecar's repo; with `max_concurrency=20` and uvicorn handling concurrent `/eval` requests, two in-flight `_transfer_commit` calls can race: fetch B overwrites `FETCH_HEAD` after fetch A finishes but before A's `rev-parse FETCH_HEAD` runs. A then resolves B's SHA and evaluates B's commit while attributing the result to A's request — a trust-boundary violation where one agent can inadvertently (or deliberately via rapid concurrent calls) evaluate a different commit.

The fix is to write each transfer to a unique local ref (`<target>:<unique-local-ref>`) and resolve that ref, then delete it, so concurrent transfers never share state.

### Issue 2 of 2
vero/src/vero/harbor/auth.py:24-28
**Token readable during write-then-chmod window**

`write_text` creates the file with the process umask (commonly 0o644), then `chmod` restricts it. In the window between the two syscalls the token is world-readable — any process sharing the same filesystem can race to read it. Since this token gates `/finalize` (the reward-writing endpoint), a leak lets `agent.user` call `/finalize` directly.

The fix is to open the file with the target mode in a single atomic step so it is never created with wider permissions.

```suggestion
    import os

    p = Path(path)
    p.parent.mkdir(parents=True, exist_ok=True)
    fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
    try:
        os.write(fd, token.encode())
    finally:
        os.close(fd)
    return p
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(harbor): Mode A scorer provenance, a..."](https://github.com/scaleapi/vero/commit/38709b191394170de927dea40f626c99cd84c344) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39627888)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->