### PR TITLE
[Harbor 4/4] architecture docs, tutorial, and the GAIA example

### DIFF
--- a/vero/README.md
+++ b/vero/README.md
@@ -525,6 +525,22 @@ agent = VeroAgent(
 )
 ```
 
+## Harbor integration
+
+vero can compile an optimization run into a [Harbor](https://www.harborframework.com) task, so the *optimizer* itself becomes a Harbor agent-under-test: any Harbor agent (Claude Code, an oracle script, …) edits a target repo and spends an evaluation budget, and the reward is the best candidate's score on a hidden split. This makes optimization runs reproducible and leaderboard-gradeable — the optimizer can't read hidden labels, modify the scorer, or bypass its budget.
+
+```bash
+uv pip install 'scale-vero[harbor]'
+vero harbor build -c build.yaml -o /tmp/opt-task        # compile a Harbor task
+vero harbor run   -c build.yaml -a claude-code -m claude-haiku-4-5 -e docker   # build + run
+```
+
+Two evaluation modes: **Mode A** (vero runs inference + scoring against vero-side labels) and **Mode B** (evaluation is delegated to a *nested* `harbor run`, e.g. on Modal). See:
+
+- [`docs/harbor/architecture.md`](docs/harbor/architecture.md) — what it is, the topology, and the leaderboard-integrity model.
+- [`docs/harbor/tutorial.md`](docs/harbor/tutorial.md) — build and run a task end to end.
+- [`examples/gsm8k-agent`](examples/gsm8k-agent) (Mode A) and [`examples/gaia-optimization`](examples/gaia-optimization) (Mode B).
+
 ## Examples
 
 See [`examples/matmul-kernel/`](examples/matmul-kernel/) for a complete runnable example that optimizes a matrix multiply kernel for speed. It demonstrates eval-only mode, full optimization with VeroAgent or Claude Code, filesystem artifacts, and resource-based editing.

--- a/vero/README.md
+++ b/vero/README.md
@@ -539,7 +539,7 @@ Two evaluation modes: **Mode A** (vero runs inference + scoring against vero-sid
 
 - [`docs/harbor/architecture.md`](docs/harbor/architecture.md) — what it is, the topology, and the leaderboard-integrity model.
 - [`docs/harbor/tutorial.md`](docs/harbor/tutorial.md) — build and run a task end to end.
-- [`examples/gsm8k-agent`](examples/gsm8k-agent) (Mode A) and [`examples/gaia-optimization`](examples/gaia-optimization) (Mode B).
+- [`examples/gaia-optimization`](examples/gaia-optimization) (Mode B), the complete runnable example (ships a `build.yaml`). [`examples/gsm8k-agent`](examples/gsm8k-agent) (Mode A) ships the agent + vero task but not yet a `build.yaml`; pair it with the Mode A `build.yaml` snippet in [`docs/harbor/tutorial.md`](docs/harbor/tutorial.md).
 
 ## Examples
 

--- a/vero/docs/harbor/architecture.md
+++ b/vero/docs/harbor/architecture.md
@@ -5,9 +5,13 @@ task**. The agent-under-test of that Harbor task is an *optimizer*: any Harbor a
 (Claude Code, an oracle script, …) edits a target repository and spends an evaluation
 budget; the reward is the best candidate's score on a hidden test split.
 
-This lets anyone optimize a coding agent with plain `harbor run`, and makes the result
-leaderboard-gradeable — the optimizer cannot read hidden labels, modify the scorer, or
-bypass its budget.
+This lets anyone optimize a coding agent with plain `harbor run`, and aims to make the
+result leaderboard-gradeable. On a best-effort, OS/process-level basis the integration
+withholds per-sample labels from the agent volume, meters every agent evaluation against
+a budget, applies read-only paths, and gates final hidden-split scoring behind a
+`root:600` token the de-privileged optimizer cannot read (a container escape is out of
+scope). See [Leaderboard integrity](#leaderboard-integrity-the-trust-boundary) for the
+exact mechanisms and their limits.
 
 ```
 harbor run -p <task> -a <optimizer> -m <model> -e <provider>
@@ -44,8 +48,10 @@ harbor run -p <task> -a <optimizer> -m <model> -e <provider>
 The seam is a single injection point on the `Evaluator` (`eval_strategy`):
 
 - **Mode A — vero scores** (`task_project`/`task` + dataset). vero runs the agent's
-  inference and a vero scoring function against vero-side labels. Example:
-  [`examples/gsm8k-agent`](../../examples/gsm8k-agent).
+  inference and a vero scoring function against vero-side labels. Example agent:
+  [`examples/gsm8k-agent`](../../examples/gsm8k-agent) (note: it ships the agent and
+  vero task but not yet a `build.yaml`; see the Mode A `build.yaml` snippet in the
+  [tutorial](./tutorial.md) for a runnable config).
 - **Mode B — Harbor scores** (`HarborConfig`). Inference is delegated: for each
   candidate, `HarborRunner` runs a *nested* `harbor run` of the agent on a set of
   Harbor tasks (e.g. on Modal) and collates the verifier rewards. One Harbor task =
@@ -60,8 +66,12 @@ The optimizer is untrusted. Integrity rests on a few mechanisms, all best-effort
 the OS/process level (a container escape is out of scope):
 
 - **3-tier split visibility** (`SplitAccessLevel`): `visible` (aggregate + per-sample
-  results), `non_viewable` (aggregate score only — no labels), `no_access` (hidden;
-  never evaluable by the agent, never written to its volume).
+  results), `non_viewable` (aggregate score only, no labels), `no_access` (hidden;
+  never evaluable by the agent, never written to its volume). **A split not listed in
+  `splits:` currently defaults to viewable (fail-open).** List *every* split explicitly
+  and give held-out splits `no_access`; do not rely on omission to hide a split. (Once
+  the protocol fix lands this default becomes fail-closed: an unlisted split defaults to
+  `no_access`.)
 - **Write-routing by tier**: the sidecar writes only the agent-permitted projection of
   each result to the *agent-results* volume (read-only in `main`). Full results, the
   dataset, the ledger, and creds live on the *admin* volume, **never** mounted to `main`.
@@ -74,13 +84,21 @@ the OS/process level (a container escape is out of scope):
 - **Commit transfer**: the sidecar `git fetch`es the agent's commit from the mounted
   repo into its *own* repo with hooks disabled and `file://` (object copy, no
   alternates), so the evaluated tree is fully owned by the sidecar and tamper-evident.
-- **Protected scorer / write-access**: the scorer is sidecar-only; `read_only_paths`
-  in `build.yaml` are applied as unix perms in `main` before the optimizer runs.
+- **Protected scorer / write-access** (mode-dependent): in **Mode B** the scorer,
+  dataset, and creds are sidecar-only and never share a filesystem with the optimizer.
+  In **Mode A** the scoring function is vero task code that lives inside the agent's
+  *editable* `agent_repo` (e.g. `src/gsm8k_agent/vero_tasks`); it is protected only by
+  `read_only_paths` in `build.yaml`, applied as unix perms in `main` before the
+  optimizer runs (best-effort, not container isolation). Full Mode A scorer isolation
+  requires baking the task project into the sidecar instead of the agent repo, which
+  lands with the `serve.py` fix.
 
 ### Why a sidecar + shared verifier
 
-The evaluation engine, dataset, scorer, and creds live in a separate container so the
-optimizer never shares a filesystem or process space with them. We use Harbor's
+The evaluation engine, dataset, and creds live in a separate container so the optimizer
+never shares a filesystem or process space with them (in **Mode B** the scorer too; in
+**Mode A** the scorer currently lives in the agent's editable repo and is guarded only by
+`read_only_paths`, until the `serve.py` fix bakes a Mode A task project into the sidecar). We use Harbor's
 **shared verifier** (the env, including the sidecar, stays up during `tests/test.sh`)
 so the verifier can reach the live engine over HTTP and stay the single source of
 truth — avoiding shipping the repo/dataset/ledger into a fresh verifier container. The
@@ -104,6 +122,7 @@ vero/harbor/
 ├── runner.py         HarborRunner (Mode-B EvalStrategy): nested `harbor run` → collate
 ├── dataset.py        Mode-B {split: [task_names]} partition → DatasetDict
 └── protocol.py       aggregate-safe wire types + the redaction of an Experiment
+                      (note: an unlisted split currently defaults to viewable / fail-open)
 
 vero/evaluation/
 ├── engine.py         EvaluationEngine: budget metering + the single evaluate() entry point
@@ -117,5 +136,5 @@ the optimizer↔sidecar contract is the HTTP API in `app.py` (+ the `vero harbor
 ## See also
 
 - [Tutorial](./tutorial.md) — build and run an optimization task end to end.
-- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) — Mode A.
+- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) (Mode A agent; no `build.yaml` yet, use the tutorial's Mode A snippet).
 - [`examples/gaia-optimization`](../../examples/gaia-optimization) — Mode B (nested Harbor on Modal).

--- a/vero/docs/harbor/architecture.md
+++ b/vero/docs/harbor/architecture.md
@@ -1,0 +1,121 @@
+# Harbor integration — architecture
+
+The Harbor integration turns a **vero optimization run into a [Harbor](https://www.harborframework.com)
+task**. The agent-under-test of that Harbor task is an *optimizer*: any Harbor agent
+(Claude Code, an oracle script, …) edits a target repository and spends an evaluation
+budget; the reward is the best candidate's score on a hidden test split.
+
+This lets anyone optimize a coding agent with plain `harbor run`, and makes the result
+leaderboard-gradeable — the optimizer cannot read hidden labels, modify the scorer, or
+bypass its budget.
+
+```
+harbor run -p <task> -a <optimizer> -m <model> -e <provider>
+        │
+        ▼  one optimization trial (a Docker Compose environment):
+  ┌────────────────────────┐        ┌────────────────────────────────────┐
+  │ main (optimizer bench)  │  HTTP  │ eval-sidecar (the evaluation engine) │
+  │  • target repo (rw*)    │ ─────► │  • dataset + scorer + baseline repo  │
+  │  • `vero harbor` client │        │  • budget ledger + creds             │
+  │  • runs the -a optimizer│        │  • `vero harbor serve` (FastAPI)     │
+  └────────────────────────┘        └────────────────────────────────────┘
+        │  (trial end, shared verifier)            ▲
+        └── `vero harbor finalize` (admin token) ──┘ → /logs/verifier/reward.json
+```
+
+## The optimization loop
+
+1. **`vero harbor build`** compiles a `build.yaml` into a Harbor task directory
+   (`environment/` compose + Dockerfiles, `instruction.md`, `tests/test.sh`), baking
+   the dataset, scorer, baseline repo, and a `ServeConfig`.
+2. At trial start, **`main`** seeds the target repo onto a shared volume and applies
+   write-access rules; the **eval-sidecar** starts `vero harbor serve` and writes a
+   per-trial admin token.
+3. The **optimizer** (the `-a` agent) edits the repo, commits, and calls
+   `vero harbor eval --split <train|validation>` to measure a commit. The sidecar
+   fetches that commit, evaluates it (metered against the budget), and returns an
+   **aggregate** score (never per-sample labels).
+4. At trial end, Harbor runs `tests/test.sh` in `main` (shared verifier mode). It
+   reads the admin token and calls the sidecar's **`finalize`**: the sidecar selects
+   the winning commit and scores it on the **hidden** test split, producing the reward.
+
+## Two evaluation modes
+
+The seam is a single injection point on the `Evaluator` (`eval_strategy`):
+
+- **Mode A — vero scores** (`task_project`/`task` + dataset). vero runs the agent's
+  inference and a vero scoring function against vero-side labels. Example:
+  [`examples/gsm8k-agent`](../../examples/gsm8k-agent).
+- **Mode B — Harbor scores** (`HarborConfig`). Inference is delegated: for each
+  candidate, `HarborRunner` runs a *nested* `harbor run` of the agent on a set of
+  Harbor tasks (e.g. on Modal) and collates the verifier rewards. One Harbor task =
+  one sample. Example: [`examples/gaia-optimization`](../../examples/gaia-optimization).
+
+Both modes share the same topology, trust boundary, budget, and verifier — only the
+"produce sample results" step differs.
+
+## Leaderboard integrity (the trust boundary)
+
+The optimizer is untrusted. Integrity rests on a few mechanisms, all best-effort at
+the OS/process level (a container escape is out of scope):
+
+- **3-tier split visibility** (`SplitAccessLevel`): `visible` (aggregate + per-sample
+  results), `non_viewable` (aggregate score only — no labels), `no_access` (hidden;
+  never evaluable by the agent, never written to its volume).
+- **Write-routing by tier**: the sidecar writes only the agent-permitted projection of
+  each result to the *agent-results* volume (read-only in `main`). Full results, the
+  dataset, the ledger, and creds live on the *admin* volume, **never** mounted to `main`.
+- **Token-gated finalize**: `finalize` (selection + hidden-split scoring) requires an
+  admin token written `root:600` on a volume `main` mounts read-only. The optimizer
+  runs as a de-privileged user and cannot read it, so it cannot trigger scoring or
+  probe the test split; the verifier (root, shared mode) can.
+- **Metered budget**: a durable `BudgetLedger` caps how much the agent can evaluate per
+  split. Admin (verifier) evaluations bypass the meter.
+- **Commit transfer**: the sidecar `git fetch`es the agent's commit from the mounted
+  repo into its *own* repo with hooks disabled and `file://` (object copy, no
+  alternates), so the evaluated tree is fully owned by the sidecar and tamper-evident.
+- **Protected scorer / write-access**: the scorer is sidecar-only; `read_only_paths`
+  in `build.yaml` are applied as unix perms in `main` before the optimizer runs.
+
+### Why a sidecar + shared verifier
+
+The evaluation engine, dataset, scorer, and creds live in a separate container so the
+optimizer never shares a filesystem or process space with them. We use Harbor's
+**shared verifier** (the env, including the sidecar, stays up during `tests/test.sh`)
+so the verifier can reach the live engine over HTTP and stay the single source of
+truth — avoiding shipping the repo/dataset/ledger into a fresh verifier container. The
+agent/admin split is enforced by the `root:600` token rather than separate services.
+
+## Component map
+
+```
+vero/harbor/
+├── build/            `vero harbor build`: BuildConfig → Harbor task dir
+│   ├── config.py       BuildConfig (the build.yaml schema)
+│   ├── compiler.py     renders the task dir; bakes dataset/scorer/repo/ServeConfig
+│   └── templates/      compose, two Dockerfiles, instruction.md, test.sh, seed.sh, solve.sh
+├── serve.py          `vero harbor serve`: assemble engine+sidecar+verifier from ServeConfig
+├── app.py            FastAPI surface: /eval /submit /status (agent), /finalize (admin)
+├── server.py         EvaluationSidecar: commit transfer + tier write-routing (transport-agnostic)
+├── verifier.py       Verifier: commit selection (submit | auto_best) + hidden-split scoring
+├── auth.py           per-trial admin token (generate / root:600 write / verify)
+├── cli.py            `vero harbor` group: build | run | serve | eval | submit | status | finalize
+├── config.py         HarborConfig (Mode B)
+├── runner.py         HarborRunner (Mode-B EvalStrategy): nested `harbor run` → collate
+├── dataset.py        Mode-B {split: [task_names]} partition → DatasetDict
+└── protocol.py       aggregate-safe wire types + the redaction of an Experiment
+
+vero/evaluation/
+├── engine.py         EvaluationEngine: budget metering + the single evaluate() entry point
+├── evaluator.py      Evaluator: checkout + run; the eval_strategy seam (Mode A vs B)
+└── strategy.py       EvalStrategy protocol
+```
+
+The compiler↔sidecar contract is `ServeConfig` (baked as `environment/sidecar/serve.json`);
+the optimizer↔sidecar contract is the HTTP API in `app.py` (+ the `vero harbor` CLI clients).
+
+## See also
+
+- [Tutorial](./tutorial.md) — build and run an optimization task end to end.
+- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) — Mode A.
+- [`examples/gaia-optimization`](../../examples/gaia-optimization) — Mode B (nested Harbor on Modal).

--- a/vero/docs/harbor/tutorial.md
+++ b/vero/docs/harbor/tutorial.md
@@ -129,6 +129,6 @@ cat <jobs-dir>/*/*/verifier/reward.json
 
 ## Examples
 
-- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) — Mode A (vero scores gsm8k).
+- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) (Mode A agent, vero scores gsm8k). It ships the agent + vero task but not a `build.yaml` yet; use the Mode A `build.yaml` snippet above to drive it.
 - [`examples/gaia-optimization`](../../examples/gaia-optimization) — Mode B (terminus on
   GAIA via nested Harbor on Modal), with an editable-prompt optimization surface.

--- a/vero/docs/harbor/tutorial.md
+++ b/vero/docs/harbor/tutorial.md
@@ -1,0 +1,134 @@
+# Harbor integration — tutorial
+
+This walks through compiling a vero optimization run into a Harbor task and running it
+with an optimizer agent. Read the [architecture](./architecture.md) first for the
+concepts (modes, the trust boundary, the optimization loop).
+
+## Install
+
+```bash
+uv pip install 'scale-vero[harbor]'          # adds the `vero harbor` CLI
+# the Harbor CLI itself is invoked via uvx; for Modal-backed inner runs use the extra:
+uvx --from 'harbor[modal]' harbor --help
+```
+
+## 1. Write a `build.yaml`
+
+A build config describes the optimization task: the repo to optimize, how candidates
+are scored, the split tiers, the budget, and the reward.
+
+### Mode A — vero runs inference + scoring
+
+```yaml
+name: myorg/gsm8k-opt
+agent_repo: /path/to/gsm8k-agent     # the repo the optimizer edits
+mode: A
+task: gsm8k                          # vero task name
+task_module: gsm8k_agent.vero_tasks  # module that registers it
+dataset: /path/to/gsm8k-dataset      # a saved DatasetDict (inputs + labels)
+
+splits:
+  - { split: validation, access: non_viewable }   # optimizer sees aggregate score only
+  - { split: test,       access: no_access }       # hidden; scored at the end
+budgets:
+  - { split: validation, total_run_budget: 5 }
+reward_mode: auto_best                # best validation commit auto-selected
+selection_split: validation
+targets:
+  - { split: test, reward_key: reward }
+read_only_paths:
+  - src/gsm8k_agent/vero_tasks        # the scorer — optimizer may not edit it
+secrets: [OPENAI_API_KEY, OPENAI_BASE_URL]   # injected into the eval sidecar only
+```
+
+### Mode B — a nested `harbor run` scores (e.g. on Modal)
+
+```yaml
+name: myorg/gaia-opt
+agent_repo: /path/to/gaia-agent
+mode: B
+harbor:
+  agent_import_path: "gaia_agent:GaiaAgent"   # the agent inside agent_repo
+  task_source: gaia/gaia                       # Harbor registry benchmark (or a local dir)
+  environment: modal
+  model: openai/gpt-4o-mini                    # the inner agent's model
+partition:                                     # {split: [harbor task names]} — one task = one sample
+  train:      [gaia/<id1>, gaia/<id2>, ...]
+  validation: [gaia/<id6>, gaia/<id7>, ...]
+splits:
+  - { split: train,      access: non_viewable }
+  - { split: validation, access: no_access }
+budgets:
+  - { split: train, total_run_budget: 3 }
+reward_mode: auto_best
+selection_split: train
+targets:
+  - { split: validation, reward_key: accuracy }
+secrets: [OPENAI_API_KEY, OPENAI_BASE_URL, MODAL_TOKEN_ID, MODAL_TOKEN_SECRET]
+```
+
+`secrets` are variable **names**: their values are read from your shell at run time and
+injected into the eval sidecar only — never into the optimizer's container. The full
+field list is in `vero/harbor/build/config.py` (`BuildConfig`).
+
+## 2. Build the task
+
+```bash
+vero harbor build -c build.yaml -o /tmp/opt-task
+```
+
+This emits a Harbor task directory: `environment/` (a Docker Compose env = the optimizer
+workbench `main` + the `eval-sidecar`, plus volumes), `instruction.md` (the protocol the
+optimizer reads), and `tests/test.sh` (the verifier). The dataset/scorer/baseline repo
+and the sidecar's `ServeConfig` are baked in.
+
+## 3. Run it with an optimizer
+
+Any Harbor agent can be the optimizer. Provide its creds in your shell (Harbor forwards
+them into `main`); e.g. for `claude-code` set `ANTHROPIC_API_KEY` (+ `ANTHROPIC_BASE_URL`
+if routing through a gateway).
+
+```bash
+# build + run in one step:
+vero harbor run -c build.yaml -a claude-code -m claude-haiku-4-5 -e docker
+
+# or run a pre-built task dir:
+uvx harbor run -p /tmp/opt-task -a claude-code -m claude-haiku-4-5 -e docker
+
+# the `oracle` agent runs solution/solve.sh (a scripted optimizer) — handy for a smoke test:
+uvx harbor run -p /tmp/opt-task -a oracle -e docker
+```
+
+The reward lands in the job's `verifier/reward.json` (e.g. `{"reward": 0.42}`), and Harbor
+reports it as the trial reward.
+
+## What the optimizer does (the agent-side protocol)
+
+Inside `main`, the optimizer follows `instruction.md`. The `vero harbor` CLI talks to the
+eval sidecar over `VERO_EVAL_URL` (set automatically):
+
+```bash
+vero harbor status                                   # remaining budget, evaluable splits
+# edit the repo, commit, then measure the current HEAD:
+vero harbor eval --dataset-id <id> --split validation
+vero harbor submit                                   # (if reward_mode: submit) nominate the final commit
+```
+
+- `eval` returns an aggregate score + remaining budget; for `no_access` splits it is
+  rejected, and labels are never returned.
+- With `reward_mode: auto_best`, the best commit on `selection_split` is chosen
+  automatically; with `submit`, the agent nominates one.
+- The verifier scores the chosen commit on the hidden `targets` split at the end.
+
+## Inspecting a run
+
+```bash
+uvx harbor view <jobs-dir>          # browse trials
+cat <jobs-dir>/*/*/verifier/reward.json
+```
+
+## Examples
+
+- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) — Mode A (vero scores gsm8k).
+- [`examples/gaia-optimization`](../../examples/gaia-optimization) — Mode B (terminus on
+  GAIA via nested Harbor on Modal), with an editable-prompt optimization surface.

--- a/vero/examples/gaia-optimization/README.md
+++ b/vero/examples/gaia-optimization/README.md
@@ -1,0 +1,79 @@
+# GAIA optimization example (Harbor Mode B)
+
+This example shows the **vero ⇄ Harbor** integration optimizing a coding agent on a
+real benchmark. An optimizer (e.g. Claude Code) edits a GAIA agent's prompt; each
+candidate is scored by a **nested `harbor run`** of the agent on real
+[GAIA](https://huggingface.co/datasets/gaia-benchmark/GAIA) tasks (on Modal). The
+reward is accuracy on a hidden split.
+
+This is "Mode B": vero does **no** inference itself — evaluation is delegated to a
+nested Harbor run, and the reward comes from Harbor's verifier. (Contrast "Mode A",
+e.g. [`../gsm8k-agent`](../gsm8k-agent), where vero runs inference and scoring directly.)
+
+## What's here
+
+```
+gaia-optimization/
+├── build.yaml                         # the optimization task definition (vero harbor build -c)
+├── pyproject.toml                     # deps: harbor[modal]
+└── src/gaia_agent/
+    ├── agent.py                       # GaiaAgent(Terminus2): the editable agent
+    └── prompts/                       # the OPTIMIZATION SURFACE — the optimizer edits these
+        ├── terminus-json-plain.txt
+        └── terminus-xml-plain.txt
+```
+
+`GaiaAgent` subclasses Harbor's `Terminus2` and overrides only its prompt-template
+path so the prompt is read from this package's editable `prompts/` directory. The
+optimizer improves `prompts/terminus-json-plain.txt`; the terminal loop, tmux
+session, and response parsing are reused from `Terminus2` unchanged.
+
+## Prerequisites
+
+- The `harbor` CLI (`uvx --from 'harbor[modal]' harbor ...`) and Docker (outer trial).
+- A [Modal](https://modal.com) account for the inner GAIA runs:
+  `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` in your shell env.
+- An OpenAI-compatible LLM endpoint for the **inner** GAIA agent:
+  `OPENAI_API_KEY` (+ optional `OPENAI_BASE_URL` to point at a gateway). The model is
+  set in `build.yaml` (`harbor.model`, default `openai/gpt-4o-mini`).
+- Creds for the **outer** optimizer agent, per that agent (e.g. `ANTHROPIC_API_KEY`
+  for `-a claude-code`). Harbor forwards these from your shell into the optimizer's
+  container; they are **not** shared with the eval sidecar.
+
+Secrets are resolved from your shell at run time and injected into the eval sidecar
+**only** (see `build.yaml`'s `secrets:` — those are variable *names*, not values).
+
+## Run it
+
+```bash
+# install vero with the harbor extra
+uv pip install 'scale-vero[harbor]'
+
+# build the task, then run it with an optimizer of your choice
+vero harbor build -c build.yaml -o /tmp/gaia-task
+uvx harbor run -p /tmp/gaia-task -a claude-code -m claude-haiku-4-5 -e docker
+
+# ...or build + run in one step:
+vero harbor run -c build.yaml -a claude-code -m claude-haiku-4-5 -e docker
+```
+
+The optimizer reads the task instruction, edits `src/gaia_agent/prompts/...`, commits,
+and calls `vero harbor eval --split train` to measure candidates within its budget.
+At the end, the best train commit is scored on the hidden `validation` split and the
+accuracy is written to Harbor's `reward.json`.
+
+## Notes
+
+- **GAIA is hard.** A terminal agent solves only some tasks; expect low scores and
+  weak optimization signal on a 5-task subset. Increase the subset, pick easier tasks,
+  or use a stronger model for a more meaningful run.
+- **Cost/time.** Each GAIA task is a full agent rollout on a Modal sandbox (minutes +
+  LLM tokens). The default budget keeps a run to a handful of nested evals.
+- Pick your own task ids by enumerating the benchmark:
+  `python -c "import asyncio; from harbor.models.job.config import DatasetConfig as D; print(asyncio.run(D(name='gaia/gaia').get_task_configs()))"`
+
+## Attribution
+
+`src/gaia_agent/prompts/*.txt` are copied from Harbor's `terminus_2` agent
+(© Harbor authors, Apache-2.0) so the prompt stays compatible with the parser
+`GaiaAgent` inherits. They are included here as the editable optimization surface.

--- a/vero/examples/gaia-optimization/build.yaml
+++ b/vero/examples/gaia-optimization/build.yaml
@@ -1,0 +1,63 @@
+# `vero harbor build -c build.yaml -o <task-dir>` compiles this into a Harbor task.
+# Then: `harbor run -p <task-dir> -a <optimizer-agent> -m <optimizer-model> -e docker`
+# (or use `vero harbor run -c build.yaml -a ...` to build + run in one step).
+#
+# Mode B: the optimizer edits the GaiaAgent prompt in this repo; the eval sidecar
+# scores candidates by a *nested* `harbor run` of the agent on real GAIA tasks
+# (here on Modal). Reward = accuracy on the hidden `validation` split.
+
+name: examples/gaia-optimization
+description: Optimize a terminus-2 GAIA agent's prompt; reward = accuracy on hidden GAIA tasks.
+
+agent_repo: .                       # this directory (the GaiaAgent the optimizer edits)
+mode: B
+
+harbor:
+  agent_import_path: "gaia_agent:GaiaAgent"
+  task_source: gaia/gaia            # Harbor registry benchmark (enumerated below)
+  environment: modal                # inner provider; needs MODAL_TOKEN_ID/SECRET (see README)
+  # The inner GAIA agent's model. `openai/<name>` routes via OPENAI_BASE_URL, so this
+  # works against OpenAI directly or any OpenAI-compatible gateway you point it at.
+  model: openai/gpt-4o-mini
+  max_retries: 1
+
+# A small subset of gaia/gaia: 5 tasks the optimizer may measure on (train) and
+# 5 held-out tasks scored once at the end (validation). Swap in your own ids;
+# list them with: DatasetConfig(name="gaia/gaia").get_task_configs()
+partition:
+  train:
+    - gaia/00d579ea-0889-4fd9-a771-2c8d79835c8d
+    - gaia/023e9d44-96ae-4eed-b912-244ee8c3b994
+    - gaia/0383a3ee-47a7-41a4-b493-519bdefe0488
+    - gaia/04a04a9b-226c-43fd-b319-d5e89743676f
+    - gaia/0512426f-4d28-49f0-be77-06d05daec096
+  validation:
+    - gaia/05407167-39ec-4d3a-a234-73a9120c325d
+    - gaia/076c8171-9b3b-49b9-a477-244d2a532826
+    - gaia/08c0b6e9-1b43-4c2e-ae55-4e3fce2c2715
+    - gaia/08cae58d-4084-4616-b6dd-dd6534e4825b
+    - gaia/08f3a05f-5947-4089-a4c4-d4bcfaa6b7a0
+
+splits:
+  - { split: train, access: non_viewable }   # optimizer sees aggregate scores only
+  - { split: validation, access: no_access }  # hidden; never reaches the optimizer
+
+budgets:
+  - { split: train, total_run_budget: 3 }      # up to 3 measured evals of the train split
+
+reward_mode: auto_best                          # best train commit is auto-selected
+selection_split: train
+targets:
+  - { split: validation, reward_key: accuracy }
+
+# Secrets are resolved from your shell env and injected into the eval sidecar only,
+# never into the optimizer's container. These are variable NAMES, not values.
+secrets:
+  - OPENAI_API_KEY
+  - OPENAI_BASE_URL
+  - MODAL_TOKEN_ID
+  - MODAL_TOKEN_SECRET
+
+timeout: 3600
+sample_timeout: 900
+max_concurrency: 5

--- a/vero/examples/gaia-optimization/build.yaml
+++ b/vero/examples/gaia-optimization/build.yaml
@@ -40,7 +40,16 @@ partition:
 
 splits:
   - { split: train, access: non_viewable }   # optimizer sees aggregate scores only
-  - { split: validation, access: no_access }  # hidden; never reaches the optimizer
+  - { split: validation, access: no_access }  # scores are never returned to the optimizer
+# CAVEAT: `access: no_access` withholds the validation *scores*, not the validation
+# *identity*. Because `agent_repo: .` and this build.yaml is git-tracked, the validation
+# task ids above are seeded into the optimizer's repo (via `git archive HEAD`) and ARE
+# readable by it. That is acceptable here because gaia/gaia is a public benchmark, so the
+# held-out *ids* are not secret; only the per-sample results are. If you adapt this for a
+# benchmark whose held-out *identity* must stay secret, do NOT keep the held-out partition
+# in the git-tracked agent_repo: move build.yaml (or just the held-out `partition`/`splits`
+# entries) outside the agent_repo subtree, add it to .gitignore, or inject the held-out
+# split sidecar-side at build time so it is never archived into /work/agent.
 
 budgets:
   - { split: train, total_run_budget: 3 }      # up to 3 measured evals of the train split

--- a/vero/examples/gaia-optimization/pyproject.toml
+++ b/vero/examples/gaia-optimization/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "gaia-agent"
+version = "0.1.0"
+description = "A GAIA agent (terminus-2 + editable prompt) optimized via the vero Harbor integration."
+requires-python = ">=3.12"   # harbor[modal] requires Python 3.12+
+dependencies = [
+    "harbor[modal]>=0.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gaia_agent"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/gaia_agent/prompts" = "gaia_agent/prompts"

--- a/vero/examples/gaia-optimization/src/gaia_agent/__init__.py
+++ b/vero/examples/gaia-optimization/src/gaia_agent/__init__.py
@@ -1,0 +1,3 @@
+from gaia_agent.agent import GaiaAgent
+
+__all__ = ["GaiaAgent"]

--- a/vero/examples/gaia-optimization/src/gaia_agent/agent.py
+++ b/vero/examples/gaia-optimization/src/gaia_agent/agent.py
@@ -1,0 +1,38 @@
+"""A GAIA optimization target: Harbor's terminus-2 with an editable prompt.
+
+``GaiaAgent`` subclasses Harbor's ``Terminus2`` and points its prompt template at
+this package's ``prompts/`` directory instead of the copy baked into the harbor
+package. That makes the prompt the *optimization surface*: an optimizer (e.g.
+Claude Code, driving ``vero harbor eval``) edits ``prompts/terminus-json-plain.txt``
+to improve the agent's GAIA score, while the terminal loop, tmux session, and
+response parsing are reused unchanged from ``Terminus2``.
+
+The agent runs in the Harbor orchestrator process (where the LLM creds live) and
+drives the task sandbox via ``environment.exec``; see the example README.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harbor.agents.terminus_2.terminus_2 import Terminus2
+
+_PROMPTS = Path(__file__).parent / "prompts"
+
+
+class GaiaAgent(Terminus2):
+    """Terminus-2 with its prompt sourced from this package's editable ``prompts/``."""
+
+    @staticmethod
+    def name() -> str:
+        return "gaia-agent"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    def _get_prompt_template_path(self) -> Path:
+        if self._parser_name == "json":
+            return _PROMPTS / "terminus-json-plain.txt"
+        if self._parser_name == "xml":
+            return _PROMPTS / "terminus-xml-plain.txt"
+        return super()._get_prompt_template_path()

--- a/vero/examples/gaia-optimization/src/gaia_agent/prompts/terminus-json-plain.txt
+++ b/vero/examples/gaia-optimization/src/gaia_agent/prompts/terminus-json-plain.txt
@@ -1,0 +1,54 @@
+You are an AI assistant tasked with solving command-line tasks in a Linux environment. You will be given a task description and the output from previously executed commands. Your goal is to solve the task by providing batches of shell commands.
+
+Format your response as JSON with the following structure:
+
+{{
+  "analysis": "Analyze the current state based on the terminal output provided. What do you see? What has been accomplished? What still needs to be done?",
+  "plan": "Describe your plan for the next steps. What commands will you run and why? Be specific about what you expect each command to accomplish.",
+  "commands": [
+    {{
+      "keystrokes": "ls -la\n",
+      "duration": 0.1
+    }},
+    {{
+      "keystrokes": "cd project\n",
+      "duration": 0.1
+    }}
+  ],
+  "task_complete": true
+}}
+
+Required fields:
+- "analysis": Your analysis of the current situation
+- "plan": Your plan for the next steps
+- "commands": Array of command objects to execute
+
+Optional fields:
+- "task_complete": Boolean indicating if the task is complete (defaults to false if not present)
+
+Command object structure:
+- "keystrokes": String containing the exact keystrokes to send to the terminal (required)
+- "duration": Number of seconds to wait for the command to complete before the next command will be executed (defaults to 1.0 if not present)
+
+IMPORTANT: The text inside "keystrokes" will be used completely verbatim as keystrokes. Write commands exactly as you want them sent to the terminal:
+- You must end every command with a newline (\n) or it will not execute.
+- For special key sequences, use tmux-style escape sequences:
+  - C-c for Ctrl+C
+  - C-d for Ctrl+D
+
+The "duration" attribute specifies the number of seconds to wait for the command to complete (default: 1.0) before the next command will be executed. On immediate tasks (e.g., cd, ls, echo, cat) set a duration of 0.1 seconds. On commands (e.g., gcc, find, rustc) set a duration of 1.0 seconds. On slow commands (e.g., make, python3 [long running script], wget [file]) set an appropriate duration as you determine necessary.
+
+It is better to set a smaller duration than a longer duration. It is always possible to wait again if the prior output has not finished, by running {{"keystrokes": "", "duration": 10.0}} on subsequent requests to wait longer. Never wait longer than 60 seconds; prefer to poll to see intermediate result status.
+
+Important notes:
+- Each command's keystrokes are sent exactly as written to the terminal
+- Do not include extra whitespace before or after the keystrokes unless it's part of the intended command
+- Extra text before or after the JSON will generate warnings but be tolerated
+- The JSON must be valid - use proper escaping for quotes and special characters within strings
+- Commands array can be empty if you want to wait without taking action
+
+Task Description:
+{instruction}
+
+Current terminal state:
+{terminal_state}

--- a/vero/examples/gaia-optimization/src/gaia_agent/prompts/terminus-xml-plain.txt
+++ b/vero/examples/gaia-optimization/src/gaia_agent/prompts/terminus-xml-plain.txt
@@ -1,0 +1,60 @@
+You are an AI assistant tasked with solving command-line tasks in a Linux environment. You will be given a task description and the output from previously executed commands. Your goal is to solve the task by providing batches of shell commands.
+
+Format your response as XML with the following structure:
+
+<response>
+<analysis>
+Analyze the current state based on the terminal output provided. What do you see? What has been accomplished? What still needs to be done?
+</analysis>
+<plan>
+Describe your plan for the next steps. What commands will you run and why? Be specific about what you expect each command to accomplish.
+</plan>
+<commands>
+<keystrokes duration="0.1">ls -la
+</keystrokes>
+<keystrokes duration="0.1">cd project
+</keystrokes>
+</commands>
+<task_complete>true</task_complete>
+</response>
+
+Required sections:
+- <analysis>: Your analysis of the current situation
+- <plan>: Your plan for the next steps  
+- <commands>: XML structure containing commands to execute
+
+The `duration` attribute of <keystrokes> specifies the number of seconds to wait for the command to complete (default: 1.0) before the next command will be executed. On immediate tasks (e.g., cd, ls, echo, cat) set a duration of 0.1 seconds. On commands (e.g., gcc, find, rustc) set a duration of 1.0 seconds. On slow commands (e.g., make, python3 [long running script], wget [file]) set an apprpriate duration as you determine necessary.
+
+It is better to set a smaller duration than a longer duration. In is always possible to wait again if the prior output has not finished, by running <keystrokes duration="10.0"></keystrokes> on subsequent requests to wait longer. Never wait longer than 60 seconds; prefer to poll to see intermediate result status.
+
+Optional sections:
+- <task_complete>: Include this tag if the task is complete. Can be:
+  - <task_complete>true</task_complete> (task complete)
+  - <task_complete>false</task_complete> (task not complete)
+  - <task_complete/> (self-closing, equivalent to false)
+  - <task_complete></task_complete> (empty, equivalent to false)
+  - If not present, task is assumed not complete
+
+IMPORTANT: The text inside each <keystrokes></keystrokes> tag will be used completely verbatim as keystrokes. DO NOT XML-encode special characters - write them directly:
+- Use < and > directly, NOT &lt; and &gt;
+- Use & directly, NOT &amp;
+- Use quotes directly, NOT &quot;
+Even though this is XML, the content inside keystrokes tags is treated as raw text and sent exactly as written. Ensure there is no extra leading or trailing whitespace unless intended. You must end every command with a newline (\n) or it will not execute. 
+
+
+Special key sequences (use tmux-style escape sequences):
+- C-c for Ctrl+C. MUST be sent as a keystroke by itself, e.g., <keystrokes>C-c</keystrokes>
+- C-d for Ctrl+D. MUST be sent as a keystroke by itself, e.g., <keystrokes>C-d</keystrokes>
+- For Enter/newline: simply add a newline (line break) in the XML, everything inside the command tag will be sent byte-for-byte
+
+Important notes:
+- Each command's text content is sent exactly as keystrokes to the terminal
+- Do not include extra whitespace before or after the command text unless it's part of the intended command
+- Avoid extra text before or after the <response> tags
+- Avoid additional XML tags outside of analysis/plan/commands/task_complete
+
+Task Description:
+{instruction}
+
+Current terminal state:
+{terminal_state}


### PR DESCRIPTION
**Draft · Stack 4 of 4** — targets `harbor-3-compiler`. Additive, low-risk.

- `docs/harbor/architecture.md` — what it is, the compiled-task topology, the two modes, the component map, and the leaderboard-integrity model.
- `docs/harbor/tutorial.md` — build + run end to end (both modes, the agent-side protocol); README Harbor section.
- `examples/gaia-optimization` — a Mode-B example optimizing a `GaiaAgent` (thin `Terminus2` subclass with an editable prompt) on `gaia/gaia` via a nested harbor run on Modal.

Start your reading here for the big picture, then dive into [1/4]–[3/4].

Stack: [1/4] core → [2/4] sidecar → [3/4] compiler → **this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This stack-capping PR adds documentation and a runnable example for the Harbor integration: an architecture doc, an end-to-end tutorial, and the `gaia-optimization` Mode B example that optimizes a `Terminus2`-based GAIA agent's prompt via nested Harbor runs on Modal.

- `docs/harbor/architecture.md` and `docs/harbor/tutorial.md` document the compiled-task topology, the two evaluation modes, the leaderboard-integrity trust model (including an honest fail-open caveat for unlisted splits), and the full build + run workflow.
- `examples/gaia-optimization` ships a complete Mode B setup: a `GaiaAgent` (`Terminus2` subclass with editable prompts), a `build.yaml` with explicit split access and a well-commented caveat about validation task-ID visibility through `agent_repo`, and a `pyproject.toml` that bundles the prompt files into the wheel.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is an additive, docs-and-example-only PR with no changes to production code paths; safe to merge.

All changes are documentation files and a new example package. The only code is agent.py, a thin subclass that overrides prompt routing. No existing logic is modified. The two findings are editorial (typos in the upstream-copied prompt) and a defensive-coding suggestion (explicit fallthrough guard) — neither affects correctness of the current example.

No files require special attention. agent.py has a minor silent-fallthrough risk worth a quick read.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/README.md | Additive Harbor integration section with CLI quickstart and links to the new docs; no logic changes. |
| vero/docs/harbor/architecture.md | New architecture doc covering the compiled-task topology, two evaluation modes, component map, and leaderboard integrity; correctly documents the fail-open split default as a known limitation. |
| vero/docs/harbor/tutorial.md | New end-to-end tutorial with Mode A and Mode B build.yaml examples and the agent-side protocol; clear and accurate against the architecture. |
| vero/examples/gaia-optimization/README.md | Well-structured example README with prerequisites, run instructions, and an honest caveat about validation task-ID visibility through agent_repo. |
| vero/examples/gaia-optimization/build.yaml | Mode B build config with all splits explicitly listed (avoiding the fail-open default), a detailed caveat about held-out task-ID visibility, and correctly scoped secrets. |
| vero/examples/gaia-optimization/pyproject.toml | Standard hatchling src-layout config; force-include for the prompts directory ensures they are bundled into the wheel. |
| vero/examples/gaia-optimization/src/gaia_agent/__init__.py | Trivial re-export of GaiaAgent; correct. |
| vero/examples/gaia-optimization/src/gaia_agent/agent.py | Thin Terminus2 subclass redirecting prompt paths via _get_prompt_template_path; accesses private _parser_name — a silent fallthrough to the base-class path if the attribute's values drift upstream. |
| vero/examples/gaia-optimization/src/gaia_agent/prompts/terminus-json-plain.txt | Verbatim copy of the Harbor terminus-2 JSON prompt; no issues. |
| vero/examples/gaia-optimization/src/gaia_agent/prompts/terminus-xml-plain.txt | Copy of the Harbor terminus-2 XML prompt with two typos inherited from upstream: "apprpriate" and "In is always possible". |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(harbor): honest integrity guarantee..."](https://github.com/scaleapi/vero/commit/f70a93cb44dad0f01dfb4bfb19458cc3c328718d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39627966)</sub>

<!-- /greptile_comment -->