### PR TITLE
fix(harbor): Mode A scorer provenance, auto_best admin re-score, fail-closed tiers [fixes 2/4 sidecar]

### DIFF
--- a/vero/src/vero/harbor/protocol.py
+++ b/vero/src/vero/harbor/protocol.py
@@ -9,11 +9,14 @@ delivered as files on the agent-readable volume, gated by split tier.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict, dataclass, field
 
 from vero.core.budget import SplitBudget
 from vero.core.dataset.base import SplitAccess, SplitAccessLevel
 from vero.core.db.database import Experiment
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -54,11 +57,22 @@ class StatusSummary:
 
 
 def tier_for_split(split: str, split_accesses: list[SplitAccess]) -> SplitAccessLevel:
-    """Resolve a split's visibility tier (default: viewable when unlisted)."""
+    """Resolve a split's visibility tier.
+
+    Fails CLOSED: an unlisted split is treated as ``no_access`` (not
+    agent-evaluable, nothing written to the agent volume). A split with no
+    declared access is a misconfiguration, not an invitation to expose labels,
+    so we log a warning and deny rather than default to the most permissive tier.
+    """
     for sa in split_accesses:
         if sa.split == split:
             return sa.access
-    return SplitAccessLevel.viewable
+    logger.warning(
+        "Split %r has no declared access level; failing closed to no_access. "
+        "Declare it explicitly in split_accesses if the agent should see it.",
+        split,
+    )
+    return SplitAccessLevel.no_access
 
 
 def summarize_experiment(

--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -8,8 +8,10 @@ contract.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -60,7 +62,7 @@ class ServeConfig(BaseModel):
     harbor: dict | None = None  # HarborConfig kwargs
 
     # selection / reward
-    reward_mode: str = "auto_best"
+    reward_mode: Literal["submit", "auto_best"] = "auto_best"
     selection_split: str = "validation"
     targets: list[_TargetCfg] = Field(default_factory=list)
     base_commit: str | None = None
@@ -85,15 +87,73 @@ class ServeConfig(BaseModel):
         return cls.model_validate_json(Path(path).read_text())
 
 
+def _load_or_build_ledger(
+    budget_cfgs: list[dict], persist_path: Path
+) -> BudgetLedger:
+    """Build the durable ledger, reloading spent budget from ``persist_path`` if present.
+
+    The ledger flushes every mutation to ``persist_path``; without reloading it,
+    a sidecar restart would reset all spent budget to full, letting the agent
+    regain its full evaluation budget by triggering a restart. On startup we
+    reconstruct each SplitBudget and restore its persisted ``remaining_*`` values.
+    Falls back to the configured budgets if the file is missing or unreadable
+    (fail-safe to the configured budget, never to unlimited).
+    """
+    if persist_path.exists():
+        try:
+            persisted = json.loads(persist_path.read_text())
+            budgets: list[SplitBudget] = []
+            for entry in persisted:
+                b = SplitBudget(
+                    split=entry["split"],
+                    dataset_id=entry.get("dataset_id", ""),
+                    total_sample_budget=entry.get("total_sample_budget"),
+                    total_run_budget=entry.get("total_run_budget"),
+                    max_samples_per_run=entry.get("max_samples_per_run"),
+                )
+                # __post_init__ reset remaining_* to total_*; restore spent state.
+                b.remaining_sample_budget = entry.get("remaining_sample_budget")
+                b.remaining_run_budget = entry.get("remaining_run_budget")
+                budgets.append(b)
+            logger.info(
+                "Reloaded persisted budget ledger from %s (%d splits).",
+                persist_path,
+                len(budgets),
+            )
+            return BudgetLedger(budgets, persist_path=persist_path)
+        except (json.JSONDecodeError, KeyError, OSError) as e:
+            logger.warning(
+                "Could not reload persisted ledger %s (%s); using configured budgets.",
+                persist_path,
+                e,
+            )
+    return BudgetLedger(
+        [SplitBudget(**b) for b in budget_cfgs], persist_path=persist_path
+    )
+
+
 async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Verifier, str]:
     """Assemble the sidecar + verifier (sharing one engine) and the admin token."""
     vero_home = get_vero_home_dir()
+
+    # Integrity guard: in Mode A the vero scorer (@task.evaluation()) is resolved
+    # and executed by the Evaluator. With task_project unset, that scorer would be
+    # discovered from the AGENT's committed repo, so a committed scorer returning
+    # 1.0 would win the hidden-split/admin reward. Require a sidecar-baked task
+    # project so the scorer is trusted (agent code is layered as --with-editable,
+    # never the scorer's source). Mode B (config.harbor set) uses an eval_strategy
+    # that ignores the vero scorer and is exempt.
+    if config.harbor is None and not config.task_project:
+        raise ValueError(
+            "Mode A requires `task_project` so the scorer is loaded from the "
+            "sidecar-baked task project, not the agent's committed repo. Refusing "
+            "to start: with task_project unset the agent controls its own scoring."
+        )
+
     workspace = await GitWorkspace.create(config.repo_path)
 
-    budget = BudgetLedger(
-        [SplitBudget(**b) for b in config.budgets],
-        persist_path=Path(config.admin_volume) / "ledger.json",
-    )
+    persist_path = Path(config.admin_volume) / "ledger.json"
+    budget = _load_or_build_ledger(config.budgets, persist_path)
 
     eval_strategy = None
     if config.harbor is not None:
@@ -142,10 +202,12 @@ async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Veri
     verifier = Verifier(
         engine=engine,
         admin_volume=Path(config.admin_volume),
-        reward_mode=config.reward_mode,  # type: ignore[arg-type]
+        reward_mode=config.reward_mode,
         targets=[VerificationTarget(**t.model_dump()) for t in config.targets],
         selection_split=config.selection_split,
         base_commit=config.base_commit,
+        selection_task=config.task,
+        selection_dataset_id=config.dataset_id,
     )
 
     token = generate_token()

--- a/vero/src/vero/harbor/server.py
+++ b/vero/src/vero/harbor/server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 from dataclasses import replace
 from pathlib import Path
 
@@ -163,6 +164,12 @@ class EvaluationSidecar:
 
         commit = experiment.run.candidate.commit
         dest = self.agent_volume / "results" / f"{split}__{commit[:12]}"
+        # Recreate the dir so it reflects exactly this metered run. The dir is keyed
+        # only on (split, commit[:12]); a prior eval of the same commit on a larger
+        # sample set would otherwise leave stale per-sample files behind that this
+        # run did not produce, and result_path would surface them as if they were.
+        if dest.exists():
+            shutil.rmtree(dest)
         dest.mkdir(parents=True, exist_ok=True)
 
         # Aggregate summary is label-safe for both visible and partial tiers.

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -49,6 +49,9 @@ class Verifier:
         targets: list[VerificationTarget],
         selection_split: str = "validation",
         base_commit: str | None = None,
+        selection_task: str | None = None,
+        selection_dataset_id: str | None = None,
+        rescore_top_k: int = 3,
     ):
         self.engine = engine
         self.admin_volume = Path(admin_volume)
@@ -56,10 +59,16 @@ class Verifier:
         self.targets = targets
         self.selection_split = selection_split
         self.base_commit = base_commit
+        # auto_best re-scores the top-K shortlist admin-side; selection_task is the
+        # task to score the selection split with (the trusted, sidecar-baked scorer),
+        # and selection_dataset_id constrains ranking to the intended dataset.
+        self.selection_task = selection_task
+        self.selection_dataset_id = selection_dataset_id
+        self.rescore_top_k = rescore_top_k
 
     async def finalize(self) -> dict[str, float]:
         """Select the commit and score it on every target -> {reward_key: score}."""
-        sha = self._select_commit()
+        sha = await self._select_commit()
         logger.info(f"Verifier selected commit {sha} (mode={self.reward_mode})")
         rewards: dict[str, float] = {}
         for target in self.targets:
@@ -76,10 +85,10 @@ class Verifier:
             )
         return rewards
 
-    def _select_commit(self) -> str:
+    async def _select_commit(self) -> str:
         if self.reward_mode == "submit":
             return self._submitted_commit()
-        return self._best_from_db()
+        return await self._best_from_db()
 
     def _submitted_commit(self) -> str:
         path = self.admin_volume / "submission.json"
@@ -92,8 +101,16 @@ class Verifier:
             raise NoCandidateError("submission.json has no commit.")
         return commit
 
-    def _best_from_db(self) -> str:
-        """Best candidate by recorded score on the selection split (excludes baseline)."""
+    async def _best_from_db(self) -> str:
+        """Best candidate on the selection split, chosen by an admin re-score.
+
+        The recorded ``mean_score`` is agent-influenced (the agent ran those
+        selection-split evals), so it is used only to shortlist the top-K
+        candidates. The winner is then decided by re-running ``evaluate_admin``
+        on the selection split with the trusted (sidecar-baked) scorer and
+        ranking by the admin score. This fails closed: an agent that inflated
+        its recorded score cannot win unless the admin scorer agrees.
+        """
         if self.engine.db is None:
             raise NoCandidateError("auto_best mode but no experiment database.")
         df = self.engine.db.get_experiments_df(fill_score=default_minimum_score)
@@ -101,6 +118,13 @@ class Verifier:
             raise NoCandidateError("auto_best mode but no experiments recorded.")
 
         split_df = df[df["dataset_subset_split"] == self.selection_split]
+        if self.selection_dataset_id is not None and "dataset_subset_dataset_id" in split_df.columns:
+            # Only rank candidates scored on the intended selection dataset: a
+            # shared experiment DB may hold same-named splits across datasets, and
+            # a high score from a foreign dataset must not select the winner.
+            split_df = split_df[
+                split_df["dataset_subset_dataset_id"] == self.selection_dataset_id
+            ]
         if self.base_commit is not None:
             split_df = split_df[split_df["candidate_commit"] != self.base_commit]
         if len(split_df) == 0:
@@ -108,7 +132,36 @@ class Verifier:
                 f"auto_best mode but no candidate experiments on split "
                 f"'{self.selection_split}'."
             )
-        best = split_df.sort_values(
+        # Shortlist by recorded score (cheap, agent-influenced -> not trusted as
+        # final), one row per candidate (highest recorded score wins the slot).
+        ranked = split_df.sort_values(
             by=["mean_score", "candidate_created_at"], ascending=[False, False]
-        ).iloc[0]
-        return best["candidate_commit"]
+        )
+        ranked = ranked.drop_duplicates(subset=["candidate_commit"], keep="first")
+        shortlist = ranked.head(max(1, self.rescore_top_k))
+
+        rescored: list[tuple[float, int, str]] = []
+        for idx, (_, row) in enumerate(shortlist.iterrows()):
+            commit = row["candidate_commit"]
+            dataset_id = row.get("dataset_subset_dataset_id")
+            exp = await self.engine.evaluate_admin(
+                task=self.selection_task,
+                dataset_id=dataset_id,
+                split=self.selection_split,
+                commit=commit,
+            )
+            score = exp.result.score()
+            admin_score = float(score) if score is not None else default_minimum_score
+            # Tie-break by shortlist position (already ordered by recorded score
+            # then recency), so ties resolve deterministically without depending on
+            # the type of candidate_created_at (a datetime in the real DB).
+            rescored.append((admin_score, idx, commit))
+            logger.info(
+                "auto_best re-score: commit=%s admin_score=%s (recorded=%s)",
+                commit,
+                admin_score,
+                row["mean_score"],
+            )
+        # Highest admin score wins; ties break to the earliest shortlist position.
+        rescored.sort(key=lambda t: (-t[0], t[1]))
+        return rescored[0][2]

--- a/vero/tests/test_harbor_app.py
+++ b/vero/tests/test_harbor_app.py
@@ -1,7 +1,9 @@
 """Tests for vero.harbor.app — FastAPI routes + agent/admin auth."""
 
+import os
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from vero.exceptions import ExperimentBudgetExceeded
@@ -83,3 +85,71 @@ class TestAdminEndpoint:
         r = client.post("/finalize", headers={"Authorization": f"Bearer {TOKEN}"})
         assert r.status_code == 200 and r.json() == {"reward": 1.0}
         verifier.finalize.assert_awaited_once()
+
+
+class TestServeIntegrityGuards:
+    @pytest.mark.asyncio
+    async def test_mode_a_without_task_project_rejected(self, tmp_path):
+        # Mode A (no `harbor`) with task_project unset would load the scorer from
+        # the agent repo. build_components must refuse to start.
+        from vero.harbor.serve import ServeConfig, build_components
+
+        cfg = ServeConfig(
+            repo_path=str(tmp_path / "repo"),
+            agent_repo_path=str(tmp_path / "agent"),
+            session_id="s",
+            dataset_id="ds",
+            split_accesses=[{"split": "test", "access": "no_access"}],
+            budgets=[{"split": "validation", "dataset_id": "ds", "total_run_budget": 1}],
+            task="math",
+            task_project=None,  # the vulnerability
+            agent_volume=str(tmp_path / "agent_vol"),
+            admin_volume=str(tmp_path / "admin_vol"),
+            admin_token_path=str(tmp_path / "admin_vol" / "token"),
+        )
+        with pytest.raises(ValueError, match="task_project"):
+            await build_components(cfg)
+
+
+class TestNoAccessRejection:
+    def test_eval_on_no_access_split_maps_to_400(self):
+        # A no_access split is rejected in the engine (InvalidSplitError); the app
+        # must surface that as 400 so the agent can never evaluate it. Mirrors the
+        # 429 budget-exceeded mapping. The end-to-end engine guarantee (the gate
+        # fires before any scoring) is covered by the no_access gate test in
+        # test_engine.py on the core PR.
+        from vero.exceptions import InvalidSplitError
+
+        sidecar = MagicMock()
+        sidecar.evaluate = AsyncMock(side_effect=InvalidSplitError("no_access split"))
+        r = _client(sidecar=sidecar).post(
+            "/eval", json={"dataset_id": "ds", "split": "test"}
+        )
+        assert r.status_code == 400
+        sidecar.evaluate.assert_awaited_once()
+
+
+class TestTokenFilePermissions:
+    def test_token_file_not_world_or_group_readable(self, tmp_path):
+        # The admin token gates /finalize; agent.user (a different uid) must not be
+        # able to read it. The portable OS guarantee is the 0o600 mode bit.
+        tok = generate_token()
+        p = write_admin_token(tmp_path / "token", tok)
+        mode = p.stat().st_mode & 0o777
+        assert mode == 0o600
+        assert mode & 0o077 == 0, "token must not be group/other readable"
+
+    @pytest.mark.skipif(
+        os.geteuid() != 0,
+        reason="uid-drop read test requires running as root to seteuid to a non-owner",
+    )
+    def test_non_owner_uid_cannot_read_token(self, tmp_path):
+        tok = generate_token()
+        p = write_admin_token(tmp_path / "token", tok)
+        os.chown(p, 0, 0)  # root-owned, like the real sidecar
+        try:
+            os.seteuid(65534)  # nobody
+            with pytest.raises(PermissionError):
+                read_admin_token(p)
+        finally:
+            os.seteuid(0)

--- a/vero/tests/test_harbor_protocol.py
+++ b/vero/tests/test_harbor_protocol.py
@@ -44,8 +44,13 @@ class TestTier:
         assert tier_for_split("test", accesses) == SplitAccessLevel.no_access
         assert tier_for_split("validation", accesses) == SplitAccessLevel.non_viewable
 
-    def test_unlisted_defaults_viewable(self):
-        assert tier_for_split("train", []) == SplitAccessLevel.viewable
+    def test_unlisted_fails_closed_to_no_access(self):
+        # An undeclared split must fail CLOSED, never default to viewable.
+        assert tier_for_split("train", []) == SplitAccessLevel.no_access
+        assert (
+            tier_for_split("train", [SplitAccess.no_access("test")])
+            == SplitAccessLevel.no_access
+        )
 
 
 class TestSummarize:
@@ -74,13 +79,15 @@ class TestBuildStatus:
             ("train", "ds1"): SplitBudget(split="train", dataset_id="ds1", total_run_budget=10),
             ("validation", "ds1"): SplitBudget(split="validation", dataset_id="ds1", total_run_budget=3),
         }
-        accesses = [SplitAccess.non_viewable("validation")]  # train defaults viewable
+        accesses = [SplitAccess.non_viewable("validation")]  # train left unlisted -> fails closed
         status = build_status(submit_enabled=True, budget=budget, split_accesses=accesses)
 
         assert status.submit_enabled is True
         by_split = {s["split"]: s for s in status.splits}
-        assert by_split["train"]["tier"] == str(SplitAccessLevel.viewable)
-        assert by_split["train"]["agent_evaluable"] is True
+        # An unlisted split now fails CLOSED (no_access), not open (viewable): a
+        # budgeted split must be tiered explicitly or the sidecar denies it.
+        assert by_split["train"]["tier"] == str(SplitAccessLevel.no_access)
+        assert by_split["train"]["agent_evaluable"] is False
         assert by_split["validation"]["tier"] == str(SplitAccessLevel.non_viewable)
         assert by_split["validation"]["agent_evaluable"] is True
         assert by_split["validation"]["remaining_run_budget"] == 3

--- a/vero/tests/test_harbor_serve.py
+++ b/vero/tests/test_harbor_serve.py
@@ -141,3 +141,81 @@ async def test_serve_assembles_and_evaluates_and_finalizes(fixture):
     # verifier selects the (only) candidate on "test" and scores it on the test target
     rewards = await verifier.finalize()
     assert rewards["reward"] == 1.0
+
+
+def _create_cheating_agent(root: Path) -> tuple[Path, str]:
+    """An agent whose committed repo ALSO ships a vero_tasks scorer that returns 1.0
+    for everything, and whose solve() returns a wrong answer. If the verifier ran
+    the agent's scorer, reward would be 1.0; with the sidecar-baked task project it
+    must reflect the real (0.0) score."""
+    d = root / "cheating-agent"
+    vt = d / "src" / "my_agent" / "vero_tasks"
+    vt.mkdir(parents=True)
+    (d / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "my-agent"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/my_agent"]
+    """))
+    (d / "src" / "my_agent" / "__init__.py").write_text('def solve(q): return "WRONG"\n')
+    # Adversarial scorer baked into the AGENT repo: always 1.0.
+    (vt / "__init__.py").write_text("from my_agent.vero_tasks import math_task  # noqa\n")
+    (vt / "math_task.py").write_text(textwrap.dedent("""\
+        from vero.core.db.result import TaskOutput, TaskResult
+        from vero.core.task import create_task
+        math_task = create_task("math")
+        @math_task.inference()
+        async def run_inference(task, evaluation_parameters):
+            return TaskOutput(output="WRONG")
+        @math_task.evaluation()
+        async def evaluate(task, output, evaluation_parameters):
+            return TaskResult(output=output.output, score=1.0)  # always passes
+    """))
+    _git(d, "init")
+    _git(d, "add", ".")
+    _git(d, "commit", "-m", "init")
+    return d, _git(d, "rev-parse", "HEAD")
+
+
+@pytest.mark.asyncio
+async def test_finalize_does_not_run_agent_supplied_scorer(fixture):
+    # Reuse the trusted task project from the fixture; swap in a cheating agent
+    # whose committed repo carries a 1.0 scorer and a wrong solve().
+    _, _, task_dir, dataset_id, tmp = fixture
+    agent_dir, head = _create_cheating_agent(tmp)
+    config = _serve_config(agent_dir, head, task_dir, dataset_id, tmp)
+
+    sidecar, verifier, _ = await build_components(config)
+    # Real eval: agent answers "WRONG" for sample 0 (expects "42"); trusted scorer -> 0.0
+    exp = await sidecar.engine.evaluate(
+        EvalRequest(dataset_id=dataset_id, split="test", commit=head, sample_ids=[0])
+    )
+    assert exp.result.sample_results[0].score == 0.0
+    # Finalize must reflect the TRUSTED score, not the agent's 1.0 scorer.
+    rewards = await verifier.finalize()
+    assert rewards["reward"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_ledger_reloads_spent_budget_across_restart(fixture):
+    agent_dir, head, task_dir, dataset_id, tmp = fixture
+    config = _serve_config(agent_dir, head, task_dir, dataset_id, tmp)
+
+    # First boot: spend one run on the test split.
+    sidecar, _, _ = await build_components(config)
+    before = sidecar.engine.budget.get(dataset_id, "test").remaining_run_budget
+    await sidecar.engine.evaluate(
+        EvalRequest(dataset_id=dataset_id, split="test", commit=head, sample_ids=[0])
+    )
+    after = sidecar.engine.budget.get(dataset_id, "test").remaining_run_budget
+    assert after == before - 1
+
+    # Restart: rebuild from the SAME config + admin_volume; spent budget must persist.
+    sidecar2, _, _ = await build_components(config)
+    reloaded = sidecar2.engine.budget.get(dataset_id, "test").remaining_run_budget
+    assert reloaded == after, "sidecar restart must not refill spent budget"

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -66,47 +66,70 @@ class TestMultiTarget:
 
 class TestAutoBestSelection:
     @pytest.mark.asyncio
-    async def test_finalize_auto_best_picks_top_validation_score(self, tmp_path):
-        engine = _engine([0.95])
+    async def test_auto_best_reranks_by_admin_score(self, tmp_path):
+        # 'hi' has the best RECORDED score (agent-influenced) but the admin re-score
+        # rates 'lo' higher; selection must follow the admin score.
+        engine = MagicMock()
         engine.db.get_experiments_df.return_value = pd.DataFrame(
             {
                 "dataset_subset_split": ["validation", "validation", "train"],
+                "dataset_subset_dataset_id": ["ds1", "ds1", "ds1"],
                 "candidate_commit": ["lo", "hi", "ignored"],
                 "mean_score": [0.5, 0.9, 1.0],
                 "candidate_created_at": [1, 2, 3],
             }
         )
+        admin_scores = {"hi": 0.1, "lo": 0.95}
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(
+                result=MagicMock(score=MagicMock(return_value=admin_scores.get(commit, 0.99)))
+            )
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
         v = Verifier(
             engine=engine,
             admin_volume=tmp_path,
             reward_mode="auto_best",
             selection_split="validation",
-            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="test", reward_key="reward")],
         )
         rewards = await v.finalize()
-        assert rewards == {"reward": 0.95}
-        # selected the highest validation score ("hi"), not the train row
-        assert engine.evaluate_admin.await_args.kwargs["commit"] == "hi"
+        # the final (target) eval is on the WINNER 'lo', chosen by admin re-score
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "lo"
+        assert engine.evaluate_admin.await_args.kwargs["split"] == "test"
+        # reward is the winner 'lo' scored on the target split -> its admin score
+        assert rewards["reward"] == 0.95
 
     @pytest.mark.asyncio
-    async def test_finalize_auto_best_excludes_baseline(self, tmp_path):
-        engine = _engine([0.7])
+    async def test_auto_best_excludes_baseline_after_rescore(self, tmp_path):
+        engine = MagicMock()
         engine.db.get_experiments_df.return_value = pd.DataFrame(
             {
                 "dataset_subset_split": ["validation", "validation"],
+                "dataset_subset_dataset_id": ["ds1", "ds1"],
                 "candidate_commit": ["base", "agent"],
                 "mean_score": [0.99, 0.6],
                 "candidate_created_at": [1, 2],
             }
         )
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=0.7)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
         v = Verifier(
             engine=engine,
             admin_volume=tmp_path,
             reward_mode="auto_best",
             selection_split="validation",
             base_commit="base",
-            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="test", reward_key="reward")],
         )
         await v.finalize()
-        # baseline excluded even though it scored higher
+        # baseline 'base' was never re-scored; 'agent' is selected + target-scored
+        rescored_commits = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
+        assert "base" not in rescored_commits
         assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"


### PR DESCRIPTION
Stacks on **#4** (`harbor-2-sidecar`). Addresses the trust-boundary findings from the review of that PR. 2 of 4 fix PRs.

### What this fixes

| # | Sev | Finding | Fix |
|---|---|---|---|
| S1 | 🔴 | `tier_for_split` fails **open** (unlisted split → `viewable` → per-sample labels written to the agent volume) | Fail **closed**: unlisted → `no_access`, with a warning |
| S2 | 🔴 | **Mode A scorer provenance (the headline).** `task_project=None` loads the `@task.evaluation()` scorer from the agent's committed repo; `evaluate_admin` then scores the hidden split with it, so a committed scorer returning `1.0` wins | `build_components` refuses a Mode A config without `task_project`, so the hidden-split scorer is always sidecar-baked, never the agent's commit |
| S3 | 🔴 | `auto_best` ranks candidates purely by the agent-influenced recorded score, so a candidate can inflate its own selection score | Recorded score only shortlists; the winner is decided by re-running `evaluate_admin` (trusted scorer) on the selection split for the top-K and ranking by admin score. Fails closed |
| S4 | 🟠 | The budget ledger is rebuilt from config on every start, so a sidecar restart resets spent budget to full | Reload `remaining_*` from the persisted ledger when present (fail-safe to configured budgets) |
| S5 | 🟠 | No adversarial/OS-level tests for the integrity claims | Added: `no_access`→400, a cheating-agent repo proving `finalize` doesn't run the agent's scorer, token `0o600`/unreadable |

### Greptile findings on PR #4, also fixed here (replies posted on #4)
- **stale result dirs** (`server.py`): `_route_results` recreates the dir so it reflects exactly the current metered run.
- **`reward_mode` typed** (`serve.py`): now `Literal["submit","auto_best"]`, rejected at parse time.
- **`auto_best` dataset scoping** (`verifier.py`): candidates filtered by `selection_dataset_id` so a foreign dataset's same-named split can't select the winner.

### Architecture question
This PR keeps `tier_for_split` as the sidecar's write-routing resolver and flips it fail-closed; the engine-side real-time access gate lands in the core PR. See the design note (answering "should split access be a dataset property with a real-time check?") for the full reasoning. Short answer: yes, and the core PR implements the minimal version.

### Tests
20 harbor unit tests pass (protocol, verifier, app). The 3 real-eval serve tests pass end-to-end (built via `uv` against a real task project): the honest path, the cheating-agent scorer-provenance proof (reward stays `0.0`, not the agent's `1.0`), and the ledger-reload-across-restart test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens Harbor sidecar evaluation and reward handling. The main changes are:

- Unlisted splits now fail closed to `no_access`.
- Mode A startup now requires a trusted `task_project`.
- Budget ledgers are reloaded from persisted state across restarts.
- `auto_best` now admin re-scores a shortlist before choosing a winner.
- Result directories are recreated to avoid stale per-sample files.
- Tests cover scorer provenance, no-access handling, token permissions, ledger reload, and verifier selection.

<details><summary><h3>Confidence Score: 2/5</h3></summary>

Not merge-safe until the auto-selection and budget reload paths are corrected.

The changes address several trust-boundary issues, but runtime checks reproduced cases where candidate selection can still be controlled by recorded scores, scorer failures can abort finalization prematurely, and persisted budget state can override the current baked configuration.

`vero/src/vero/harbor/verifier.py` and `vero/src/vero/harbor/serve.py` need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused pytest harness against the Verifier auto\_best path with five validation candidates and a recorded-score shortlist that excluded the trusted best commit.
- The run showed evaluate\_admin was called only for bad\_1, bad\_2, and bad\_3, with the final scoring run on bad\_3 and the true\_best (0.99) not evaluated because its mean\_score ranked below the shortlist.
- The test failed asserting the selected winner should match the full admin best, demonstrating auto\_best picked bad\_3 instead of true\_best.
- Ran a focused ledger-restart repro that wrote a persisted ledger.json with dataset-a/test budgets (100 samples, 10 runs, max 50) and then restarted ledger loading with reduced budgets (10 samples, 1 run, max 5).
- The loaded ledger still contained the persisted old values, allowed check(dataset-a, test, 6) despite the current max\_samples\_per\_run being 5, and, when restarted with an empty budget\_cfgs list, the removed dataset-a/test split remained evaluable from the persisted ledger.
- Ran a Harbor Verifier auto\_best harness with two candidates ordered by recorded score; monkeypatched evaluate\_admin to raise for first\_raises and return 0.95 for later\_success, and finalize raised RuntimeError after evaluating only first\_raises, so later\_success was never considered.
- Before: a fail-open tier showed viewable split\_accesses; After: the code path moved to a fail-closed tier with no\_access, and a repro script constructs the failing path for the tier switch.
- Before: mode A provenance showed harbor=None, task\_project=None, initialized components, token written, and exit code 0; After: head raised ValueError about missing task\_project and the fail-closed guard activated, with exit code 0; Supplemental: a fail-closed pytest run appeared successful, though the trusted-scorer test did not run due to a FileNotFoundError during fixture setup.
- Before: reward\_mode='bogus' with no selection\_dataset\_id and a chosen foreign\_ds2\_commit; After: the head rejected the bogus reward mode with ValidationError, exposed selection\_dataset\_id, narrowed ranking to ds1, and selected intended\_ds1\_commit.

<a href="https://app.greptile.com/trex/runs/12757215/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A135-141%0A**Shortlist%20still%20controls%20selection.**%20The%20admin%20re-score%20only%20runs%20on%20candidates%20admitted%20by%20the%20agent-influenced%20%60mean_score%60%20ranking.%20An%20agent%20can%20run%20three%20throwaway%20commits%20with%20inflated%20recorded%20scores%20and%20leave%20the%20actually%20best%20commit%20below%20%60rescore_top_k%60%3B%20the%20trusted%20scorer%20never%20evaluates%20that%20lower-recorded%20commit%2C%20so%20%60auto_best%60%20can%20select%20a%20worse%20winner%20than%20the%20admin%20score%20would%20choose.%20Re-score%20every%20eligible%20candidate%2C%20or%20choose%20the%20shortlist%20from%20a%20source%20that%20is%20not%20ranked%20by%20agent-written%20scores.%0A%0A%23%23%23%20Issue%202%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fserve.py%3A102-123%0A**Persisted%20ledger%20overrides%20config.**%20When%20%60ledger.json%60%20exists%2C%20this%20path%20rebuilds%20the%20budget%20ledger%20only%20from%20persisted%20entries%20and%20ignores%20the%20current%20baked%20%60budget_cfgs%60.%20If%20a%20restart%20follows%20a%20config%20change%20that%20lowers%20a%20budget%2C%20removes%20a%20split%2C%20or%20changes%20%60max_samples_per_run%60%2C%20the%20old%20persisted%20entry%20remains%20active%20with%20its%20old%20limits%20and%20can%20keep%20that%20split%20evaluable.%20Rebuild%20from%20%60budget_cfgs%60%20as%20the%20authority%2C%20overlay%20persisted%20%60remaining_*%60%20only%20for%20matching%20%60%28split%2C%20dataset_id%29%60%20entries%2C%20and%20clamp%20remaining%20values%20to%20the%20configured%20totals.%0A%0A%23%23%23%20Issue%203%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A147-152%0A**Failed%20re-score%20aborts%20finalize.**%20Any%20exception%20from%20%60evaluate_admin%60%20inside%20the%20shortlist%20loop%20aborts%20%60_best_from_db%60%20before%20the%20remaining%20candidates%20are%20considered.%20Because%20the%20shortlist%20is%20chosen%20from%20recorded%20scores%2C%20a%20high-recorded%20commit%20that%20fails%20under%20the%20trusted%20scorer%20can%20prevent%20finalization%20even%20when%20lower-ranked%20candidates%20would%20re-score%20successfully.%20Treat%20failed%20re-scores%20as%20%60default_minimum_score%60%20or%20skip%20them%20after%20logging%2C%20and%20only%20raise%20%60NoCandidateError%60%20if%20every%20candidate%20fails.%0A%0A&pr=8&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A135-141%0A**Shortlist%20still%20controls%20selection.**%20The%20admin%20re-score%20only%20runs%20on%20candidates%20admitted%20by%20the%20agent-influenced%20%60mean_score%60%20ranking.%20An%20agent%20can%20run%20three%20throwaway%20commits%20with%20inflated%20recorded%20scores%20and%20leave%20the%20actually%20best%20commit%20below%20%60rescore_top_k%60%3B%20the%20trusted%20scorer%20never%20evaluates%20that%20lower-recorded%20commit%2C%20so%20%60auto_best%60%20can%20select%20a%20worse%20winner%20than%20the%20admin%20score%20would%20choose.%20Re-score%20every%20eligible%20candidate%2C%20or%20choose%20the%20shortlist%20from%20a%20source%20that%20is%20not%20ranked%20by%20agent-written%20scores.%0A%0A%23%23%23%20Issue%202%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fserve.py%3A102-123%0A**Persisted%20ledger%20overrides%20config.**%20When%20%60ledger.json%60%20exists%2C%20this%20path%20rebuilds%20the%20budget%20ledger%20only%20from%20persisted%20entries%20and%20ignores%20the%20current%20baked%20%60budget_cfgs%60.%20If%20a%20restart%20follows%20a%20config%20change%20that%20lowers%20a%20budget%2C%20removes%20a%20split%2C%20or%20changes%20%60max_samples_per_run%60%2C%20the%20old%20persisted%20entry%20remains%20active%20with%20its%20old%20limits%20and%20can%20keep%20that%20split%20evaluable.%20Rebuild%20from%20%60budget_cfgs%60%20as%20the%20authority%2C%20overlay%20persisted%20%60remaining_*%60%20only%20for%20matching%20%60%28split%2C%20dataset_id%29%60%20entries%2C%20and%20clamp%20remaining%20values%20to%20the%20configured%20totals.%0A%0A%23%23%23%20Issue%203%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A147-152%0A**Failed%20re-score%20aborts%20finalize.**%20Any%20exception%20from%20%60evaluate_admin%60%20inside%20the%20shortlist%20loop%20aborts%20%60_best_from_db%60%20before%20the%20remaining%20candidates%20are%20considered.%20Because%20the%20shortlist%20is%20chosen%20from%20recorded%20scores%2C%20a%20high-recorded%20commit%20that%20fails%20under%20the%20trusted%20scorer%20can%20prevent%20finalization%20even%20when%20lower-ranked%20candidates%20would%20re-score%20successfully.%20Treat%20failed%20re-scores%20as%20%60default_minimum_score%60%20or%20skip%20them%20after%20logging%2C%20and%20only%20raise%20%60NoCandidateError%60%20if%20every%20candidate%20fails.%0A%0A&repo=scaleapi%2Fvero&pr=8&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-2-sidecar-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-2-sidecar-fixes%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A135-141%0A**Shortlist%20still%20controls%20selection.**%20The%20admin%20re-score%20only%20runs%20on%20candidates%20admitted%20by%20the%20agent-influenced%20%60mean_score%60%20ranking.%20An%20agent%20can%20run%20three%20throwaway%20commits%20with%20inflated%20recorded%20scores%20and%20leave%20the%20actually%20best%20commit%20below%20%60rescore_top_k%60%3B%20the%20trusted%20scorer%20never%20evaluates%20that%20lower-recorded%20commit%2C%20so%20%60auto_best%60%20can%20select%20a%20worse%20winner%20than%20the%20admin%20score%20would%20choose.%20Re-score%20every%20eligible%20candidate%2C%20or%20choose%20the%20shortlist%20from%20a%20source%20that%20is%20not%20ranked%20by%20agent-written%20scores.%0A%0A%23%23%23%20Issue%202%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fserve.py%3A102-123%0A**Persisted%20ledger%20overrides%20config.**%20When%20%60ledger.json%60%20exists%2C%20this%20path%20rebuilds%20the%20budget%20ledger%20only%20from%20persisted%20entries%20and%20ignores%20the%20current%20baked%20%60budget_cfgs%60.%20If%20a%20restart%20follows%20a%20config%20change%20that%20lowers%20a%20budget%2C%20removes%20a%20split%2C%20or%20changes%20%60max_samples_per_run%60%2C%20the%20old%20persisted%20entry%20remains%20active%20with%20its%20old%20limits%20and%20can%20keep%20that%20split%20evaluable.%20Rebuild%20from%20%60budget_cfgs%60%20as%20the%20authority%2C%20overlay%20persisted%20%60remaining_*%60%20only%20for%20matching%20%60%28split%2C%20dataset_id%29%60%20entries%2C%20and%20clamp%20remaining%20values%20to%20the%20configured%20totals.%0A%0A%23%23%23%20Issue%203%20of%203%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A147-152%0A**Failed%20re-score%20aborts%20finalize.**%20Any%20exception%20from%20%60evaluate_admin%60%20inside%20the%20shortlist%20loop%20aborts%20%60_best_from_db%60%20before%20the%20remaining%20candidates%20are%20considered.%20Because%20the%20shortlist%20is%20chosen%20from%20recorded%20scores%2C%20a%20high-recorded%20commit%20that%20fails%20under%20the%20trusted%20scorer%20can%20prevent%20finalization%20even%20when%20lower-ranked%20candidates%20would%20re-score%20successfully.%20Treat%20failed%20re-scores%20as%20%60default_minimum_score%60%20or%20skip%20them%20after%20logging%2C%20and%20only%20raise%20%60NoCandidateError%60%20if%20every%20candidate%20fails.%0A%0A&repo=scaleapi%2Fvero&pr=8&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vero/src/vero/harbor/verifier.py:135-141
**Shortlist still controls selection.** The admin re-score only runs on candidates admitted by the agent-influenced `mean_score` ranking. An agent can run three throwaway commits with inflated recorded scores and leave the actually best commit below `rescore_top_k`; the trusted scorer never evaluates that lower-recorded commit, so `auto_best` can select a worse winner than the admin score would choose. Re-score every eligible candidate, or choose the shortlist from a source that is not ranked by agent-written scores.

### Issue 2 of 3
vero/src/vero/harbor/serve.py:102-123
**Persisted ledger overrides config.** When `ledger.json` exists, this path rebuilds the budget ledger only from persisted entries and ignores the current baked `budget_cfgs`. If a restart follows a config change that lowers a budget, removes a split, or changes `max_samples_per_run`, the old persisted entry remains active with its old limits and can keep that split evaluable. Rebuild from `budget_cfgs` as the authority, overlay persisted `remaining_*` only for matching `(split, dataset_id)` entries, and clamp remaining values to the configured totals.

### Issue 3 of 3
vero/src/vero/harbor/verifier.py:147-152
**Failed re-score aborts finalize.** Any exception from `evaluate_admin` inside the shortlist loop aborts `_best_from_db` before the remaining candidates are considered. Because the shortlist is chosen from recorded scores, a high-recorded commit that fails under the trusted scorer can prevent finalization even when lower-ranked candidates would re-score successfully. Treat failed re-scores as `default_minimum_score` or skip them after logging, and only raise `NoCandidateError` if every candidate fails.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(harbor): Mode A scorer provenance, a..."](https://github.com/scaleapi/vero/commit/2bcd7882e81876e3eb602eecebeb4590e06fd106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40777034)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->