### PR TITLE
docs(harbor): honest integrity guarantees, GAIA leak caveat, Mode A example [fixes 4/4 docs]

### DIFF
--- a/vero/README.md
+++ b/vero/README.md
@@ -539,7 +539,7 @@ Two evaluation modes: **Mode A** (vero runs inference + scoring against vero-sid
 
 - [`docs/harbor/architecture.md`](docs/harbor/architecture.md) — what it is, the topology, and the leaderboard-integrity model.
 - [`docs/harbor/tutorial.md`](docs/harbor/tutorial.md) — build and run a task end to end.
-- [`examples/gsm8k-agent`](examples/gsm8k-agent) (Mode A) and [`examples/gaia-optimization`](examples/gaia-optimization) (Mode B).
+- [`examples/gaia-optimization`](examples/gaia-optimization) (Mode B), the complete runnable example (ships a `build.yaml`). [`examples/gsm8k-agent`](examples/gsm8k-agent) (Mode A) ships the agent + vero task but not yet a `build.yaml`; pair it with the Mode A `build.yaml` snippet in [`docs/harbor/tutorial.md`](docs/harbor/tutorial.md).
 
 ## Examples
 

--- a/vero/docs/harbor/architecture.md
+++ b/vero/docs/harbor/architecture.md
@@ -5,9 +5,13 @@ task**. The agent-under-test of that Harbor task is an *optimizer*: any Harbor a
 (Claude Code, an oracle script, …) edits a target repository and spends an evaluation
 budget; the reward is the best candidate's score on a hidden test split.
 
-This lets anyone optimize a coding agent with plain `harbor run`, and makes the result
-leaderboard-gradeable — the optimizer cannot read hidden labels, modify the scorer, or
-bypass its budget.
+This lets anyone optimize a coding agent with plain `harbor run`, and aims to make the
+result leaderboard-gradeable. On a best-effort, OS/process-level basis the integration
+withholds per-sample labels from the agent volume, meters every agent evaluation against
+a budget, applies read-only paths, and gates final hidden-split scoring behind a
+`root:600` token the de-privileged optimizer cannot read (a container escape is out of
+scope). See [Leaderboard integrity](#leaderboard-integrity-the-trust-boundary) for the
+exact mechanisms and their limits.
 
 ```
 harbor run -p <task> -a <optimizer> -m <model> -e <provider>
@@ -44,8 +48,10 @@ harbor run -p <task> -a <optimizer> -m <model> -e <provider>
 The seam is a single injection point on the `Evaluator` (`eval_strategy`):
 
 - **Mode A — vero scores** (`task_project`/`task` + dataset). vero runs the agent's
-  inference and a vero scoring function against vero-side labels. Example:
-  [`examples/gsm8k-agent`](../../examples/gsm8k-agent).
+  inference and a vero scoring function against vero-side labels. Example agent:
+  [`examples/gsm8k-agent`](../../examples/gsm8k-agent) (note: it ships the agent and
+  vero task but not yet a `build.yaml`; see the Mode A `build.yaml` snippet in the
+  [tutorial](./tutorial.md) for a runnable config).
 - **Mode B — Harbor scores** (`HarborConfig`). Inference is delegated: for each
   candidate, `HarborRunner` runs a *nested* `harbor run` of the agent on a set of
   Harbor tasks (e.g. on Modal) and collates the verifier rewards. One Harbor task =
@@ -60,8 +66,12 @@ The optimizer is untrusted. Integrity rests on a few mechanisms, all best-effort
 the OS/process level (a container escape is out of scope):
 
 - **3-tier split visibility** (`SplitAccessLevel`): `visible` (aggregate + per-sample
-  results), `non_viewable` (aggregate score only — no labels), `no_access` (hidden;
-  never evaluable by the agent, never written to its volume).
+  results), `non_viewable` (aggregate score only, no labels), `no_access` (hidden;
+  never evaluable by the agent, never written to its volume). **A split not listed in
+  `splits:` currently defaults to viewable (fail-open).** List *every* split explicitly
+  and give held-out splits `no_access`; do not rely on omission to hide a split. (Once
+  the protocol fix lands this default becomes fail-closed: an unlisted split defaults to
+  `no_access`.)
 - **Write-routing by tier**: the sidecar writes only the agent-permitted projection of
   each result to the *agent-results* volume (read-only in `main`). Full results, the
   dataset, the ledger, and creds live on the *admin* volume, **never** mounted to `main`.
@@ -74,13 +84,21 @@ the OS/process level (a container escape is out of scope):
 - **Commit transfer**: the sidecar `git fetch`es the agent's commit from the mounted
   repo into its *own* repo with hooks disabled and `file://` (object copy, no
   alternates), so the evaluated tree is fully owned by the sidecar and tamper-evident.
-- **Protected scorer / write-access**: the scorer is sidecar-only; `read_only_paths`
-  in `build.yaml` are applied as unix perms in `main` before the optimizer runs.
+- **Protected scorer / write-access** (mode-dependent): in **Mode B** the scorer,
+  dataset, and creds are sidecar-only and never share a filesystem with the optimizer.
+  In **Mode A** the scoring function is vero task code that lives inside the agent's
+  *editable* `agent_repo` (e.g. `src/gsm8k_agent/vero_tasks`); it is protected only by
+  `read_only_paths` in `build.yaml`, applied as unix perms in `main` before the
+  optimizer runs (best-effort, not container isolation). Full Mode A scorer isolation
+  requires baking the task project into the sidecar instead of the agent repo, which
+  lands with the `serve.py` fix.
 
 ### Why a sidecar + shared verifier
 
-The evaluation engine, dataset, scorer, and creds live in a separate container so the
-optimizer never shares a filesystem or process space with them. We use Harbor's
+The evaluation engine, dataset, and creds live in a separate container so the optimizer
+never shares a filesystem or process space with them (in **Mode B** the scorer too; in
+**Mode A** the scorer currently lives in the agent's editable repo and is guarded only by
+`read_only_paths`, until the `serve.py` fix bakes a Mode A task project into the sidecar). We use Harbor's
 **shared verifier** (the env, including the sidecar, stays up during `tests/test.sh`)
 so the verifier can reach the live engine over HTTP and stay the single source of
 truth — avoiding shipping the repo/dataset/ledger into a fresh verifier container. The
@@ -104,6 +122,7 @@ vero/harbor/
 ├── runner.py         HarborRunner (Mode-B EvalStrategy): nested `harbor run` → collate
 ├── dataset.py        Mode-B {split: [task_names]} partition → DatasetDict
 └── protocol.py       aggregate-safe wire types + the redaction of an Experiment
+                      (note: an unlisted split currently defaults to viewable / fail-open)
 
 vero/evaluation/
 ├── engine.py         EvaluationEngine: budget metering + the single evaluate() entry point
@@ -117,5 +136,5 @@ the optimizer↔sidecar contract is the HTTP API in `app.py` (+ the `vero harbor
 ## See also
 
 - [Tutorial](./tutorial.md) — build and run an optimization task end to end.
-- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) — Mode A.
+- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) (Mode A agent; no `build.yaml` yet, use the tutorial's Mode A snippet).
 - [`examples/gaia-optimization`](../../examples/gaia-optimization) — Mode B (nested Harbor on Modal).

--- a/vero/docs/harbor/tutorial.md
+++ b/vero/docs/harbor/tutorial.md
@@ -129,6 +129,6 @@ cat <jobs-dir>/*/*/verifier/reward.json
 
 ## Examples
 
-- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) — Mode A (vero scores gsm8k).
+- [`examples/gsm8k-agent`](../../examples/gsm8k-agent) (Mode A agent, vero scores gsm8k). It ships the agent + vero task but not a `build.yaml` yet; use the Mode A `build.yaml` snippet above to drive it.
 - [`examples/gaia-optimization`](../../examples/gaia-optimization) — Mode B (terminus on
   GAIA via nested Harbor on Modal), with an editable-prompt optimization surface.

--- a/vero/examples/gaia-optimization/build.yaml
+++ b/vero/examples/gaia-optimization/build.yaml
@@ -40,7 +40,16 @@ partition:
 
 splits:
   - { split: train, access: non_viewable }   # optimizer sees aggregate scores only
-  - { split: validation, access: no_access }  # hidden; never reaches the optimizer
+  - { split: validation, access: no_access }  # scores are never returned to the optimizer
+# CAVEAT: `access: no_access` withholds the validation *scores*, not the validation
+# *identity*. Because `agent_repo: .` and this build.yaml is git-tracked, the validation
+# task ids above are seeded into the optimizer's repo (via `git archive HEAD`) and ARE
+# readable by it. That is acceptable here because gaia/gaia is a public benchmark, so the
+# held-out *ids* are not secret; only the per-sample results are. If you adapt this for a
+# benchmark whose held-out *identity* must stay secret, do NOT keep the held-out partition
+# in the git-tracked agent_repo: move build.yaml (or just the held-out `partition`/`splits`
+# entries) outside the agent_repo subtree, add it to .gitignore, or inject the held-out
+# split sidecar-side at build time so it is never archived into /work/agent.
 
 budgets:
   - { split: train, total_run_budget: 3 }      # up to 3 measured evals of the train split


### PR DESCRIPTION
Stacks on **#6** (`harbor-4-docs`). Documentation-accuracy fixes from the review of that PR. 4 of 4 fix PRs.

### What this fixes

| # | Sev | Finding | Fix |
|---|---|---|---|
| D1 | 🟠 | The intro over-claims a hard guarantee ("the optimizer cannot read hidden labels, modify the scorer, or bypass its budget") | Softened to best-effort, OS/process-level language describing what is actually enforced |
| D2 | 🔴 | The GAIA `build.yaml` says the validation split "never reaches the optimizer", but `agent_repo: .` + a git-tracked `build.yaml` seeds the held-out task ids into the optimizer's repo | Corrected: only the *scores* are withheld (fine for a public benchmark), with a caveat + mitigations for secret-identity benchmarks |
| D3 | 🟠 | `gsm8k-agent` is cited as the Mode A example but ships no `build.yaml` | Repointed: `gaia-optimization` is the complete runnable example; `gsm8k-agent` is the Mode A agent reference, paired with the tutorial's Mode A `build.yaml` snippet |
| D4 | 🟠 | The 3-tier visibility section omits the current fail-open default for unlisted splits | Documented the fail-open default + "list every split", and noted it becomes fail-closed once the protocol fix lands |
| D5 | 🟠 | "The scorer is sidecar-only" holds only for Mode B | Split by mode: sidecar-only in Mode B; in Mode A the scorer is in the agent's editable repo until the serve.py fix bakes a sidecar task project |

Prose/yaml only; `build.yaml` still parses. These align the docs with the behavior after the core/sidecar fix PRs (#7, #8) land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Harbor documentation to describe the current integrity limits more accurately. The main changes are:

- Softens architecture wording around leaderboard guarantees.
- Documents fail-open split visibility for unlisted splits.
- Clarifies Mode A versus Mode B scorer isolation.
- Repoints the runnable example guidance toward `gaia-optimization`.
- Adds a GAIA `build.yaml` caveat about held-out task IDs being visible.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Merge is mostly safe after the README wording is aligned with the caveated integrity model documented elsewhere.

The changes are documentation-only and generally improve accuracy, but one prominent README paragraph still preserves an over-strong guarantee that can mislead users about the actual isolation properties.

vero/README.md
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the pre-change gaia-buildyaml-contract state by inspecting trex-artifacts/gaia-buildyaml-contract-01-before.log to verify base checkout, parse success, validation access: 'no\_access', and the old caveat line.
- Reviewed the post-change gaia-buildyaml-contract state by inspecting trex-artifacts/gaia-buildyaml-contract-02-after.log to verify head checkout, parse success, validation access: 'no\_access', extracted caveat lines 44-52, and that all corrected-caveat assertions pass.
- Saved the validation script trex-artifacts/gaia\_buildyaml\_contract\_check.py that implements the checks used to verify the gaia build.yaml contract results.

<a href="https://app.greptile.com/trex/runs/12757578/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vero/README.md`, line 530 ([link](https://github.com/scaleapi/vero/blob/3ec89f46ba508f2b67ff24b9ab47a3c3b4d955fc/vero/README.md#L530)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale integrity guarantee** This README paragraph still gives the hard guarantee this PR is trying to remove: it says the optimizer can't read hidden labels, modify the scorer, or bypass its budget. The updated architecture docs now describe best-effort process-level limits, Mode A scorer exposure through `agent_repo` and `read_only_paths`, fail-open unlisted splits, and the GAIA identity caveat. A user who reads only the README can still rely on guarantees the implementation does not provide, so this paragraph should be softened or pointed at the caveated integrity model.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vero/README.md
   Line: 530

   Comment:
   **Stale integrity guarantee** This README paragraph still gives the hard guarantee this PR is trying to remove: it says the optimizer can't read hidden labels, modify the scorer, or bypass its budget. The updated architecture docs now describe best-effort process-level limits, Mode A scorer exposure through `agent_repo` and `read_only_paths`, fail-open unlisted splits, and the GAIA identity caveat. A user who reads only the README can still rely on guarantees the implementation does not provide, so this paragraph should be softened or pointed at the caveated integrity model.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2FREADME.md%0ALine%3A%20530%0A%0AComment%3A%0A**Stale%20integrity%20guarantee**%20This%20README%20paragraph%20still%20gives%20the%20hard%20guarantee%20this%20PR%20is%20trying%20to%20remove%3A%20it%20says%20the%20optimizer%20can't%20read%20hidden%20labels%2C%20modify%20the%20scorer%2C%20or%20bypass%20its%20budget.%20The%20updated%20architecture%20docs%20now%20describe%20best-effort%20process-level%20limits%2C%20Mode%20A%20scorer%20exposure%20through%20%60agent_repo%60%20and%20%60read_only_paths%60%2C%20fail-open%20unlisted%20splits%2C%20and%20the%20GAIA%20identity%20caveat.%20A%20user%20who%20reads%20only%20the%20README%20can%20still%20rely%20on%20guarantees%20the%20implementation%20does%20not%20provide%2C%20so%20this%20paragraph%20should%20be%20softened%20or%20pointed%20at%20the%20caveated%20integrity%20model.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=10&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2FREADME.md%0ALine%3A%20530%0A%0AComment%3A%0A**Stale%20integrity%20guarantee**%20This%20README%20paragraph%20still%20gives%20the%20hard%20guarantee%20this%20PR%20is%20trying%20to%20remove%3A%20it%20says%20the%20optimizer%20can't%20read%20hidden%20labels%2C%20modify%20the%20scorer%2C%20or%20bypass%20its%20budget.%20The%20updated%20architecture%20docs%20now%20describe%20best-effort%20process-level%20limits%2C%20Mode%20A%20scorer%20exposure%20through%20%60agent_repo%60%20and%20%60read_only_paths%60%2C%20fail-open%20unlisted%20splits%2C%20and%20the%20GAIA%20identity%20caveat.%20A%20user%20who%20reads%20only%20the%20README%20can%20still%20rely%20on%20guarantees%20the%20implementation%20does%20not%20provide%2C%20so%20this%20paragraph%20should%20be%20softened%20or%20pointed%20at%20the%20caveated%20integrity%20model.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fvero&pr=10&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-4-docs-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-4-docs-fixes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2FREADME.md%0ALine%3A%20530%0A%0AComment%3A%0A**Stale%20integrity%20guarantee**%20This%20README%20paragraph%20still%20gives%20the%20hard%20guarantee%20this%20PR%20is%20trying%20to%20remove%3A%20it%20says%20the%20optimizer%20can't%20read%20hidden%20labels%2C%20modify%20the%20scorer%2C%20or%20bypass%20its%20budget.%20The%20updated%20architecture%20docs%20now%20describe%20best-effort%20process-level%20limits%2C%20Mode%20A%20scorer%20exposure%20through%20%60agent_repo%60%20and%20%60read_only_paths%60%2C%20fail-open%20unlisted%20splits%2C%20and%20the%20GAIA%20identity%20caveat.%20A%20user%20who%20reads%20only%20the%20README%20can%20still%20rely%20on%20guarantees%20the%20implementation%20does%20not%20provide%2C%20so%20this%20paragraph%20should%20be%20softened%20or%20pointed%20at%20the%20caveated%20integrity%20model.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fvero&pr=10&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2FREADME.md%3A530%0A**Stale%20integrity%20guarantee**%20This%20README%20paragraph%20still%20gives%20the%20hard%20guarantee%20this%20PR%20is%20trying%20to%20remove%3A%20it%20says%20the%20optimizer%20can't%20read%20hidden%20labels%2C%20modify%20the%20scorer%2C%20or%20bypass%20its%20budget.%20The%20updated%20architecture%20docs%20now%20describe%20best-effort%20process-level%20limits%2C%20Mode%20A%20scorer%20exposure%20through%20%60agent_repo%60%20and%20%60read_only_paths%60%2C%20fail-open%20unlisted%20splits%2C%20and%20the%20GAIA%20identity%20caveat.%20A%20user%20who%20reads%20only%20the%20README%20can%20still%20rely%20on%20guarantees%20the%20implementation%20does%20not%20provide%2C%20so%20this%20paragraph%20should%20be%20softened%20or%20pointed%20at%20the%20caveated%20integrity%20model.%0A%0A&pr=10&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2FREADME.md%3A530%0A**Stale%20integrity%20guarantee**%20This%20README%20paragraph%20still%20gives%20the%20hard%20guarantee%20this%20PR%20is%20trying%20to%20remove%3A%20it%20says%20the%20optimizer%20can't%20read%20hidden%20labels%2C%20modify%20the%20scorer%2C%20or%20bypass%20its%20budget.%20The%20updated%20architecture%20docs%20now%20describe%20best-effort%20process-level%20limits%2C%20Mode%20A%20scorer%20exposure%20through%20%60agent_repo%60%20and%20%60read_only_paths%60%2C%20fail-open%20unlisted%20splits%2C%20and%20the%20GAIA%20identity%20caveat.%20A%20user%20who%20reads%20only%20the%20README%20can%20still%20rely%20on%20guarantees%20the%20implementation%20does%20not%20provide%2C%20so%20this%20paragraph%20should%20be%20softened%20or%20pointed%20at%20the%20caveated%20integrity%20model.%0A%0A&repo=scaleapi%2Fvero&pr=10&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-4-docs-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-4-docs-fixes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2FREADME.md%3A530%0A**Stale%20integrity%20guarantee**%20This%20README%20paragraph%20still%20gives%20the%20hard%20guarantee%20this%20PR%20is%20trying%20to%20remove%3A%20it%20says%20the%20optimizer%20can't%20read%20hidden%20labels%2C%20modify%20the%20scorer%2C%20or%20bypass%20its%20budget.%20The%20updated%20architecture%20docs%20now%20describe%20best-effort%20process-level%20limits%2C%20Mode%20A%20scorer%20exposure%20through%20%60agent_repo%60%20and%20%60read_only_paths%60%2C%20fail-open%20unlisted%20splits%2C%20and%20the%20GAIA%20identity%20caveat.%20A%20user%20who%20reads%20only%20the%20README%20can%20still%20rely%20on%20guarantees%20the%20implementation%20does%20not%20provide%2C%20so%20this%20paragraph%20should%20be%20softened%20or%20pointed%20at%20the%20caveated%20integrity%20model.%0A%0A&repo=scaleapi%2Fvero&pr=10&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vero/README.md:530
**Stale integrity guarantee** This README paragraph still gives the hard guarantee this PR is trying to remove: it says the optimizer can't read hidden labels, modify the scorer, or bypass its budget. The updated architecture docs now describe best-effort process-level limits, Mode A scorer exposure through `agent_repo` and `read_only_paths`, fail-open unlisted splits, and the GAIA identity caveat. A user who reads only the README can still rely on guarantees the implementation does not provide, so this paragraph should be softened or pointed at the caveated integrity model.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(harbor): honest integrity guarantee..."](https://github.com/scaleapi/vero/commit/3ec89f46ba508f2b67ff24b9ab47a3c3b4d955fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40777635)</sub>

<!-- /greptile_comment -->