### PR TITLE
fix(harbor): floor rewards on no-candidate outcome instead of erroring

### DIFF
--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -67,8 +67,27 @@ class Verifier:
         self.rescore_top_k = rescore_top_k
 
     async def finalize(self) -> dict[str, float]:
-        """Select the commit and score it on every target -> {reward_key: score}."""
-        sha = await self._select_commit()
+        """Select the commit and score it on every target -> {reward_key: score}.
+
+        A run in which the optimizer produced no scorable candidate (never
+        submitted in ``submit`` mode; no non-baseline experiments on the
+        selection split in ``auto_best`` mode) is a legitimate *outcome* of an
+        optimization run, not an infrastructure failure: every target is
+        floored at ``default_minimum_score`` so the outer harness records a
+        reward of 0.0 instead of a missing-reward exception. Infrastructure
+        problems (e.g. a missing experiment database) still raise.
+        """
+        try:
+            sha = await self._select_commit()
+        except NoCandidateError as exc:
+            logger.warning(
+                "No candidate commit to finalize (%s); flooring all %d target(s) "
+                "at %s.",
+                exc,
+                len(self.targets),
+                default_minimum_score,
+            )
+            return {t.reward_key: float(default_minimum_score) for t in self.targets}
         logger.info(f"Verifier selected commit {sha} (mode={self.reward_mode})")
         rewards: dict[str, float] = {}
         for target in self.targets:
@@ -112,7 +131,9 @@ class Verifier:
         its recorded score cannot win unless the admin scorer agrees.
         """
         if self.engine.db is None:
-            raise NoCandidateError("auto_best mode but no experiment database.")
+            # Misconfiguration, not an agent outcome: surface as a hard error so
+            # a broken sidecar doesn't silently zero every trial.
+            raise RuntimeError("auto_best mode but no experiment database.")
         df = self.engine.db.get_experiments_df(fill_score=default_minimum_score)
         if df.empty or "dataset_subset_split" not in df.columns:
             raise NoCandidateError("auto_best mode but no experiments recorded.")

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -34,15 +34,23 @@ class TestSubmitSelection:
         assert engine.evaluate_admin.await_args.kwargs["split"] == "test"
 
     @pytest.mark.asyncio
-    async def test_finalize_submit_no_submission_raises(self, tmp_path):
+    async def test_finalize_submit_no_submission_floors_rewards(self, tmp_path):
+        # "The agent never submitted" is an outcome, not an infrastructure
+        # failure: finalize floors every target instead of raising, so the
+        # outer harness records reward 0.0 rather than a missing-reward error.
+        engine = _engine([])
         v = Verifier(
-            engine=_engine([]),
+            engine=engine,
             admin_volume=tmp_path,
             reward_mode="submit",
-            targets=[VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward")],
+            targets=[
+                VerificationTarget(task="t", dataset_id="ds1", split="test", reward_key="reward"),
+                VerificationTarget(task="t2", dataset_id="ds2", split="test", reward_key="held_out"),
+            ],
         )
-        with pytest.raises(NoCandidateError):
-            await v.finalize()
+        rewards = await v.finalize()
+        assert rewards == {"reward": 0.0, "held_out": 0.0}
+        engine.evaluate_admin.assert_not_awaited()
 
 
 class TestMultiTarget:
@@ -132,4 +140,102 @@ class TestAutoBestSelection:
         # baseline 'base' was never re-scored; 'agent' is selected + target-scored
         rescored_commits = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
         assert "base" not in rescored_commits
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"
+
+
+class TestNoCandidateFallback:
+    """finalize() floors rewards when the optimizer produced no candidate.
+
+    Found live: with a small budget, an optimizer that spends every eval on
+    the seeded baseline leaves an empty candidate pool (the baseline is
+    excluded from auto_best selection), and finalize used to 409 -> the outer
+    Harbor trial died with RewardFileNotFoundError instead of scoring 0.0.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_best_baseline_only_floors_rewards(self, tmp_path):
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = pd.DataFrame(
+            {
+                "dataset_subset_split": ["train", "train"],
+                "dataset_subset_dataset_id": ["ds1", "ds1"],
+                "candidate_commit": ["base", "base"],
+                "mean_score": [0.0, 0.2],
+                "candidate_created_at": [1, 2],
+            }
+        )
+        engine.evaluate_admin = AsyncMock()
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            base_commit="base",
+            targets=[VerificationTarget(task=None, dataset_id="ds1", split="validation", reward_key="accuracy")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.0}
+        # no candidate -> nothing re-scored, no target eval spent
+        engine.evaluate_admin.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_best_no_experiments_floors_rewards(self, tmp_path):
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = pd.DataFrame()
+        engine.evaluate_admin = AsyncMock()
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            targets=[VerificationTarget(task=None, dataset_id="ds1", split="validation", reward_key="accuracy")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.0}
+        engine.evaluate_admin.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_best_missing_db_still_raises(self, tmp_path):
+        # A missing experiment DB is sidecar misconfiguration, not an agent
+        # outcome: it must surface as an error, not silently zero the trial.
+        engine = MagicMock()
+        engine.db = None
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            targets=[VerificationTarget(task=None, dataset_id="ds1", split="validation", reward_key="accuracy")],
+        )
+        with pytest.raises(RuntimeError, match="no experiment database"):
+            await v.finalize()
+
+    @pytest.mark.asyncio
+    async def test_candidates_present_keeps_normal_selection(self, tmp_path):
+        # Regression guard: the fallback must not swallow the normal path.
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = pd.DataFrame(
+            {
+                "dataset_subset_split": ["train", "train"],
+                "dataset_subset_dataset_id": ["ds1", "ds1"],
+                "candidate_commit": ["base", "agent"],
+                "mean_score": [0.9, 0.1],
+                "candidate_created_at": [1, 2],
+            }
+        )
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=0.5)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            base_commit="base",
+            targets=[VerificationTarget(task=None, dataset_id="ds1", split="validation", reward_key="accuracy")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.5}
         assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"


### PR DESCRIPTION
Stacked on #8 (`harbor-2-sidecar-fixes`). Implements the fix proposed in [the live-run finding on #4](https://github.com/scaleapi/vero/pull/4#issuecomment-4864279604).

## Problem (found empirically, not in review)

In a live Mode B smoke run of `examples/gaia-optimization` (outer claude-code trial, nested Modal evals), the optimizer spent its whole `total_run_budget: 1` on evaluating the **seeded baseline commit** ("measure the baseline first" is a natural agent strategy). `auto_best` selection excludes `base_commit` from the candidate pool, so `finalize` returned:

```
409 {"error":"auto_best mode but no candidate experiments on split 'train'."}
```

and the outer Harbor trial died with `RewardFileNotFoundError`: an **exception**, not a score. Harness-level aggregation counts these trials as errors rather than zeros, and with small budgets a perfectly reasonable agent walks into it.

## Fix

"The optimizer produced no scorable candidate" is a legitimate *outcome* of an optimization run, and its honest value is the floor score:

- `Verifier.finalize()` now catches `NoCandidateError` and writes `{reward_key: default_minimum_score}` (0.0) for every configured target, with a warning log. Applies to both `auto_best` (no non-baseline experiments on the selection split) and `submit` (agent never submitted).
- A missing experiment **database** is reclassified from `NoCandidateError` to `RuntimeError`: that is sidecar misconfiguration, and it must surface as an error rather than silently zeroing every trial. This is the deliberate line between agent outcomes (floor) and infra failures (raise).
- The `base_commit` exclusion itself is unchanged; it correctly stops "do nothing" from winning selection.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| auto_best, only baseline evaluated | 409 -> `RewardFileNotFoundError` (trial errors) | `reward.json` with 0.0 per target |
| auto_best, no experiments at all | 409 -> trial errors | `reward.json` with 0.0 per target |
| submit mode, never submitted | 409 -> trial errors | `reward.json` with 0.0 per target |
| experiment DB missing | 409 -> trial errors | `RuntimeError` (500; loud infra failure) |
| candidates exist | normal selection | unchanged |

## Tests

`tests/test_harbor_verifier.py`: baseline-only pool floors, empty experiment table floors, submit-no-submission floors (multi-target), missing DB still raises, candidates-present regression guard. 19 pass.

A follow-up (separate, compiler-side) adds an instruction-template warning that baseline evals consume budget without creating candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes `finalize()` to treat "no scorable candidate" as a legitimate run outcome rather than a hard error: when `_select_commit` raises `NoCandidateError`, every configured target is now written to `reward.json` at `default_minimum_score` (0.0) with a warning, preventing the outer Harbor harness from counting the trial as an error.

- `Verifier.finalize()` wraps `_select_commit` in a `try/except NoCandidateError` block and returns a floor-score dict, with no downstream admin scoring triggered.
- A missing experiment database is reclassified from `NoCandidateError` to `RuntimeError` so broken-sidecar misconfiguration still surfaces as a loud error rather than silently zeroing trials.
- Five new tests cover baseline-only pool, empty DB, missing DB (must raise), submit-no-submission (multi-target), and a regression guard that the normal candidate path is unaffected.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic change is narrow and well-tested, with the only open item being a trivial unused import in the test file.

The verifier change is well-scoped: the except NoCandidateError block is correctly typed (it does not accidentally swallow the new RuntimeError path because NoCandidateError is a subclass, not the parent), the floor-score dict comprehension is straightforward, and all five new test scenarios validate the intended boundary. The one minor gap is the leftover NoCandidateError import in the test file.

The unused NoCandidateError import in vero/tests/test_harbor_verifier.py is the only item worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/verifier.py | finalize() now catches NoCandidateError and returns floor rewards; missing-DB branch correctly reclassified to RuntimeError so it bypasses the catch and propagates as an infra error |
| vero/tests/test_harbor_verifier.py | Good coverage of all new paths; NoCandidateError is now an unused import since the one test that asserted on it was replaced |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[finalize called] --> B[_select_commit]
    B --> C{reward_mode}
    C -->|submit| D[_submitted_commit]
    C -->|auto_best| E[_best_from_db]
    D -->|submission.json missing or no commit| F[raise NoCandidateError]
    D -->|commit found| G[sha]
    E -->|engine.db is None| H[raise RuntimeError - sidecar misconfiguration]
    E -->|df empty or missing column| F
    E -->|all rows are base_commit| F
    E -->|candidates found| I[admin re-score shortlist]
    I --> G
    F --> J[catch NoCandidateError in finalize]
    J --> K[log warning - return floor scores for all targets]
    H --> L[propagates uncaught outside finalize]
    G --> M[evaluate_admin per target]
    M --> N[return reward dict]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[finalize called] --> B[_select_commit]
    B --> C{reward_mode}
    C -->|submit| D[_submitted_commit]
    C -->|auto_best| E[_best_from_db]
    D -->|submission.json missing or no commit| F[raise NoCandidateError]
    D -->|commit found| G[sha]
    E -->|engine.db is None| H[raise RuntimeError - sidecar misconfiguration]
    E -->|df empty or missing column| F
    E -->|all rows are base_commit| F
    E -->|candidates found| I[admin re-score shortlist]
    I --> G
    F --> J[catch NoCandidateError in finalize]
    J --> K[log warning - return floor scores for all targets]
    H --> L[propagates uncaught outside finalize]
    G --> M[evaluate_admin per target]
    M --> N[return reward dict]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2Ftests%2Ftest_harbor_verifier.py%3A9%0A%60NoCandidateError%60%20is%20imported%20but%20unused%20after%20the%20old%20%60pytest.raises%28NoCandidateError%29%60%20test%20was%20replaced.%0A%0A%60%60%60suggestion%0Afrom%20vero.harbor.verifier%20import%20VerificationTarget%2C%20Verifier%0A%60%60%60%0A%0A&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2Ftests%2Ftest_harbor_verifier.py%3A9%0A%60NoCandidateError%60%20is%20imported%20but%20unused%20after%20the%20old%20%60pytest.raises%28NoCandidateError%29%60%20test%20was%20replaced.%0A%0A%60%60%60suggestion%0Afrom%20vero.harbor.verifier%20import%20VerificationTarget%2C%20Verifier%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-2-sidecar-autobest-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-2-sidecar-autobest-fallback%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2Ftests%2Ftest_harbor_verifier.py%3A9%0A%60NoCandidateError%60%20is%20imported%20but%20unused%20after%20the%20old%20%60pytest.raises%28NoCandidateError%29%60%20test%20was%20replaced.%0A%0A%60%60%60suggestion%0Afrom%20vero.harbor.verifier%20import%20VerificationTarget%2C%20Verifier%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vero/tests/test_harbor_verifier.py:9
`NoCandidateError` is imported but unused after the old `pytest.raises(NoCandidateError)` test was replaced.

```suggestion
from vero.harbor.verifier import VerificationTarget, Verifier
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(harbor): floor rewards on no-candida..."](https://github.com/scaleapi/vero/commit/347264727d8f5010db7c8db8e3fc6c957ad888d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41336357)</sub>

<!-- /greptile_comment -->