### PR TITLE
docs(harbor): warn in the task instruction that baseline evals create no candidate

### DIFF
--- a/vero/src/vero/harbor/build/templates/instruction.md.j2
+++ b/vero/src/vero/harbor/build/templates/instruction.md.j2
@@ -18,7 +18,10 @@ progress on the splits you *are* allowed to evaluate, within a fixed budget.
 4. Check budget / which splits are evaluable anytime: `vero harbor status`.
 {% if submit_enabled %}5. When done, nominate your best commit: `vero harbor submit`.{% else %}
 The best commit you evaluate on `{{ selection_split }}` is selected automatically and
-scored on the hidden test split at the end.{% endif %}
+scored on the hidden test split at the end. Only commits *other than the seeded
+baseline* are selectable: evaluating the unmodified baseline spends budget without
+creating a candidate, so make sure at least one eval is of a commit that contains
+your changes.{% endif %}
 
 ## Rules
 

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -167,3 +167,12 @@ def test_seed_documents_advisory_read_only(built):
     seed = (built / "environment/main/seed.sh").read_text()
     assert "ADVISORY ONLY" in seed
     assert "sidecar-side" in seed
+
+
+def test_instruction_warns_baseline_not_selectable(built):
+    # auto_best: the agent must be told baseline evals do not create candidates
+    # (found live: an optimizer that spent its whole budget measuring the
+    # baseline died with "no candidate experiments" at finalize).
+    text = (built / "instruction.md").read_text()
+    assert "other than the seeded" in text
+    assert "spends budget without" in text

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -176,3 +176,23 @@ def test_instruction_warns_baseline_not_selectable(built):
     text = (built / "instruction.md").read_text()
     assert "other than the seeded" in text
     assert "spends budget without" in text
+
+
+def test_submit_mode_instruction_has_no_baseline_warning(tmp_path, monkeypatch):
+    # The warning belongs to the auto_best branch only; pin the conditional
+    # boundary so a template refactor cannot leak it into submit-mode tasks.
+    monkeypatch.setenv("VERO_SKIP_SECRET_CHECK", "1")
+    config = BuildConfig(
+        name="vero/gsm8k-opt",
+        agent_repo=str(_agent_repo(tmp_path)),
+        mode="A",
+        task="gsm8k",
+        dataset=str(_dataset(tmp_path)),
+        splits=[{"split": "validation", "access": "non_viewable"}],
+        reward_mode="submit",
+        submit_enabled=True,
+    )
+    out = compile_task(config, tmp_path / "task", vero_root=_stub_vero(tmp_path))
+    text = (out / "instruction.md").read_text()
+    assert "other than the seeded" not in text
+    assert "spends budget without" not in text


### PR DESCRIPTION
Stacked on #9 (`harbor-3-compiler-fixes`). Companion to #11: the generated `instruction.md` (auto_best branch) now warns the optimizer that only commits other than the seeded baseline are selectable, and that evaluating the unmodified baseline spends budget without creating a candidate.

Found in the same live Mode B smoke run as #11: the optimizer spent its whole budget measuring the baseline and walked blind into finalize's empty candidate pool. #11 makes that outcome score 0.0 instead of erroring; this PR makes the agent unlikely to hit it at all.

One rendered-content test added (`test_instruction_warns_baseline_not_selectable`). 9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a runtime warning to the `auto_best` branch of the Harbor task instruction template, telling optimizers that evaluating the unmodified baseline commit spends budget without creating a selectable candidate. It was motivated by a live smoke-run failure where an optimizer exhausted its entire budget on the baseline and then hit an empty candidate pool at finalize.

- **Template change** (`instruction.md.j2`): Appends three sentences to the `{% else %}` (auto_best) block explaining the baseline-exclusion rule and urging the optimizer to include at least one eval of a modified commit.
- **Test coverage** (`test_harbor_build.py`): Adds both a positive assertion (warning text present in auto_best output) and a negative assertion (warning text absent in submit-mode output), directly closing the gap flagged in the previous review thread about the missing conditional-boundary test.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive text in a documentation template and two focused tests with no logic side-effects.

The template edit is confined to the {% else %} (auto_best) branch and does not touch any control-flow code. Both the positive and negative test cases pass, and the new negative test explicitly guards the conditional boundary that was missing in the previous iteration of this PR.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/templates/instruction.md.j2 | Adds baseline-exclusion warning to the auto_best ({% else %}) branch of the instruction template; the warning correctly does not appear in the submit_enabled branch. |
| vero/tests/test_harbor_build.py | Adds two tests: one positive (auto_best warning is present) and one negative (submit mode has no warning), pinning the conditional boundary against future template regressions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[instruction.md.j2 rendered] --> B{submit_enabled?}
    B -- Yes --> C["Step 5: nominate best commit\n(vero harbor submit)"]
    B -- No/auto_best --> D["Best commit on selection_split\nselected automatically"]
    D --> E["⚠️ WARNING: Only commits\nother than seeded baseline\nare selectable"]
    E --> F["Evaluating unmodified baseline\nspends budget without creating\na candidate"]
    F --> G["Make sure ≥1 eval is of\na commit with your changes"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[instruction.md.j2 rendered] --> B{submit_enabled?}
    B -- Yes --> C["Step 5: nominate best commit\n(vero harbor submit)"]
    B -- No/auto_best --> D["Best commit on selection_split\nselected automatically"]
    D --> E["⚠️ WARNING: Only commits\nother than seeded baseline\nare selectable"]
    E --> F["Evaluating unmodified baseline\nspends budget without creating\na candidate"]
    F --> G["Make sure ≥1 eval is of\na commit with your changes"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(harbor): pin the baseline warning t..."](https://github.com/scaleapi/vero/commit/f03508229ff3b9985bb60ed2da8b3b340177a71d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41336611)</sub>

<!-- /greptile_comment -->