### PR TITLE
fix(harbor): allow viewable splits to carry budgets

### DIFF
--- a/vero/src/vero/policy.py
+++ b/vero/src/vero/policy.py
@@ -532,10 +532,13 @@ class Policy:
 
     def _validate_budget_splits(self) -> None:
         """Warn if any budget splits do not exist in the dataset, and verify
-        that every agent-budgeted split is tiered ``non_viewable``.
+        that every agent-budgeted split is agent-evaluable.
 
-        ``viewable`` would leak per-sample labels to the agent; ``no_access``
-        would make the budget unusable. Both are misconfigurations and raise.
+        ``no_access`` would make the budget unusable and raises. ``viewable``
+        is allowed: a budget meters *compute* (each eval can be a real, paid
+        benchmark run), which is orthogonal to result visibility; it does mean
+        per-sample results reach the agent, so it is logged loudly rather than
+        rejected.
         """
         if not self.budget:
             return
@@ -558,12 +561,19 @@ class Policy:
                 pass
 
             tier = resolve_split_access(b.split, self.split_accesses)
-            if tier != SplitAccessLevel.non_viewable:
+            if tier == SplitAccessLevel.no_access:
                 raise ValueError(
-                    f"Agent-budgeted split '{b.split}' is tiered '{tier}', but a "
-                    f"budgeted split must be 'non_viewable' (agent-evaluable with "
-                    f"per-sample labels hidden). 'viewable' would leak labels and "
-                    f"'no_access' would make the budget unusable."
+                    f"Agent-budgeted split '{b.split}' is tiered 'no_access', "
+                    f"which makes the budget unusable (the engine rejects agent "
+                    f"evals of no_access splits). Tier it 'non_viewable' or "
+                    f"'viewable', or drop the budget."
+                )
+            if tier == SplitAccessLevel.viewable:
+                logger.warning(
+                    f"Agent-budgeted split '{b.split}' is tiered 'viewable': the "
+                    f"budget meters eval compute, but per-sample results are "
+                    f"fully visible to the agent. Use 'non_viewable' if labels "
+                    f"must stay hidden."
                 )
 
     def _maybe_make_db(self) -> ExperimentDatabase:

--- a/vero/tests/test_policy_budget_splits.py
+++ b/vero/tests/test_policy_budget_splits.py
@@ -44,13 +44,18 @@ def test_ensure_then_validate_passes_for_train_budget_default():
     p._validate_budget_splits()  # no raise
 
 
-def test_validate_rejects_explicit_viewable_budgeted_split():
+def test_validate_allows_explicit_viewable_budgeted_split(caplog):
+    # A budget meters *compute* (each eval can be a paid benchmark run), which
+    # is orthogonal to result visibility: viewable + budget is legitimate
+    # (e.g. a classic ML train split with per-task feedback). It warns loudly
+    # instead of raising.
     p = _policy(
         [SplitAccess.viewable("dev")],
         [SplitBudget(split="dev", dataset_id="ds1", total_sample_budget=10)],
     )
-    with pytest.raises(ValueError, match="non_viewable"):
-        p._validate_budget_splits()
+    with caplog.at_level("WARNING"):
+        p._validate_budget_splits()  # no raise
+    assert any("viewable" in r.message for r in caplog.records)
 
 
 def test_validate_rejects_explicit_no_access_budgeted_split():
@@ -58,7 +63,7 @@ def test_validate_rejects_explicit_no_access_budgeted_split():
         [SplitAccess.no_access("dev")],
         [SplitBudget(split="dev", dataset_id="ds1", total_sample_budget=10)],
     )
-    with pytest.raises(ValueError, match="non_viewable"):
+    with pytest.raises(ValueError, match="no_access"):
         p._validate_budget_splits()
 
 


### PR DESCRIPTION
Stacked on #7. Driven by a live experiment, not review: a GAIA prompt-optimization run needed a budgeted **and** viewable train split (per-task feedback; aggregate-only signal over 6 single-rollout tasks was too noisy for the optimizer to climb: trajectory 0.5 -> 0.33 -> 0.33, gave up with 7/10 budget unspent).

The old check conflated two orthogonal axes:
- **Information**: what the agent sees per eval (the access tier's job)
- **Compute**: how many paid evals the agent may run (the budget's job)

In Mode B each eval is a real nested benchmark run costing real money, so metering a fully-visible split is legitimate and often the correct experimental design (classic ML train visibility, bounded spend).

Changes: `no_access` + budget still raises (unusable budget = config bug). `viewable` + budget now **warns loudly** instead of raising. Auto-tiering of *unlisted* budgeted splits to `non_viewable` is unchanged, so the safe default stands; only an explicit author choice unlocks viewable.

Tests updated + new warning assertion. 12 policy/engine tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes the budget/split-access validation in `Policy._validate_budget_splits` so that a `viewable` split can carry a budget (logs a loud warning) while a `no_access`+budget combination still raises. The `_ensure_budgeted_splits_tiered` auto-tiering behaviour is unchanged — unlisted splits still default to `non_viewable`.

- **`policy.py`**: The single `if tier != non_viewable: raise` guard is replaced by two targeted checks — `no_access` raises, `viewable` warns — so `non_viewable` remains the silent/safe path and `viewable` is an explicit, loudly-flagged opt-in.
- **`test_policy_budget_splits.py`**: The former `pytest.raises(ValueError)` test is flipped to assert no exception plus a warning emission; the `no_access` rejection test is updated to match the new error message.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the logic change is narrow, well-tested, and the engine's no_access guard is unchanged.

The two changed files are small and self-contained. The new two-branch check correctly maps all three SplitAccessLevel values, the auto-tiering default is untouched, and the existing test suite covers the key scenarios. The only things worth a second look are the stale first sentence in _ensure_budgeted_splits_tiered's docstring and the missing logger argument in caplog.at_level — neither affects runtime behaviour.

The _ensure_budgeted_splits_tiered docstring in policy.py now contradicts the new policy; minor but worth updating before the code drifts further.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/policy.py | Logic in `_validate_budget_splits` correctly relaxed to allow `viewable`+budget (warn) while keeping `no_access`+budget as a hard error; `_ensure_budgeted_splits_tiered` docstring is now slightly stale |
| vero/tests/test_policy_budget_splits.py | Test correctly flipped from `pytest.raises` to a warning assertion; `caplog.at_level` would be more robust with a logger name |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_validate_budget_splits called] --> B{budget empty?}
    B -- yes --> Z[return]
    B -- no --> C[resolve split tier]
    C --> D{tier == no_access?}
    D -- yes --> E[raise ValueError 'budget unusable']
    D -- no --> F{tier == viewable?}
    F -- yes --> G[logger.warning 'labels visible to agent']
    F -- no --> H[non_viewable silent]
    G --> I[continue loop]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[_validate_budget_splits called] --> B{budget empty?}
    B -- yes --> Z[return]
    B -- no --> C[resolve split tier]
    C --> D{tier == no_access?}
    D -- yes --> E[raise ValueError 'budget unusable']
    D -- no --> F{tier == viewable?}
    F -- yes --> G[logger.warning 'labels visible to agent']
    F -- no --> H[non_viewable silent]
    G --> I[continue loop]
    H --> I
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Avero%2Fsrc%2Fvero%2Fpolicy.py%3A512-518%0AThe%20%60_ensure_budgeted_splits_tiered%60%20docstring%20still%20says%20a%20budgeted%20split%20%22must%20be%20agent-evaluable%20with%20per-sample%20labels%20hidden%2C%20i.e.%20%60non_viewable%60%22%2C%20but%20after%20this%20PR%20%60viewable%60%20is%20also%20permitted%20%28with%20a%20warning%29.%20The%20first%20sentence%20now%20contradicts%20the%20new%20policy%20and%20could%20mislead%20a%20future%20reader%20into%20thinking%20the%20auto-tiering%20logic%20should%20also%20gate%20out%20%60viewable%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20A%20budgeted%20split%20is%20one%20the%20agent%20may%20evaluate%2C%20so%20it%20must%20be%0A%20%20%20%20%20%20%20%20agent-evaluable%20%28%60%60non_viewable%60%60%20or%20%60%60viewable%60%60%3B%20%60%60no_access%60%60%20is%0A%20%20%20%20%20%20%20%20rejected%20by%20the%20engine%29.%20Any%20budgeted%20split%20missing%20from%0A%20%20%20%20%20%20%20%20%60%60split_accesses%60%60%20is%20auto-tiered%20%60%60non_viewable%60%60%20here%2C%20so%20a%20budget%0A%20%20%20%20%20%20%20%20is%20never%20silently%20unusable%20%28%60%60no_access%60%60%20by%20omission%29%20nor%20accidentally%0A%20%20%20%20%20%20%20%20fully%20visible%20%28%60%60viewable%60%60%20by%20omission%29.%20Explicit%20author%20tiers%20are%0A%20%20%20%20%20%20%20%20left%20untouched%20and%20checked%20in%20%3Ameth%3A%60_validate_budget_splits%60.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Avero%2Ftests%2Ftest_policy_budget_splits.py%3A56-58%0A%60caplog.at_level%28%22WARNING%22%29%60%20without%20a%20%60logger%60%20argument%20sets%20the%20level%20on%20the%20root%20logger%20but%20does%20not%20guarantee%20the%20%60vero.policy%60%20named%20logger%20emits%20at%20WARNING%20if%20it%20ever%20receives%20an%20explicit%20level%20configuration.%20Passing%20the%20logger%20name%20makes%20the%20test%20self-sufficient%20regardless%20of%20external%20log-level%20wiring.%0A%0A%60%60%60suggestion%0A%20%20%20%20with%20caplog.at_level%28%22WARNING%22%2C%20logger%3D%22vero.policy%22%29%3A%0A%20%20%20%20%20%20%20%20p._validate_budget_splits%28%29%20%20%23%20no%20raise%0A%20%20%20%20assert%20any%28%22viewable%22%20in%20r.message%20for%20r%20in%20caplog.records%29%0A%60%60%60%0A%0A&pr=13&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=5"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=5"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=5"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Avero%2Fsrc%2Fvero%2Fpolicy.py%3A512-518%0AThe%20%60_ensure_budgeted_splits_tiered%60%20docstring%20still%20says%20a%20budgeted%20split%20%22must%20be%20agent-evaluable%20with%20per-sample%20labels%20hidden%2C%20i.e.%20%60non_viewable%60%22%2C%20but%20after%20this%20PR%20%60viewable%60%20is%20also%20permitted%20%28with%20a%20warning%29.%20The%20first%20sentence%20now%20contradicts%20the%20new%20policy%20and%20could%20mislead%20a%20future%20reader%20into%20thinking%20the%20auto-tiering%20logic%20should%20also%20gate%20out%20%60viewable%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20A%20budgeted%20split%20is%20one%20the%20agent%20may%20evaluate%2C%20so%20it%20must%20be%0A%20%20%20%20%20%20%20%20agent-evaluable%20%28%60%60non_viewable%60%60%20or%20%60%60viewable%60%60%3B%20%60%60no_access%60%60%20is%0A%20%20%20%20%20%20%20%20rejected%20by%20the%20engine%29.%20Any%20budgeted%20split%20missing%20from%0A%20%20%20%20%20%20%20%20%60%60split_accesses%60%60%20is%20auto-tiered%20%60%60non_viewable%60%60%20here%2C%20so%20a%20budget%0A%20%20%20%20%20%20%20%20is%20never%20silently%20unusable%20%28%60%60no_access%60%60%20by%20omission%29%20nor%20accidentally%0A%20%20%20%20%20%20%20%20fully%20visible%20%28%60%60viewable%60%60%20by%20omission%29.%20Explicit%20author%20tiers%20are%0A%20%20%20%20%20%20%20%20left%20untouched%20and%20checked%20in%20%3Ameth%3A%60_validate_budget_splits%60.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Avero%2Ftests%2Ftest_policy_budget_splits.py%3A56-58%0A%60caplog.at_level%28%22WARNING%22%29%60%20without%20a%20%60logger%60%20argument%20sets%20the%20level%20on%20the%20root%20logger%20but%20does%20not%20guarantee%20the%20%60vero.policy%60%20named%20logger%20emits%20at%20WARNING%20if%20it%20ever%20receives%20an%20explicit%20level%20configuration.%20Passing%20the%20logger%20name%20makes%20the%20test%20self-sufficient%20regardless%20of%20external%20log-level%20wiring.%0A%0A%60%60%60suggestion%0A%20%20%20%20with%20caplog.at_level%28%22WARNING%22%2C%20logger%3D%22vero.policy%22%29%3A%0A%20%20%20%20%20%20%20%20p._validate_budget_splits%28%29%20%20%23%20no%20raise%0A%20%20%20%20assert%20any%28%22viewable%22%20in%20r.message%20for%20r%20in%20caplog.records%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=13&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=5"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=5"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-1-core-viewable-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-1-core-viewable-budget%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Avero%2Fsrc%2Fvero%2Fpolicy.py%3A512-518%0AThe%20%60_ensure_budgeted_splits_tiered%60%20docstring%20still%20says%20a%20budgeted%20split%20%22must%20be%20agent-evaluable%20with%20per-sample%20labels%20hidden%2C%20i.e.%20%60non_viewable%60%22%2C%20but%20after%20this%20PR%20%60viewable%60%20is%20also%20permitted%20%28with%20a%20warning%29.%20The%20first%20sentence%20now%20contradicts%20the%20new%20policy%20and%20could%20mislead%20a%20future%20reader%20into%20thinking%20the%20auto-tiering%20logic%20should%20also%20gate%20out%20%60viewable%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20A%20budgeted%20split%20is%20one%20the%20agent%20may%20evaluate%2C%20so%20it%20must%20be%0A%20%20%20%20%20%20%20%20agent-evaluable%20%28%60%60non_viewable%60%60%20or%20%60%60viewable%60%60%3B%20%60%60no_access%60%60%20is%0A%20%20%20%20%20%20%20%20rejected%20by%20the%20engine%29.%20Any%20budgeted%20split%20missing%20from%0A%20%20%20%20%20%20%20%20%60%60split_accesses%60%60%20is%20auto-tiered%20%60%60non_viewable%60%60%20here%2C%20so%20a%20budget%0A%20%20%20%20%20%20%20%20is%20never%20silently%20unusable%20%28%60%60no_access%60%60%20by%20omission%29%20nor%20accidentally%0A%20%20%20%20%20%20%20%20fully%20visible%20%28%60%60viewable%60%60%20by%20omission%29.%20Explicit%20author%20tiers%20are%0A%20%20%20%20%20%20%20%20left%20untouched%20and%20checked%20in%20%3Ameth%3A%60_validate_budget_splits%60.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Avero%2Ftests%2Ftest_policy_budget_splits.py%3A56-58%0A%60caplog.at_level%28%22WARNING%22%29%60%20without%20a%20%60logger%60%20argument%20sets%20the%20level%20on%20the%20root%20logger%20but%20does%20not%20guarantee%20the%20%60vero.policy%60%20named%20logger%20emits%20at%20WARNING%20if%20it%20ever%20receives%20an%20explicit%20level%20configuration.%20Passing%20the%20logger%20name%20makes%20the%20test%20self-sufficient%20regardless%20of%20external%20log-level%20wiring.%0A%0A%60%60%60suggestion%0A%20%20%20%20with%20caplog.at_level%28%22WARNING%22%2C%20logger%3D%22vero.policy%22%29%3A%0A%20%20%20%20%20%20%20%20p._validate_budget_splits%28%29%20%20%23%20no%20raise%0A%20%20%20%20assert%20any%28%22viewable%22%20in%20r.message%20for%20r%20in%20caplog.records%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=13&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=5"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=5"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=5"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vero/src/vero/policy.py:512-518
The `_ensure_budgeted_splits_tiered` docstring still says a budgeted split "must be agent-evaluable with per-sample labels hidden, i.e. `non_viewable`", but after this PR `viewable` is also permitted (with a warning). The first sentence now contradicts the new policy and could mislead a future reader into thinking the auto-tiering logic should also gate out `viewable`.

```suggestion
        A budgeted split is one the agent may evaluate, so it must be
        agent-evaluable (``non_viewable`` or ``viewable``; ``no_access`` is
        rejected by the engine). Any budgeted split missing from
        ``split_accesses`` is auto-tiered ``non_viewable`` here, so a budget
        is never silently unusable (``no_access`` by omission) nor accidentally
        fully visible (``viewable`` by omission). Explicit author tiers are
        left untouched and checked in :meth:`_validate_budget_splits`.
```

### Issue 2 of 2
vero/tests/test_policy_budget_splits.py:56-58
`caplog.at_level("WARNING")` without a `logger` argument sets the level on the root logger but does not guarantee the `vero.policy` named logger emits at WARNING if it ever receives an explicit level configuration. Passing the logger name makes the test self-sufficient regardless of external log-level wiring.

```suggestion
    with caplog.at_level("WARNING", logger="vero.policy"):
        p._validate_budget_splits()  # no raise
    assert any("viewable" in r.message for r in caplog.records)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(harbor): allow viewable splits to ca..."](https://github.com/scaleapi/vero/commit/6fd36beb34309abe5209535de7778b613342a1e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41553924)</sub>

<!-- /greptile_comment -->