### PR TITLE
feat(harbor): admin /experiments endpoint for mid-run observability

### DIFF
--- a/vero/src/vero/harbor/app.py
+++ b/vero/src/vero/harbor/app.py
@@ -81,11 +81,18 @@ def create_app(
     async def status():
         return sidecar.status().to_dict()
 
-    # --- admin endpoint (bearer-token gated) ---
+    # --- admin endpoints (bearer-token gated) ---
     @app.post("/finalize")
     async def finalize(authorization: str | None = Header(default=None)):
         if not check_admin(authorization, admin_token):
             raise HTTPException(status_code=403, detail="admin token required")
         return await verifier.finalize()
+
+    @app.get("/experiments")
+    async def experiments(authorization: str | None = Header(default=None)):
+        """Mid-run observability: every recorded experiment, unredacted."""
+        if not check_admin(authorization, admin_token):
+            raise HTTPException(status_code=403, detail="admin token required")
+        return {"experiments": sidecar.list_experiments()}
 
     return app

--- a/vero/src/vero/harbor/server.py
+++ b/vero/src/vero/harbor/server.py
@@ -110,20 +110,38 @@ class EvaluationSidecar:
         waiting for finalize. Admin-only: recorded scores on non_viewable
         splits must not reach the agent.
         """
+        import pandas as pd
+
         if self.engine.db is None:
             return []
-        df = self.engine.db.get_experiments_df()
+        # fill_score=None: errored samples must surface as null, not as the
+        # minimum-score floor: a synthetic 0.0 is indistinguishable from a real
+        # measured failure when watching the trajectory. error_rate carries the
+        # failure signal explicitly.
+        df = self.engine.db.get_experiments_df(fill_score=None)
         if df.empty:
             return []
+
+        def _clean(v):
+            return None if v is None or pd.isna(v) else float(v)
+
         rows = []
         for _, r in df.iterrows():
+            created = r.get("candidate_created_at")
             rows.append(
                 {
                     "commit": r.get("candidate_commit"),
                     "dataset_id": r.get("dataset_subset_dataset_id"),
                     "split": r.get("dataset_subset_split"),
-                    "mean_score": r.get("mean_score"),
-                    "created_at": str(r.get("candidate_created_at")),
+                    "mean_score": _clean(r.get("mean_score")),
+                    "error_rate": _clean(r.get("error_rate")),
+                    "created_at": (
+                        created.isoformat()
+                        if created is not None
+                        and str(created) not in ("NaT", "None")
+                        and hasattr(created, "isoformat")
+                        else None
+                    ),
                 }
             )
         return rows

--- a/vero/src/vero/harbor/server.py
+++ b/vero/src/vero/harbor/server.py
@@ -101,6 +101,33 @@ class EvaluationSidecar:
             split_accesses=self.split_accesses,
         )
 
+    def list_experiments(self) -> list[dict]:
+        """All recorded experiments, unredacted (admin observability).
+
+        One row per experiment: commit, dataset/split, recorded score, and
+        creation time. Lets an operator (or the outer harness) watch an
+        optimization run mid-flight without exec-ing into the container or
+        waiting for finalize. Admin-only: recorded scores on non_viewable
+        splits must not reach the agent.
+        """
+        if self.engine.db is None:
+            return []
+        df = self.engine.db.get_experiments_df()
+        if df.empty:
+            return []
+        rows = []
+        for _, r in df.iterrows():
+            rows.append(
+                {
+                    "commit": r.get("candidate_commit"),
+                    "dataset_id": r.get("dataset_subset_dataset_id"),
+                    "split": r.get("dataset_subset_split"),
+                    "mean_score": r.get("mean_score"),
+                    "created_at": str(r.get("candidate_created_at")),
+                }
+            )
+        return rows
+
     # ------------------------------------------------------------------
     # Trust-boundary mechanics
     # ------------------------------------------------------------------

--- a/vero/tests/test_harbor_app.py
+++ b/vero/tests/test_harbor_app.py
@@ -153,3 +153,25 @@ class TestTokenFilePermissions:
                 read_admin_token(p)
         finally:
             os.seteuid(0)
+
+
+class TestExperimentsEndpoint:
+    def test_experiments_requires_token_and_lists_rows(self):
+        sidecar = MagicMock()
+        sidecar.list_experiments.return_value = [
+            {"commit": "abc123", "dataset_id": "ds", "split": "train",
+             "mean_score": 0.5, "created_at": "2026-07-03"},
+        ]
+        client = _client(sidecar=sidecar)
+
+        assert client.get("/experiments").status_code == 403  # no token
+        assert (
+            client.get("/experiments", headers={"Authorization": "Bearer wrong"}).status_code
+            == 403
+        )
+        sidecar.list_experiments.assert_not_called()
+
+        r = client.get("/experiments", headers={"Authorization": f"Bearer {TOKEN}"})
+        assert r.status_code == 200
+        rows = r.json()["experiments"]
+        assert rows and rows[0]["commit"] == "abc123" and rows[0]["mean_score"] == 0.5

--- a/vero/tests/test_harbor_server.py
+++ b/vero/tests/test_harbor_server.py
@@ -41,7 +41,7 @@ def _experiment(split: str, commit: str = "abcdef123456") -> Experiment:
     )
 
 
-def _sidecar(tmp_path, *, split, submit_enabled=False):
+def _sidecar(tmp_path, *, split, submit_enabled=False, accesses=None):
     engine = MagicMock()
     engine.evaluate = AsyncMock(return_value=_experiment(split))
     engine.budget = BudgetLedger(
@@ -49,7 +49,8 @@ def _sidecar(tmp_path, *, split, submit_enabled=False):
     )
     sidecar = EvaluationSidecar(
         engine=engine,
-        split_accesses=[SplitAccess.non_viewable("validation"), SplitAccess.no_access("test")],
+        split_accesses=accesses
+        or [SplitAccess.non_viewable("validation"), SplitAccess.no_access("test")],
         agent_repo_path=tmp_path / "agent_repo",
         agent_volume=tmp_path / "agent_vol",
         admin_volume=tmp_path / "admin_vol",
@@ -63,7 +64,11 @@ def _sidecar(tmp_path, *, split, submit_enabled=False):
 class TestRouting:
     @pytest.mark.asyncio
     async def test_visible_split_writes_full_per_sample(self, tmp_path):
-        sidecar = _sidecar(tmp_path, split="train")  # train defaults to viewable
+        # Unlisted splits are fail-closed (no_access) since the tier flip, so
+        # viewable must be declared explicitly.
+        sidecar = _sidecar(
+            tmp_path, split="train", accesses=[SplitAccess.viewable("train")]
+        )
         summary = await sidecar.evaluate(EvalRequest(dataset_id="ds1", split="train"))
 
         dest = tmp_path / "agent_vol" / "results" / "train__abcdef123456"


### PR DESCRIPTION
Stacked on #8. Operational gap found running live GAIA optimization trials: mid-run, the only visibility into what the optimizer had measured was mining its transcript or exec-ing into the sidecar container.

Adds token-gated `GET /experiments` returning every recorded experiment (commit, dataset/split, recorded score, created_at). An operator or the outer harness can now watch an optimization trajectory as it happens, e.g.:

```
TOKEN=$(cat /state/token/admin.token)
curl -s -H "Authorization: Bearer $TOKEN" localhost:8000/experiments
```

Admin-only on purpose (reuses the finalize bearer gate): recorded scores on `non_viewable` splits must not reach the agent. Test covers the 403 paths and the row shape. 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a token-gated `GET /experiments` admin endpoint to `EvaluationSidecar` that returns every recorded experiment (commit, dataset/split, mean score, error rate, and creation timestamp) for mid-run optimization observability — without requiring exec access to the sidecar container. It also fixes an existing test helper to explicitly declare `viewable` for unlisted splits, reflecting the new fail-closed default.

- `server.py` adds `list_experiments()` with `fill_score=None` so errored samples surface as `null` (not the minimum-score floor), plus NaT/NaN guards for the timestamp and score fields.
- `app.py` wires the endpoint behind the same bearer-token gate used by `/finalize`, correctly rejecting unauthenticated callers before touching the DB.
- Tests cover the 403 rejection path and the row shape at the app layer, and the `_sidecar` helper is updated to support explicit split-access declarations.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The new endpoint is correctly gated behind the same bearer-token check as /finalize, and no agent-facing path is touched.

The auth boundary is tight and identical to the existing /finalize gate. list_experiments() correctly addresses the issues from the prior review round. The only remaining concerns are the absence of a direct server-layer test and lack of pagination, neither of which causes incorrect behavior.

vero/src/vero/harbor/server.py — the list_experiments() DataFrame processing path (NaT guard, _clean helper) has no direct unit test in the server test suite.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/server.py | Adds list_experiments() with fill_score=None, NaT/NaN guards, and lazy pandas import; the actual NaT/fill logic has no dedicated server-layer unit test. |
| vero/src/vero/harbor/app.py | Adds GET /experiments behind the same bearer-token check as /finalize; auth gate is correctly placed before data access. |
| vero/tests/test_harbor_app.py | Adds TestExperimentsEndpoint covering 403 rejection and row shape; sidecar is mocked so the underlying list_experiments() logic is not exercised here. |
| vero/tests/test_harbor_server.py | Adds accesses parameter to _sidecar() helper and fixes the viewable-split test to declare the split explicitly; no new test for list_experiments() itself. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Operator
    participant FastAPI as FastAPI (app.py)
    participant Sidecar as EvaluationSidecar (server.py)
    participant DB as ExperimentDatabase

    Operator->>FastAPI: GET /experiments Authorization: Bearer token
    FastAPI->>FastAPI: check_admin(token)
    alt invalid token
        FastAPI-->>Operator: 403 admin token required
    else valid token
        FastAPI->>Sidecar: list_experiments()
        Sidecar->>DB: "get_experiments_df(fill_score=None)"
        DB-->>Sidecar: DataFrame (all experiments)
        Sidecar->>Sidecar: _clean() NaN to null, isoformat() with NaT guard
        Sidecar-->>FastAPI: list[dict] rows
        FastAPI-->>Operator: 200 experiments list
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Operator
    participant FastAPI as FastAPI (app.py)
    participant Sidecar as EvaluationSidecar (server.py)
    participant DB as ExperimentDatabase

    Operator->>FastAPI: GET /experiments Authorization: Bearer token
    FastAPI->>FastAPI: check_admin(token)
    alt invalid token
        FastAPI-->>Operator: 403 admin token required
    else valid token
        FastAPI->>Sidecar: list_experiments()
        Sidecar->>DB: "get_experiments_df(fill_score=None)"
        DB-->>Sidecar: DataFrame (all experiments)
        Sidecar->>Sidecar: _clean() NaN to null, isoformat() with NaT guard
        Sidecar-->>FastAPI: list[dict] rows
        FastAPI-->>Operator: 200 experiments list
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(harbor): /experiments must not repor..."](https://github.com/scaleapi/vero/commit/74c0456aebe95b5ed3aa568dfaaa0311282f4ef2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41554154)</sub>

<!-- /greptile_comment -->