### PR TITLE
perf(harbor): pre-bake claude-code into the main image

### DIFF
--- a/vero/src/vero/harbor/build/templates/Dockerfile.main.j2
+++ b/vero/src/vero/harbor/build/templates/Dockerfile.main.j2
@@ -17,4 +17,13 @@ COPY agent-seed /opt/agent-seed
 COPY main/seed.sh /opt/seed.sh
 RUN chmod +x /opt/seed.sh && useradd -m -u 1001 agent
 
+# Pre-bake the claude-code CLI for the de-privileged agent user. Harbor's
+# per-trial agent setup re-runs the same bootstrap as that user; with this
+# layer it completes in ~250s instead of ~625s (measured 2026-07-03), inside
+# harbor's default 360s agent-setup budget, on networks where the full
+# download would blow it. A stale image (newer claude-code release) simply
+# re-downloads, degrading gracefully to the un-baked behavior; an offline
+# compile skips the layer without failing the build.
+RUN su - agent -c "curl -fsSL https://downloads.claude.ai/claude-code-releases/bootstrap.sh | bash -s --" || true
+
 WORKDIR /work/agent

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -167,3 +167,14 @@ def test_seed_documents_advisory_read_only(built):
     seed = (built / "environment/main/seed.sh").read_text()
     assert "ADVISORY ONLY" in seed
     assert "sidecar-side" in seed
+
+
+def test_main_dockerfile_prebakes_claude_code(built):
+    # The main image pre-installs claude-code for the agent user so harbor's
+    # per-trial re-run of the bootstrap is fast (~250s vs ~625s measured) and
+    # fits the default agent-setup budget. `|| true` keeps offline compiles
+    # working.
+    text = (built / "environment" / "Dockerfile").read_text()
+    assert "bootstrap.sh" in text
+    assert 'su - agent -c' in text
+    assert "|| true" in text

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -175,6 +175,7 @@ def test_main_dockerfile_prebakes_claude_code(built):
     # fits the default agent-setup budget. `|| true` keeps offline compiles
     # working.
     text = (built / "environment" / "Dockerfile").read_text()
+    assert "downloads.claude.ai" in text  # pin the official host, not just the filename
     assert "bootstrap.sh" in text
     assert 'su - agent -c' in text
     assert "|| true" in text


### PR DESCRIPTION
Stacked on #9. Kills an infra failure class found running live optimization trials on local docker: harbor installs claude-code at trial start via the bootstrap as the `agent` user, and on slow container networks that download runs ~10-17 min, blowing the default 360s agent-setup budget (observed: 1 `AgentSetupTimeoutError`, then 8 `NonZeroAgentExitCodeError` from concurrent-download resets in one 10-trial job; the failures cost no tokens but killed 8/10 trials).

**Measured, not assumed** (2026-07-03, three container experiments):
| Scenario | Bootstrap time |
|---|---|
| Cold install (today's behavior) | 625-1043s |
| Pre-baked as root, re-run as agent | 1043s (no help; per-user install) |
| **Pre-baked as agent, re-run as agent** | **253s** (fits the 360s default budget) |

So the layer installs as the `agent` user (the one harbor execs the installer as). Honest trade-offs, documented in the template comment: not a no-op (delta update); a stale image (newer claude-code release) degrades gracefully to the full download; `|| true` keeps offline compiles working; other optimizer agents ignore the layer.

Render test added. 9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pre-bakes the `claude-code` CLI into the main Harbor Docker image as the `agent` user, reducing per-trial bootstrap time from ~625–1043 s to ~250 s and reliably fitting within the default 360 s agent-setup budget. A matching test verifies the key assertions in the rendered Dockerfile.

- **Dockerfile.main.j2**: adds a single `RUN su - agent -c "curl -fsSL … | bash -s --" || true` layer so the install lands in the agent user's home directory (matching what harbor's bootstrap does at trial time); `|| true` keeps offline image builds non-fatal and is explicitly documented.
- **test_harbor_build.py**: adds `test_main_dockerfile_prebakes_claude_code` which reads the compiled Dockerfile and asserts the host domain, script name, user switch, and silent-failure guard are all present.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, the fallback path is explicitly handled with `|| true`, and the test suite covers all four key properties of the new Dockerfile layer.

The Dockerfile change is a single, well-scoped RUN layer that installs claude-code as the correct user, fails gracefully in offline environments, and degrades to the existing full-download behavior when the pre-baked install is absent or stale. The new test reads the compiled output and asserts on the host domain, script name, user switch, and silent-failure guard. No logic in the existing build path is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/templates/Dockerfile.main.j2 | Adds a pre-bake RUN layer that installs claude-code as the agent user via the official bootstrap script; `|| true` is intentional and well-documented for offline builds. |
| vero/tests/test_harbor_build.py | New test reads the compiled Dockerfile and asserts on the official host, script name, agent user switch, and silent-failure guard — all four key properties of the new layer. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Build
    participant Docker as Docker Build
    participant Img as Main Image
    participant Harbor as Harbor Runtime
    participant BS as Bootstrap Script

    CI->>Docker: docker build
    Docker->>Docker: apt-get install curl git ca-certificates
    Docker->>Docker: pip install vero[harbor]
    Docker->>Docker: useradd -m agent
    Docker->>BS: "su - agent -c curl bootstrap.sh | bash"
    alt network available
        BS-->>Img: claude-code in /home/agent (~250s)
    else error or offline
        BS-->>Img: "skip via || true, no claude-code"
    end
    CI-->>Img: image ready

    Harbor->>Img: start trial
    Img->>BS: re-run bootstrap as agent user
    alt claude-code pre-baked
        BS-->>Harbor: fast delta update ~250s fits 360s budget
    else not pre-baked
        BS-->>Harbor: full download ~625-1043s may exceed budget
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Build
    participant Docker as Docker Build
    participant Img as Main Image
    participant Harbor as Harbor Runtime
    participant BS as Bootstrap Script

    CI->>Docker: docker build
    Docker->>Docker: apt-get install curl git ca-certificates
    Docker->>Docker: pip install vero[harbor]
    Docker->>Docker: useradd -m agent
    Docker->>BS: "su - agent -c curl bootstrap.sh | bash"
    alt network available
        BS-->>Img: claude-code in /home/agent (~250s)
    else error or offline
        BS-->>Img: "skip via || true, no claude-code"
    end
    CI-->>Img: image ready

    Harbor->>Img: start trial
    Img->>BS: re-run bootstrap as agent user
    alt claude-code pre-baked
        BS-->>Harbor: fast delta update ~250s fits 360s budget
    else not pre-baked
        BS-->>Harbor: full download ~625-1043s may exceed budget
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(harbor): pin the claude-code bootst..."](https://github.com/scaleapi/vero/commit/5f5997548fe325e66e6ee17ced6c02ceca2f7cef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41558503)</sub>

<!-- /greptile_comment -->