### PR TITLE
fix(harbor): refuse to score all-zero when nested trials match no task names

### DIFF
--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -58,7 +58,7 @@ class HarborRunner:
             await self._run_harbor(
                 str(workspace.project_path), params, [t for _, t in pending], jobs_dir
             )
-        self._collate(jobs_dir, pairs, params)
+        self._collate(jobs_dir, pairs, params, ran=[t for _, t in pending])
 
     # ------------------------------------------------------------------
     # Task selection (host-side; just task names)
@@ -137,8 +137,31 @@ class HarborRunner:
         jobs_dir: Path,
         pairs: list[tuple[int, str]],
         params: EvaluationParameters,
+        ran: list[str] | None = None,
     ) -> None:
         trials = self._load_trials(jobs_dir)  # {task_name: result_dict}
+        # Guard against silently scoring everything 0. If we just ran tasks and
+        # got either no trial results at all, or trial results whose task_names
+        # match NONE of the requested ones (a task-name keying mismatch: the
+        # dataset must store harbor's canonical '<org>/<name>' form), this is an
+        # infrastructure failure, not an agent failure. Recording it as all-zero
+        # samples would be indistinguishable from "the agent failed every task".
+        if ran:
+            if not trials:
+                raise RuntimeError(
+                    f"Nested `harbor run` produced no trial results for "
+                    f"{len(ran)} task(s) (see harbor output above); refusing to "
+                    f"score all samples 0."
+                )
+            if not any(t in trials for t in ran):
+                raise RuntimeError(
+                    f"Nested `harbor run` produced {len(trials)} trial "
+                    f"result(s), but none match the requested task names "
+                    f"(requested e.g. {ran[0]!r}; recorded e.g. "
+                    f"{next(iter(trials))!r}). Task names must use harbor's "
+                    f"canonical '<org>/<name>' form; refusing to score all "
+                    f"samples 0."
+                )
         for sample_id, task_name in pairs:
             if self._is_done(params, sample_id):
                 continue  # already collated successfully (resume); errors are redone

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -212,3 +212,58 @@ class TestReviewFixes:
         results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
         assert results[0].error is None
         assert results[0].score == 1.0
+
+
+class TestCollateMismatchGuard:
+    """_collate must not silently score 0.0 when the nested run's trials exist
+    but match none of the requested task names (keying mismatch), or when the
+    run produced no trials at all. Found live: a partition with bare TB2 names
+    (vs harbor's canonical 'terminal-bench/<name>') zeroed a whole trial,
+    anchors included, indistinguishable from total agent failure.
+    """
+
+    def test_zero_name_matches_raises(self, tmp_path):
+        runner = _runner()
+        jobs = tmp_path / "jobs"
+        run = jobs / "2026-01-01__00-00-00"
+        t = run / "trial0"
+        t.mkdir(parents=True)
+        (t / "result.json").write_text(json.dumps({
+            "task_name": "terminal-bench/foo", "trial_name": "trial0",
+            "verifier_result": {"rewards": {"reward": 1.0}},
+        }))
+        with pytest.raises(RuntimeError, match="none match the requested"):
+            runner._collate(jobs, [(0, "foo")], _params(), ran=["foo"])
+
+    def test_no_trials_at_all_raises(self, tmp_path):
+        runner = _runner()
+        jobs = tmp_path / "jobs"
+        jobs.mkdir()
+        with pytest.raises(RuntimeError, match="no trial results"):
+            runner._collate(jobs, [(0, "foo")], _params(), ran=["foo"])
+
+    def test_partial_match_still_collates(self, tmp_path, monkeypatch):
+        # One of two tasks matched: not a keying mismatch; the missing task is
+        # recorded as an error sample (existing behavior).
+        runner = _runner()
+        jobs = tmp_path / "jobs"
+        run = jobs / "2026-01-01__00-00-00"
+        t = run / "trial0"
+        t.mkdir(parents=True)
+        (t / "result.json").write_text(json.dumps({
+            "task_name": "t0", "trial_name": "trial0",
+            "verifier_result": {"rewards": {"reward": 1.0}},
+        }))
+        saved = []
+        monkeypatch.setattr(
+            "vero.harbor.runner.save_sample_result",
+            lambda *a, **k: saved.append(k.get("sample_id")),
+        )
+        runner._collate(jobs, [(0, "t0"), (1, "missing")], _params(), ran=["t0", "missing"])
+        assert saved == [0, 1]
+
+    def test_resume_with_nothing_ran_skips_guard(self, tmp_path, monkeypatch):
+        # All samples already done (resume): no `ran` tasks, empty jobs dir is fine.
+        runner = _runner()
+        monkeypatch.setattr(HarborRunner, "_is_done", lambda self, p, s: True)
+        runner._collate(tmp_path / "jobs", [(0, "t0")], _params(), ran=[])

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -245,6 +245,7 @@ class TestCollateMismatchGuard:
     def test_partial_match_still_collates(self, tmp_path, monkeypatch):
         # One of two tasks matched: not a keying mismatch; the missing task is
         # recorded as an error sample (existing behavior).
+        monkeypatch.setenv("VERO_HOME_DIR", str(tmp_path / "vh"))  # _is_done must not read the real home
         runner = _runner()
         jobs = tmp_path / "jobs"
         run = jobs / "2026-01-01__00-00-00"


### PR DESCRIPTION
Stacked on #9. Found live: a TB2 optimization trial scored **0.0 on every sample, baseline-passing anchors included**, because the vero dataset stored bare task names (`break-filter-js-from-html`) while harbor records the canonical form (`terminal-bench/break-filter-js-from-html`). The nested runs executed fine; `_collate` matched nothing, silently wrote an all-zero experiment, burned budget, and produced a spurious reward. GAIA never hit this only because its dataset names happen to carry the `gaia/` prefix.

Silent all-zeros from a keying mismatch are indistinguishable from "the agent failed everything", which corrupts optimization results invisibly. `_collate` now raises when tasks were just run and either no trials were produced at all, or trials exist but none match (message shows both name forms). Partial matches and resume-with-nothing-pending keep existing behavior.

4 new tests; 14 pass. Companion PR (build-time name validation) coming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a guard in `_collate` to raise `RuntimeError` when a nested `harbor run` either produced no trial results or produced results whose task names match none of the requested ones — preventing silent all-zero scoring from a key-naming mismatch (bare task names vs. canonical `org/name` form).

- **`runner.py`**: `_collate` gains an optional `ran: list[str]` parameter; when non-empty, two new pre-loop checks raise before writing any results to disk if trials are missing or if none of the ran task names appear in the trial map. `produce_sample_results` passes `ran=[t for _, t in pending]` so only freshly-executed tasks trigger the guard.
- **`test_harbor_runner.py`**: Four new tests in `TestCollateMismatchGuard` cover: full mismatch raises, no-trials raises, partial match proceeds, and resume-with-nothing-ran skips the guard.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the guard is additive and only fires when a run produced results that match none of the requested task names, a case that previously silently corrupted optimization scores.

The change is narrowly scoped: a pre-loop check in _collate that raises before writing any results when the task-name keying is completely wrong or the run produced nothing. All four branches of the guard are exercised by the new tests, and the existing test suite continues to pass unchanged.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/runner.py | Adds `ran` guard to `_collate` that raises before any results are written when all task names are mismatched or no trials exist; logic is correct and handles all edge cases (empty ran, partial match, resume). |
| vero/tests/test_harbor_runner.py | Four new tests cover the guard's four branches (full mismatch, no-trials, partial match, resume-noop); all use proper monkeypatching of VERO_HOME_DIR or _is_done to avoid real filesystem reads. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PS as produce_sample_results
    participant RH as _run_harbor
    participant C as _collate
    participant LT as _load_trials

    PS->>PS: build pending (filter _is_done)
    alt pending non-empty
        PS->>RH: run harbor CLI with pending task names
    end
    PS->>C: "_collate(jobs_dir, pairs, params, ran=pending_names)"
    C->>LT: load trials from jobs_dir
    LT-->>C: "trials dict {task_name: result}"
    alt ran is non-empty (new guard)
        alt no trials at all
            C-->>PS: RuntimeError(no trial results)
        else trials exist but none match ran
            C-->>PS: RuntimeError(none match requested task names)
        end
    end
    loop each (sample_id, task_name) in pairs
        C->>C: _is_done? skip if resume
        C->>C: _sample_result(trials.get(task_name))
        C->>C: save_sample_result
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PS as produce_sample_results
    participant RH as _run_harbor
    participant C as _collate
    participant LT as _load_trials

    PS->>PS: build pending (filter _is_done)
    alt pending non-empty
        PS->>RH: run harbor CLI with pending task names
    end
    PS->>C: "_collate(jobs_dir, pairs, params, ran=pending_names)"
    C->>LT: load trials from jobs_dir
    LT-->>C: "trials dict {task_name: result}"
    alt ran is non-empty (new guard)
        alt no trials at all
            C-->>PS: RuntimeError(no trial results)
        else trials exist but none match ran
            C-->>PS: RuntimeError(none match requested task names)
        end
    end
    loop each (sample_id, task_name) in pairs
        C->>C: _is_done? skip if resume
        C->>C: _sample_result(trials.get(task_name))
        C->>C: save_sample_result
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(harbor): isolate VERO\_HOME\_DIR in t..."](https://github.com/scaleapi/vero/commit/bc453ee2e4c2cf3375cc203b2a03d2913639c13b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41609767)</sub>

<!-- /greptile_comment -->