### PR TITLE
feat(harbor): validate partition task names against task_source at build time

### DIFF
--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -142,6 +142,55 @@ def _register(dataset, vero_home: Path, tmp: Path) -> str:
     return resolve_and_save_dataset(dataset, sessions, datasets, SESSION_ID)
 
 
+def _resolve_task_source_names(task_source: str) -> set[str] | None:
+    """Enumerate the registry task_source's canonical task names, or None if
+    that is not possible right now (harbor not importable, offline, ...)."""
+    try:
+        import asyncio
+
+        from harbor.models.job.config import DatasetConfig
+
+        name = task_source.split("@")[0]
+        cfgs = asyncio.run(DatasetConfig(name=name).get_task_configs())
+        return {c.name for c in cfgs}
+    except Exception as e:
+        logger.debug(f"task_source enumeration failed: {type(e).__name__}: {e}")
+        return None
+
+
+def _validate_partition_names(
+    partition: dict[str, list[str]], task_source: str
+) -> None:
+    """Fail the build when partition task names do not exist in the task_source.
+
+    Harbor records trial results under canonical '<org>/<name>' task names; a
+    bare or misspelled name in the partition compiles fine but surfaces only at
+    eval time as an all-zero experiment (every nested trial unmatched). Catch it
+    here, where it costs nothing. Best-effort: when the source cannot be
+    enumerated (offline compile), warn and continue.
+    """
+    import os
+
+    if os.environ.get("VERO_SKIP_TASK_NAME_CHECK"):
+        return
+    names = _resolve_task_source_names(task_source)
+    if names is None:
+        logger.warning(
+            f"Could not enumerate task_source '{task_source}' to validate "
+            f"partition task names (offline?); skipping the check."
+        )
+        return
+    unknown = sorted({t for tasks in partition.values() for t in tasks} - names)
+    if unknown:
+        sample = sorted(names)[:3]
+        raise ValueError(
+            f"partition contains task name(s) not found in task_source "
+            f"'{task_source}': {unknown[:5]}. Task names must use harbor's "
+            f"canonical '<org>/<name>' form, e.g. {sample}. "
+            f"(Set VERO_SKIP_TASK_NAME_CHECK=1 to bypass.)"
+        )
+
+
 def _serve_config(config: BuildConfig, dataset_id: str | None, base_commit: str) -> dict:
     harbor = None
     if config.harbor is not None:
@@ -234,6 +283,10 @@ def compile_task(
                 raise ValueError("Mode B requires inner_task (local) or harbor.task_source (registry).")
             from vero.harbor.dataset import build_harbor_dataset
 
+            if config.harbor.get("task_source") and not config.inner_task:
+                _validate_partition_names(
+                    config.partition, config.harbor["task_source"]
+                )
             dataset_id = _register(build_harbor_dataset(config.partition), vh, tmp)
             if config.inner_task:  # local benchmark -> bake sidecar-only
                 shutil.copytree(Path(config.inner_task).resolve(), env_dir / "sidecar" / "inner-task")

--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -151,7 +151,19 @@ def _resolve_task_source_names(task_source: str) -> set[str] | None:
         from harbor.models.job.config import DatasetConfig
 
         name = task_source.split("@")[0]
-        cfgs = asyncio.run(DatasetConfig(name=name).get_task_configs())
+        coro = DatasetConfig(name=name).get_task_configs()
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            cfgs = asyncio.run(coro)  # no loop running: the normal sync path
+        else:
+            # A loop is already running (async caller, pytest-asyncio, notebook):
+            # asyncio.run would raise and the bare except below would silently
+            # skip validation. Run the enumeration on its own loop in a worker.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(1) as pool:
+                cfgs = pool.submit(asyncio.run, coro).result()
         return {c.name for c in cfgs}
     except Exception as e:
         logger.debug(f"task_source enumeration failed: {type(e).__name__}: {e}")
@@ -174,10 +186,14 @@ def _validate_partition_names(
     if os.environ.get("VERO_SKIP_TASK_NAME_CHECK"):
         return
     names = _resolve_task_source_names(task_source)
-    if names is None:
+    if not names:
+        # None (enumeration failed: offline, harbor missing) or an empty source;
+        # either way there is nothing meaningful to check against, and raising
+        # "unknown names, e.g. []" would only confuse.
         logger.warning(
-            f"Could not enumerate task_source '{task_source}' to validate "
-            f"partition task names (offline?); skipping the check."
+            f"Could not enumerate task names for task_source '{task_source}' "
+            f"(offline, harbor not importable, or empty source); skipping the "
+            f"check."
         )
         return
     unknown = sorted({t for tasks in partition.values() for t in tasks} - names)

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -167,3 +167,38 @@ def test_seed_documents_advisory_read_only(built):
     seed = (built / "environment/main/seed.sh").read_text()
     assert "ADVISORY ONLY" in seed
     assert "sidecar-side" in seed
+
+
+class TestPartitionNameValidation:
+    """Build-time guard: partition names must exist in the registry task_source
+    in harbor's canonical '<org>/<name>' form. Found live: bare TB2 names
+    compiled fine, then zeroed an entire trial at eval time."""
+
+    def test_unknown_name_fails_build(self, monkeypatch):
+        from vero.harbor.build import compiler
+        monkeypatch.delenv("VERO_SKIP_TASK_NAME_CHECK", raising=False)
+        monkeypatch.setattr(
+            compiler, "_resolve_task_source_names",
+            lambda ts: {"org/task-a", "org/task-b"},
+        )
+        with pytest.raises(ValueError, match="canonical"):
+            compiler._validate_partition_names({"train": ["task-a"]}, "org/bench")
+
+    def test_canonical_names_pass(self, monkeypatch):
+        from vero.harbor.build import compiler
+        monkeypatch.delenv("VERO_SKIP_TASK_NAME_CHECK", raising=False)
+        monkeypatch.setattr(
+            compiler, "_resolve_task_source_names",
+            lambda ts: {"org/task-a", "org/task-b"},
+        )
+        compiler._validate_partition_names(
+            {"train": ["org/task-a"], "validation": ["org/task-b"]}, "org/bench"
+        )  # no raise
+
+    def test_offline_enumeration_warns_and_continues(self, monkeypatch, caplog):
+        from vero.harbor.build import compiler
+        monkeypatch.delenv("VERO_SKIP_TASK_NAME_CHECK", raising=False)
+        monkeypatch.setattr(compiler, "_resolve_task_source_names", lambda ts: None)
+        with caplog.at_level("WARNING"):
+            compiler._validate_partition_names({"train": ["anything"]}, "org/bench")
+        assert any("skipping the check" in r.message for r in caplog.records)

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -201,4 +201,22 @@ class TestPartitionNameValidation:
         monkeypatch.setattr(compiler, "_resolve_task_source_names", lambda ts: None)
         with caplog.at_level("WARNING"):
             compiler._validate_partition_names({"train": ["anything"]}, "org/bench")
-        assert any("skipping the check" in r.message for r in caplog.records)
+        assert any("skipping the check" in m for m in caplog.messages)
+
+    def test_empty_source_warns_instead_of_useless_error(self, monkeypatch, caplog):
+        # An empty enumeration must not raise "unknown names, e.g. []".
+        from vero.harbor.build import compiler
+        monkeypatch.delenv("VERO_SKIP_TASK_NAME_CHECK", raising=False)
+        monkeypatch.setattr(compiler, "_resolve_task_source_names", lambda ts: set())
+        with caplog.at_level("WARNING"):
+            compiler._validate_partition_names({"train": ["anything"]}, "org/bench")
+        assert any("skipping the check" in m for m in caplog.messages)
+
+    def test_skip_env_var_bypasses_check(self, monkeypatch):
+        from vero.harbor.build import compiler
+        monkeypatch.setenv("VERO_SKIP_TASK_NAME_CHECK", "1")
+        monkeypatch.setattr(
+            compiler, "_resolve_task_source_names",
+            lambda ts: {"org/task-a"},
+        )
+        compiler._validate_partition_names({"train": ["bare-name"]}, "org/bench")  # no raise


### PR DESCRIPTION
Stacked on #9; companion to #16 (defense in depth for the same live incident). A Mode B partition with bare TB2 names (`break-filter-js-from-html` instead of `terminal-bench/break-filter-js-from-html`) compiled fine, then zeroed an entire optimization trial at eval time after burning its budget. #16 makes the eval-time failure loud; this PR catches it at build time where it costs $0.

The compiler enumerates the registry `task_source` (best-effort, via harbor's `DatasetConfig`) and fails the build naming the unknown tasks + canonical examples. Offline compiles warn and continue; `VERO_SKIP_TASK_NAME_CHECK=1` bypasses; local `inner_task` sources are exempt.

3 tests (unknown fails, canonical passes, offline warns). 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a build-time guard that validates partition task names against the registry's canonical `<org>/<name>` form, catching the class of bug where bare names compiled silently and zeroed an entire optimization trial at eval time. The implementation is best-effort: offline or harbor-unavailable compiles warn and continue; `VERO_SKIP_TASK_NAME_CHECK=1` bypasses; `inner_task` local sources are exempt.

- `_resolve_task_source_names` enumerates task names via `DatasetConfig.get_task_configs()`, handling both sync and async-caller contexts via a `ThreadPoolExecutor` workaround for running-loop environments.
- `_validate_partition_names` raises a descriptive `ValueError` on unknown names, treats both `None` and empty-set returns as warn + continue, and is inserted into `compile_task` before dataset registration so a bad config costs nothing.
- Five tests cover the unknown/canonical/offline/empty-source/bypass-env-var paths, addressing all three issues flagged in the prior review round.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new validation is best-effort and fails open when enumeration is unavailable, so it cannot block legitimate offline builds or introduce regressions on existing compile paths.

All three issues from the prior review round are addressed: the nested-event-loop bypass, the confusing empty-source error, and the missing bypass-env-var test. The validation is inserted before any filesystem side effects on the build output, and the async thread-worker approach for running-loop contexts is correct. No logic errors or unsafe paths were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/compiler.py | Adds _resolve_task_source_names and _validate_partition_names; hooks validation into compile_task before dataset registration. Handles async-context edge case via ThreadPoolExecutor. Logic is sound and well-guarded. |
| vero/tests/test_harbor_build.py | Adds 5-test TestPartitionNameValidation class covering all key branches (unknown fails, canonical passes, offline warns, empty-source warns, env-var bypass). Responds to all three prior review threads. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[compile_task Mode B] --> B{task_source set and no inner_task?}
    B -- No --> E[build_harbor_dataset + register]
    B -- Yes --> C{VERO_SKIP_TASK_NAME_CHECK?}
    C -- Yes --> E
    C -- No --> D[_resolve_task_source_names]
    D --> F{names returned?}
    F -- None or empty set --> G[logger.warning: skipping check]
    G --> E
    F -- non-empty set --> H{unknown names in partition?}
    H -- No --> E
    H -- Yes --> I[raise ValueError with sample canonical names]
    D --> J{Running event loop?}
    J -- No --> K[asyncio.run coro]
    J -- Yes --> L[ThreadPoolExecutor asyncio.run in worker thread]
    K --> M[return set of names]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[compile_task Mode B] --> B{task_source set and no inner_task?}
    B -- No --> E[build_harbor_dataset + register]
    B -- Yes --> C{VERO_SKIP_TASK_NAME_CHECK?}
    C -- Yes --> E
    C -- No --> D[_resolve_task_source_names]
    D --> F{names returned?}
    F -- None or empty set --> G[logger.warning: skipping check]
    G --> E
    F -- non-empty set --> H{unknown names in partition?}
    H -- No --> E
    H -- Yes --> I[raise ValueError with sample canonical names]
    D --> J{Running event loop?}
    J -- No --> K[asyncio.run coro]
    J -- Yes --> L[ThreadPoolExecutor asyncio.run in worker thread]
    K --> M[return set of names]
    L --> M
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(harbor): partition-name validation s..."](https://github.com/scaleapi/vero/commit/e5e4d9cb766fe28ae1a1f45c132ba99b7b0ac94f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41610133)</sub>

<!-- /greptile_comment -->