### PR TITLE
feat(harbor): mean-of-k attempt aggregation for de-noised eval scores

### DIFF
--- a/vero/src/vero/harbor/config.py
+++ b/vero/src/vero/harbor/config.py
@@ -21,6 +21,12 @@ class HarborConfig:
     n_attempts: int = 1
     max_retries: int = 2
     reward_key: str | None = None  # primary reward; default pass -> reward -> mean
+    # How to score a task when n_attempts > 1 produced several trials:
+    #   "best": the existing behavior (clean trials preferred, then latest).
+    #   "mean": average the reward across all clean scored attempts. This is the
+    #           de-noising mode: noise shrinks ~1/sqrt(k), and the score estimates
+    #           pass probability instead of pass@k (which "best" inflates toward).
+    aggregate_attempts: str = "best"
     extra_args: list[str] = field(default_factory=list)  # passthrough harbor run flags
 
     @property

--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -162,11 +162,20 @@ class HarborRunner:
                     f"canonical '<org>/<name>' form; refusing to score all "
                     f"samples 0."
                 )
+        groups = (
+            self._trial_groups(jobs_dir)
+            if self.config.aggregate_attempts == "mean"
+            else {}
+        )
         for sample_id, task_name in pairs:
             if self._is_done(params, sample_id):
                 continue  # already collated successfully (resume); errors are redone
             sample_result = self._sample_result(
-                trials.get(task_name), sample_id, task_name, params
+                trials.get(task_name),
+                sample_id,
+                task_name,
+                params,
+                attempts=groups.get(task_name),
             )
             save_sample_result(
                 get_vero_home_dir() / "sessions",
@@ -201,6 +210,22 @@ class HarborRunner:
                 trials[task_name] = data
         return trials
 
+    def _trial_groups(self, jobs_dir: Path) -> dict[str, list[dict]]:
+        """ALL trial results per task (for mean aggregation across attempts)."""
+        groups: dict[str, list[dict]] = {}
+        if not jobs_dir.exists():
+            return groups
+        for result_json in jobs_dir.rglob("result.json"):
+            try:
+                data = json.loads(result_json.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            task_name = data.get("task_name")
+            if not task_name:
+                continue
+            groups.setdefault(task_name, []).append(data)
+        return groups
+
     @staticmethod
     def _trial_rank(data: dict, result_json: Path) -> tuple:
         """Sort key for picking the best of several trials of one task. Higher wins:
@@ -221,6 +246,7 @@ class HarborRunner:
         sample_id: int,
         task_name: str,
         params: EvaluationParameters,
+        attempts: list[dict] | None = None,
     ) -> SampleResult:
         common = {
             "dataset_sample": DatasetSample(
@@ -235,6 +261,31 @@ class HarborRunner:
             return SampleResult(
                 error=f"No Harbor trial result for task '{task_name}'.", **common
             )
+        # Mean aggregation across attempts: average the reward over every clean
+        # scored attempt (a verified 0.0 is a valid measurement; an exception is
+        # not). Falls through to the single best trial when nothing scored clean.
+        if attempts:
+            scored = [
+                self._extract_reward((t.get("verifier_result") or {}).get("rewards"))
+                for t in attempts
+                if (t.get("verifier_result") or {}).get("rewards")
+                and not t.get("exception_info")
+            ]
+            if scored:
+                return SampleResult(
+                    score=sum(scored) / len(scored),
+                    metrics={
+                        "reward_mean": sum(scored) / len(scored),
+                        "n_attempts": float(len(attempts)),
+                        "n_scored": float(len(scored)),
+                    },
+                    output={
+                        "task_name": task_name,
+                        "attempt_scores": scored,
+                        "aggregate": "mean",
+                    },
+                    **common,
+                )
         rewards = (trial.get("verifier_result") or {}).get("rewards") or {}
         if not rewards:
             return SampleResult(

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -268,3 +268,57 @@ class TestCollateMismatchGuard:
         runner = _runner()
         monkeypatch.setattr(HarborRunner, "_is_done", lambda self, p, s: True)
         runner._collate(tmp_path / "jobs", [(0, "t0")], _params(), ran=[])
+
+
+class TestMeanAttemptAggregation:
+    """aggregate_attempts='mean': average the reward across clean scored
+    attempts (de-noising; estimates pass probability). Default 'best' keeps
+    the existing latest-clean behavior, which inflates toward pass@k.
+    """
+
+    def _write(self, run, trial, task, rewards=None, exc=False):
+        d = run / trial
+        d.mkdir(parents=True)
+        (d / "result.json").write_text(json.dumps({
+            "task_name": task, "trial_name": trial,
+            "finished_at": f"2026-01-01T00:0{len(trial) % 10}:00",
+            "verifier_result": {"rewards": rewards} if rewards else None,
+            "exception_info": {"exception_type": "X", "exception_message": "",
+                               "exception_traceback": ""} if exc else None,
+        }))
+
+    def test_mean_averages_clean_attempts(self, tmp_path):
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds", agent_import_path="p:m",
+            n_attempts=2, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"; run = jobs / "2026-01-01__00-00-00"
+        self._write(run, "t0a", "t0", rewards={"reward": 1.0})
+        self._write(run, "t0b", "t0", rewards={"reward": 0.0})
+        groups = runner._trial_groups(jobs)
+        r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.score == 0.5
+        assert r.metrics["n_scored"] == 2.0
+
+    def test_mean_excludes_exception_attempts(self, tmp_path):
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds", agent_import_path="p:m",
+            n_attempts=2, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"; run = jobs / "2026-01-01__00-00-00"
+        self._write(run, "t0a", "t0", rewards={"reward": 1.0})
+        self._write(run, "t0bad", "t0", exc=True)
+        groups = runner._trial_groups(jobs)
+        r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.score == 1.0
+        assert r.metrics["n_scored"] == 1.0
+
+    def test_default_best_unchanged(self, tmp_path):
+        # No attempts passed (default 'best' config): single-trial path intact.
+        runner = _runner()
+        r = runner._sample_result(
+            {"task_name": "t0", "trial_name": "x",
+             "verifier_result": {"rewards": {"reward": 1.0}}},
+            0, "t0", _params(),
+        )
+        assert r.score == 1.0


### PR DESCRIPTION
Stacked on #16. This is the fix implied by the optimization campaign's central finding: across 5 valid GAIA trials (strong/weak inner models, prompt-only and full-code surfaces, aggregate and per-task feedback), **the effect size of an edit (~1 task) sat below single-rollout eval noise (~2 tasks in 12)**, so optimizers hill-climbed on noise; one trial's optimizer re-measured its own leading commit and watched 0.667 fall to 0.5 on identical code.

With `n_attempts > 1`, the existing dedup keeps the *best* trial per task, which inflates toward pass@k, the opposite of de-noising. New `HarborConfig.aggregate_attempts`:
- `best` (default): existing behavior, unchanged
- `mean`: average reward over all clean scored attempts (a verified 0.0 counts; an exception does not), noise shrinks ~1/sqrt(k) and the score estimates pass probability

Falls back to the best trial when nothing scored clean. 3 new tests; 17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `aggregate_attempts="mean"` to `HarborConfig` and implements it in `HarborRunner._collate` / `_sample_result`. When enabled, a new `_trial_groups` scan collects all per-task trial dicts and the scorer averages the reward over every clean (no-exception, has-rewards) attempt, shrinking eval noise by ~1/√k; falls back to the existing single-best-trial path when no attempt scored clean.

- `config.py`: one new field (`aggregate_attempts: str = "best"`) with inline documentation explaining the de-noising rationale.
- `runner.py`: `_trial_groups` method mirrors `_load_trials` but retains all trials per task (not just best-ranked); mean branch in `_sample_result` filters on `not exception_info and has rewards`, then averages; fallback to best-trial is preserved.
- `test_harbor_runner.py`: three new tests for mean averaging, exception exclusion, and unchanged default-best path; 17 tests total.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the mean aggregation path is well-isolated behind the new config field, the default behavior is unchanged, and the score calculation is correct.

The default aggregate_attempts='best' path is untouched and all existing tests still pass. The new mean path correctly filters out exception-carrying trials and falls back to best-trial when nothing scored clean.

No files require special attention; runner.py carries the core logic change and is worth a quick re-read.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/config.py | Adds `aggregate_attempts: str = "best"` field to HarborConfig; plain str with no enum constraint (silent-misconfiguration concern already flagged in a previous thread). |
| vero/src/vero/harbor/runner.py | Adds `_trial_groups` and mean aggregation branch in `_sample_result`; score logic is correct, though `n_attempts` metric counts all trial JSON files including retry artifacts rather than `config.n_attempts`. |
| vero/tests/test_harbor_runner.py | Three new tests covering mean averaging, exception exclusion, and default-best path; does not cover the all-exceptions fallback path. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(harbor): mean-of-k attempt aggregat..."](https://github.com/scaleapi/vero/commit/221c93359366a45c0e8837b12f97e9aded798d2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41610458)</sub>

<!-- /greptile_comment -->