### PR TITLE
feat(harbor): optionally score the baseline at finalize (regression visibility)

### DIFF
--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -67,6 +67,10 @@ class ServeConfig(BaseModel):
     targets: list[_TargetCfg] = Field(default_factory=list)
     base_commit: str | None = None
     submit_enabled: bool = False
+    # Also admin-score the unmodified baseline on every target at finalize and
+    # write it to <admin_volume>/baseline.json: makes regressions visible
+    # (an optimized candidate can score WORSE than the untouched baseline).
+    score_baseline: bool = False
 
     # volumes / token
     agent_volume: str
@@ -208,6 +212,7 @@ async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Veri
         base_commit=config.base_commit,
         selection_task=config.task,
         selection_dataset_id=config.dataset_id,
+        score_baseline=config.score_baseline,
     )
 
     token = generate_token()

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -52,6 +52,7 @@ class Verifier:
         selection_task: str | None = None,
         selection_dataset_id: str | None = None,
         rescore_top_k: int = 3,
+        score_baseline: bool = False,
     ):
         self.engine = engine
         self.admin_volume = Path(admin_volume)
@@ -65,6 +66,7 @@ class Verifier:
         self.selection_task = selection_task
         self.selection_dataset_id = selection_dataset_id
         self.rescore_top_k = rescore_top_k
+        self.score_baseline = score_baseline
 
     async def finalize(self) -> dict[str, float]:
         """Select the commit and score it on every target -> {reward_key: score}.
@@ -102,7 +104,48 @@ class Verifier:
             rewards[target.reward_key] = (
                 float(score) if score is not None else default_minimum_score
             )
+        await self._maybe_score_baseline(rewards)
         return rewards
+
+    async def _maybe_score_baseline(self, rewards: dict[str, float]) -> None:
+        """Admin-score the unmodified baseline on every target and persist it.
+
+        An optimized candidate can score WORSE than the untouched baseline
+        (observed live: a weak inner model went 0.3 -> 0.2 after optimization);
+        without this, the regression is invisible because auto_best excludes the
+        baseline from selection and nothing else ever scores it. Written to
+        <admin_volume>/baseline.json (NOT into reward.json, whose keys the outer
+        harness consumes) and logged next to the candidate's rewards. Failures
+        here never fail the trial.
+        """
+        if not (self.score_baseline and self.base_commit):
+            return
+        try:
+            baselines: dict[str, float] = {}
+            for target in self.targets:
+                exp = await self.engine.evaluate_admin(
+                    task=target.task,
+                    dataset_id=target.dataset_id,
+                    split=target.split,
+                    commit=self.base_commit,
+                    sample_ids=target.sample_ids,
+                )
+                score = exp.result.score()
+                baselines[target.reward_key] = (
+                    float(score) if score is not None else default_minimum_score
+                )
+            self.admin_volume.mkdir(parents=True, exist_ok=True)
+            (self.admin_volume / "baseline.json").write_text(
+                json.dumps(baselines, indent=2)
+            )
+            for key, value in rewards.items():
+                base = baselines.get(key)
+                tag = " (REGRESSION vs baseline)" if base is not None and value < base else ""
+                logger.info(
+                    "finalize: %s=%s baseline=%s%s", key, value, base, tag
+                )
+        except Exception:
+            logger.exception("baseline scoring failed; reward.json is unaffected")
 
     async def _select_commit(self) -> str:
         if self.reward_mode == "submit":

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -118,7 +118,15 @@ class Verifier:
         harness consumes) and logged next to the candidate's rewards. Failures
         here never fail the trial.
         """
-        if not (self.score_baseline and self.base_commit):
+        if not self.score_baseline:
+            return
+        if not self.base_commit:
+            # Misconfiguration must not be a silent no-op: the operator asked
+            # for baseline scoring and would otherwise never learn it is off.
+            logger.warning(
+                "score_baseline=True but base_commit is not set; skipping "
+                "baseline scoring."
+            )
             return
         try:
             baselines: dict[str, float] = {}

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -301,3 +301,22 @@ class TestBaselineAtFinalize:
         )
         rewards = await v.finalize()
         assert rewards == {"accuracy": 0.7}  # trial reward survives baseline failure
+
+    @pytest.mark.asyncio
+    async def test_missing_base_commit_warns(self, tmp_path, caplog):
+        # score_baseline=True with no base_commit must not be a silent no-op.
+        (tmp_path / "submission.json").write_text(json.dumps({"commit": "cand"}))
+        engine = _engine([0.9])
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            base_commit=None,
+            score_baseline=True,
+            targets=[VerificationTarget(task=None, dataset_id="ds", split="validation", reward_key="accuracy")],
+        )
+        with caplog.at_level("WARNING", logger="vero.harbor.verifier"):
+            rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.9}
+        assert not (tmp_path / "baseline.json").exists()
+        assert any("base_commit is not set" in m for m in caplog.messages)

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -239,3 +239,65 @@ class TestNoCandidateFallback:
         rewards = await v.finalize()
         assert rewards == {"accuracy": 0.5}
         assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"
+
+
+class TestBaselineAtFinalize:
+    """score_baseline=True: finalize also admin-scores the untouched baseline
+    and persists it to admin_volume/baseline.json, so regressions are visible
+    (observed live: optimization took a weak model from 0.3 to 0.2 and nothing
+    surfaced it). reward.json keys are unaffected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_baseline_scored_and_persisted(self, tmp_path):
+        (tmp_path / "submission.json").write_text(json.dumps({"commit": "cand"}))
+        engine = _engine([0.2, 0.3])  # candidate target eval, then baseline eval
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            base_commit="base",
+            score_baseline=True,
+            targets=[VerificationTarget(task=None, dataset_id="ds", split="validation", reward_key="accuracy")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.2}  # reward.json content unchanged
+        data = json.loads((tmp_path / "baseline.json").read_text())
+        assert data == {"accuracy": 0.3}
+        # second admin eval was the baseline commit
+        assert engine.evaluate_admin.await_args_list[-1].kwargs["commit"] == "base"
+
+    @pytest.mark.asyncio
+    async def test_default_off_no_extra_evals(self, tmp_path):
+        (tmp_path / "submission.json").write_text(json.dumps({"commit": "cand"}))
+        engine = _engine([0.9])
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            base_commit="base",
+            targets=[VerificationTarget(task=None, dataset_id="ds", split="validation", reward_key="accuracy")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.9}
+        assert engine.evaluate_admin.await_count == 1
+        assert not (tmp_path / "baseline.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_baseline_failure_never_fails_trial(self, tmp_path):
+        (tmp_path / "submission.json").write_text(json.dumps({"commit": "cand"}))
+        engine = MagicMock()
+        engine.evaluate_admin = AsyncMock(
+            side_effect=[MagicMock(result=MagicMock(score=MagicMock(return_value=0.7))),
+                         RuntimeError("modal down")]
+        )
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            base_commit="base",
+            score_baseline=True,
+            targets=[VerificationTarget(task=None, dataset_id="ds", split="validation", reward_key="accuracy")],
+        )
+        rewards = await v.finalize()
+        assert rewards == {"accuracy": 0.7}  # trial reward survives baseline failure


### PR DESCRIPTION
Stacked on #11. Motivated by the sharpest live finding of the optimization campaign: a weak inner model went **0.3 -> 0.2 on the held-out split after optimization**, and nothing surfaced it. `auto_best` correctly excludes the baseline from selection, so the untouched baseline is never scored anywhere: 'optimized' can silently mean 'worse'.

`ServeConfig.score_baseline: true` makes finalize also admin-score `base_commit` on every target, persist `<admin_volume>/baseline.json`, and log candidate-vs-baseline per key (tagging regressions). Deliberate boundaries:
- **reward.json untouched**: its keys are the outer harness's contract; the baseline goes in a sibling artifact + logs
- **default off**: costs one extra admin eval per target, which in Mode B is a real (paid) benchmark run
- **never fails the trial**: baseline-scoring errors are logged and swallowed

3 tests (persisted + logged, default-off costs nothing, failure isolation). 12 pass. Compiler passthrough for build.yaml is a one-liner that can ride any compiler-side PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `score_baseline` flag to `ServeConfig` and `Verifier` that, when enabled, admin-scores the unmodified `base_commit` on every target at finalize time, persists results to `<admin_volume>/baseline.json`, and logs candidate-vs-baseline comparisons (tagging regressions). The feature is off by default and baseline failures are fully isolated from the trial reward.

- `ServeConfig.score_baseline: bool = False` threads through to `Verifier` and triggers `_maybe_score_baseline` after candidate scoring; `reward.json` keys are untouched.
- Four new tests cover the persisted artifact, default-off eval count, failure isolation, and the misconfiguration warning when `base_commit` is absent.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new baseline-scoring path is purely additive, off by default, and fully isolated from the trial reward.

All changes are additive and gated behind a default-false flag. The candidate-scoring and reward-return paths are unmodified. Failure isolation (try/except around the entire baseline block) and the NoCandidateError early-return both prevent baseline work from affecting reward.json. The only gap is that a mid-loop failure in a multi-target configuration silently discards partial baseline results without writing anything — noted as a comment but it does not affect reward correctness.

No files require special attention; verifier.py is the core change and its multi-target partial-failure behaviour is worth a follow-up but does not block merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/verifier.py | Adds `_maybe_score_baseline` method invoked at the end of `finalize`; logic is sound with a minor gap in multi-target partial-failure persistence. |
| vero/src/vero/harbor/serve.py | Adds `score_baseline: bool = False` to `ServeConfig` and threads it through to `Verifier`; clean one-liner plumbing change. |
| vero/tests/test_harbor_verifier.py | Adds `TestBaselineAtFinalize` with four tests covering the happy path, default-off eval count, failure isolation, and the missing-`base_commit` warning; tests use existing `_engine` helper consistently. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant H as Harbor harness
    participant V as Verifier.finalize()
    participant E as EvaluationEngine
    participant FS as admin_volume/

    H->>V: finalize()
    V->>V: _select_commit() → sha
    loop each target
        V->>E: "evaluate_admin(commit=sha, split=target.split)"
        E-->>V: score
        V->>V: "rewards[key] = score"
    end
    alt "score_baseline=True AND base_commit set"
        V->>V: _maybe_score_baseline(rewards)
        loop each target
            V->>E: "evaluate_admin(commit=base_commit, split=target.split)"
            E-->>V: baseline score
            V->>V: "baselines[key] = score"
        end
        V->>FS: write baseline.json
        V->>V: "log candidate vs baseline (tag REGRESSION if value < base)"
    end
    V-->>H: rewards dict (unchanged)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant H as Harbor harness
    participant V as Verifier.finalize()
    participant E as EvaluationEngine
    participant FS as admin_volume/

    H->>V: finalize()
    V->>V: _select_commit() → sha
    loop each target
        V->>E: "evaluate_admin(commit=sha, split=target.split)"
        E-->>V: score
        V->>V: "rewards[key] = score"
    end
    alt "score_baseline=True AND base_commit set"
        V->>V: _maybe_score_baseline(rewards)
        loop each target
            V->>E: "evaluate_admin(commit=base_commit, split=target.split)"
            E-->>V: baseline score
            V->>V: "baselines[key] = score"
        end
        V->>FS: write baseline.json
        V->>V: "log candidate vs baseline (tag REGRESSION if value < base)"
    end
    V-->>H: rewards dict (unchanged)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(harbor): warn when score\_baseline is..."](https://github.com/scaleapi/vero/commit/e12394edaddfbb8ffbb624662cff8ea28a0bb96f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41610771)</sub>

<!-- /greptile_comment -->