### PR TITLE
fix(harbor): warn that sample_timeout is not enforced in Mode B

### DIFF
--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -136,6 +136,23 @@ def _load_or_build_ledger(
     )
 
 
+def _warn_mode_b_sample_timeout(config: ServeConfig) -> None:
+    """sample_timeout only governs Mode A (per-sample vero scoring). In Mode B
+    the nested `harbor run` applies each task's OWN harbor-configured timeouts;
+    the only vero-side cap is `timeout` on the whole nested run. An author who
+    set sample_timeout expecting a per-task cap would silently get none: say so.
+    """
+    if config.harbor is not None and "sample_timeout" in config.model_fields_set:
+        logger.warning(
+            "sample_timeout=%s is not enforced in Mode B: nested `harbor run` "
+            "tasks use their harbor-configured timeouts (tune via "
+            "harbor.extra_args, e.g. --agent-timeout-multiplier); only "
+            "`timeout` (%ss) caps the whole nested run.",
+            config.sample_timeout,
+            config.timeout,
+        )
+
+
 async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Verifier, str]:
     """Assemble the sidecar + verifier (sharing one engine) and the admin token."""
     vero_home = get_vero_home_dir()
@@ -153,6 +170,8 @@ async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Veri
             "sidecar-baked task project, not the agent's committed repo. Refusing "
             "to start: with task_project unset the agent controls its own scoring."
         )
+
+    _warn_mode_b_sample_timeout(config)
 
     workspace = await GitWorkspace.create(config.repo_path)
 

--- a/vero/tests/test_harbor_serve.py
+++ b/vero/tests/test_harbor_serve.py
@@ -233,7 +233,9 @@ def test_mode_b_sample_timeout_warns(caplog):
     )
     with caplog.at_level("WARNING"):
         _warn_mode_b_sample_timeout(ServeConfig(**base, sample_timeout=1200))
-    assert any("not enforced in Mode B" in r.message for r in caplog.records)
+    # caplog.messages (getMessage()) rather than r.message: pytest's capture
+    # handler does not run Formatter.format(), so .message may be unset.
+    assert any("not enforced in Mode B" in m for m in caplog.messages)
 
     caplog.clear()
     with caplog.at_level("WARNING"):

--- a/vero/tests/test_harbor_serve.py
+++ b/vero/tests/test_harbor_serve.py
@@ -219,3 +219,26 @@ async def test_ledger_reloads_spent_budget_across_restart(fixture):
     sidecar2, _, _ = await build_components(config)
     reloaded = sidecar2.engine.budget.get(dataset_id, "test").remaining_run_budget
     assert reloaded == after, "sidecar restart must not refill spent budget"
+
+
+def test_mode_b_sample_timeout_warns(caplog):
+    # Setting sample_timeout in Mode B is a no-op (nested harbor tasks use their
+    # own timeouts); the author must be told rather than silently ignored.
+    from vero.harbor.serve import ServeConfig, _warn_mode_b_sample_timeout
+
+    base = dict(
+        repo_path="/r", agent_repo_path="/a", session_id="s", dataset_id="ds",
+        split_accesses=[], budgets=[], agent_volume="/v", admin_volume="/adm",
+        admin_token_path="/t", harbor={"task_source": "org/x", "agent_import_path": "p:C"},
+    )
+    with caplog.at_level("WARNING"):
+        _warn_mode_b_sample_timeout(ServeConfig(**base, sample_timeout=1200))
+    assert any("not enforced in Mode B" in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        _warn_mode_b_sample_timeout(ServeConfig(**base))  # not explicitly set
+        _warn_mode_b_sample_timeout(
+            ServeConfig(**{**base, "harbor": None, "task_project": "/tp"}, sample_timeout=900)
+        )  # Mode A: sample_timeout is real
+    assert not caplog.records


### PR DESCRIPTION
Stacked on #19. Found live: a Mode B config carried `sample_timeout: 1200` through several optimization trials and it never did anything. In Mode B the nested `harbor run` applies each task's own harbor-configured timeouts; the only vero-side cap is `timeout` on the whole nested run. TB2 tasks can legitimately run 30-40 minutes, so an author relying on a silent no-op cap gets surprising wall-clock and cost.

The sidecar now warns at startup when `sample_timeout` is explicitly set (via `model_fields_set`, so the default doesn't warn) alongside a Mode B config, pointing at `harbor.extra_args` (e.g. `--agent-timeout-multiplier`) as the real lever. Mode A behavior unchanged.

1 test (warns in Mode B when set; silent for default and for Mode A). 13 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a startup warning when `sample_timeout` is explicitly set alongside a Mode B (`harbor`) config, where it has no effect. The check uses Pydantic v2's `model_fields_set` so only explicit author-supplied values trigger the warning, not the 180 s default.

- `_warn_mode_b_sample_timeout` is a small, focused function placed in `build_components` after the existing Mode A integrity guard; it correctly short-circuits on both the absence of `harbor` and the absence of an explicit `sample_timeout`.
- The new test covers all three cases: warns in Mode B when set explicitly, silent when using the default in Mode B, and silent for Mode A with `harbor=None`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a diagnostic-only warning with no changes to runtime behavior or data paths.

The change is purely additive: a warning emitted at startup when a no-op config key is detected. No evaluation logic, budget accounting, or API surface is modified. The model_fields_set gate correctly distinguishes explicit author intent from the default, and the test validates all three cases.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/serve.py | Adds `_warn_mode_b_sample_timeout` helper and calls it in `build_components`; logic is correct, uses lazy `%s` log formatting, and `model_fields_set` detection is idiomatic Pydantic v2. |
| vero/tests/test_harbor_serve.py | New `test_mode_b_sample_timeout_warns` covers warn/no-warn paths correctly and uses `caplog.messages` (not `r.message`) per the existing review thread fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build_components called] --> B{config.harbor is None?}
    B -- Yes, Mode A --> C{task_project set?}
    C -- No --> D[raise ValueError]
    C -- Yes --> E[_warn_mode_b_sample_timeout]
    B -- No, Mode B --> E
    E --> F{"sample_timeout in\nmodel_fields_set?"}
    F -- Yes --> G[logger.warning:\nsample_timeout not enforced\nin Mode B]
    F -- No --> H[Silent — default value,\nno author intent]
    G --> I[Continue: build workspace,\nledger, evaluator, engine]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[build_components called] --> B{config.harbor is None?}
    B -- Yes, Mode A --> C{task_project set?}
    C -- No --> D[raise ValueError]
    C -- Yes --> E[_warn_mode_b_sample_timeout]
    B -- No, Mode B --> E
    E --> F{"sample_timeout in\nmodel_fields_set?"}
    F -- Yes --> G[logger.warning:\nsample_timeout not enforced\nin Mode B]
    F -- No --> H[Silent — default value,\nno author intent]
    G --> I[Continue: build workspace,\nledger, evaluator, engine]
    H --> I
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(harbor): use caplog.messages instea..."](https://github.com/scaleapi/vero/commit/f93e25f8f41e608caf37dd85f7f007cda17b909b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41611014)</sub>

<!-- /greptile_comment -->