### PR TITLE
fix(harbor): mean aggregation counts scored attempts even when harbor recorded an exception

### DIFF
--- a/vero/src/vero/harbor/config.py
+++ b/vero/src/vero/harbor/config.py
@@ -23,9 +23,12 @@ class HarborConfig:
     reward_key: str | None = None  # primary reward; default pass -> reward -> mean
     # How to score a task when n_attempts > 1 produced several trials:
     #   "best": the existing behavior (clean trials preferred, then latest).
-    #   "mean": average the reward across all clean scored attempts. This is the
-    #           de-noising mode: noise shrinks ~1/sqrt(k), and the score estimates
-    #           pass probability instead of pass@k (which "best" inflates toward).
+    #   "mean": average the reward across all scored attempts, dirty or clean
+    #           (a timed-out attempt the verifier scored 0.0 still counts; only
+    #           attempts with no rewards at all are excluded). This is the
+    #           de-noising mode: noise shrinks ~1/sqrt(k), and the score
+    #           estimates pass probability instead of pass@k (which "best"
+    #           inflates toward).
     aggregate_attempts: str = "best"
     extra_args: list[str] = field(default_factory=list)  # passthrough harbor run flags
 

--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -261,23 +261,34 @@ class HarborRunner:
             return SampleResult(
                 error=f"No Harbor trial result for task '{task_name}'.", **common
             )
-        # Mean aggregation across attempts: average the reward over every clean
-        # scored attempt (a verified 0.0 is a valid measurement; an exception is
-        # not). Falls through to the single best trial when nothing scored clean.
+        # Mean aggregation across attempts: average the reward over every SCORED
+        # attempt, dirty or clean. Harbor can record an exception (agent timeout,
+        # non-zero agent exit) and still run the verifier, so such an attempt
+        # carries a real measured 0.0; dropping it would estimate
+        # P(pass | attempt finished cleanly), which is non-monotone (one pass plus
+        # two timeouts would score 1.0) and systematically forgives candidates
+        # that make the agent slower. Only attempts with no rewards at all
+        # (failed before the verifier scored) are excluded. Falls through to the
+        # single best trial when nothing scored.
         if attempts:
-            scored = [
-                self._extract_reward((t.get("verifier_result") or {}).get("rewards"))
-                for t in attempts
-                if (t.get("verifier_result") or {}).get("rewards")
-                and not t.get("exception_info")
+            scored_trials = [
+                t for t in attempts if (t.get("verifier_result") or {}).get("rewards")
             ]
-            if scored:
+            if scored_trials:
+                scored = [
+                    self._extract_reward((t.get("verifier_result") or {}).get("rewards"))
+                    for t in scored_trials
+                ]
+                n_clean = sum(
+                    1 for t in scored_trials if not t.get("exception_info")
+                )
                 return SampleResult(
                     score=sum(scored) / len(scored),
                     metrics={
                         "reward_mean": sum(scored) / len(scored),
                         "n_attempts": float(len(attempts)),
                         "n_scored": float(len(scored)),
+                        "n_clean": float(n_clean),
                     },
                     output={
                         "task_name": task_name,

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -271,9 +271,12 @@ class TestCollateMismatchGuard:
 
 
 class TestMeanAttemptAggregation:
-    """aggregate_attempts='mean': average the reward across clean scored
-    attempts (de-noising; estimates pass probability). Default 'best' keeps
-    the existing latest-clean behavior, which inflates toward pass@k.
+    """aggregate_attempts='mean': average the reward across every SCORED
+    attempt, dirty or clean (de-noising; estimates per-attempt pass
+    probability). Harbor scores timed-out attempts 0.0 while also recording
+    the exception; those must count, or the mean forgives slow candidates.
+    Default 'best' keeps the existing latest-clean behavior, which inflates
+    toward pass@k.
     """
 
     def _write(self, run, trial, task, rewards=None, exc=False):
@@ -300,7 +303,9 @@ class TestMeanAttemptAggregation:
         assert r.score == 0.5
         assert r.metrics["n_scored"] == 2.0
 
-    def test_mean_excludes_exception_attempts(self, tmp_path):
+    def test_mean_excludes_attempts_without_rewards(self, tmp_path):
+        # An attempt that died before the verifier scored it carries no
+        # measurement; it is excluded (but still counted in n_attempts).
         runner = HarborRunner(HarborConfig(
             task_source="org/ds", agent_import_path="p:m",
             n_attempts=2, aggregate_attempts="mean",
@@ -312,6 +317,41 @@ class TestMeanAttemptAggregation:
         r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
         assert r.score == 1.0
         assert r.metrics["n_scored"] == 1.0
+        assert r.metrics["n_attempts"] == 2.0
+
+    def test_mean_counts_scored_exception_attempts(self, tmp_path):
+        # The live-GAIA shape: harbor records AgentTimeoutError but still runs
+        # the verifier, so the attempt has BOTH exception_info and a scored 0.0.
+        # [1.0 clean, 0.0 timeout, 0.0 timeout] must score 1/3, not 1.0.
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds", agent_import_path="p:m",
+            n_attempts=3, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"; run = jobs / "2026-01-01__00-00-00"
+        self._write(run, "t0a", "t0", rewards={"reward": 1.0})
+        self._write(run, "t0b", "t0", rewards={"reward": 0.0}, exc=True)
+        self._write(run, "t0c", "t0", rewards={"reward": 0.0}, exc=True)
+        groups = runner._trial_groups(jobs)
+        r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.score == pytest.approx(1 / 3)
+        assert r.metrics["n_scored"] == 3.0
+        assert r.metrics["n_clean"] == 1.0
+
+    def test_mean_over_all_dirty_attempts(self, tmp_path):
+        # Every attempt timed out but was scored (the all-timeouts live shape):
+        # the mean path must still apply, not the single-best-trial fallback.
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds", agent_import_path="p:m",
+            n_attempts=2, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"; run = jobs / "2026-01-01__00-00-00"
+        self._write(run, "t0a", "t0", rewards={"reward": 1.0}, exc=True)
+        self._write(run, "t0b", "t0", rewards={"reward": 0.0}, exc=True)
+        groups = runner._trial_groups(jobs)
+        r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.score == 0.5
+        assert r.metrics["n_clean"] == 0.0
+        assert r.output["aggregate"] == "mean"
 
     def test_default_best_unchanged(self, tmp_path):
         # No attempts passed (default 'best' config): single-trial path intact.


### PR DESCRIPTION
Stacked on #18.

## The bug

Harbor records agent timeouts and non-zero agent exits as `exception_info` but **still runs the verifier**, so such attempts carry a real, measured reward. In our 2026-06-30 GAIA ground-truth run, **all 11 excepted trials out of 165 (6.7%) had verifier rewards of 0.0** (8 AgentTimeoutError + 3 NonZeroAgentExitCodeError).

The mean-of-k filter excluded any attempt with `exception_info`, so the score estimated P(pass | attempt finished cleanly) instead of per-attempt pass probability. That estimator is non-monotone: attempts `[1.0, timeout, timeout]` scored **1.0** while `[timeout, timeout, timeout]` scored 0.0 (both verified by executing the code). Worse, it systematically forgives candidates whose prompts make the agent slower, which is exactly the failure shape we observed in the weak-model regression trial (exp4: optimized 0.2 vs baseline 0.3). AgentTimeoutError is in harbor's default retry-exclude list, so these dirty-but-scored finals are systematic, not incidental.

## The fix

Every attempt with verifier rewards counts toward the mean, dirty or clean; only attempts that died before scoring (no rewards at all) are excluded. Adds `n_clean` to the sample metrics so dirtiness stays visible alongside `n_scored`/`n_attempts`.

## Tests

- `test_mean_counts_scored_exception_attempts`: the live-GAIA shape, `[1.0 clean, 0.0 timeout, 0.0 timeout]` must score 1/3 (fails with 1.0 on the base branch).
- `test_mean_over_all_dirty_attempts`: every attempt timed out but scored, the mean path still applies (previously fell to the best-trial fallback).
- Renamed `test_mean_excludes_exception_attempts` to `test_mean_excludes_attempts_without_rewards` to match the real rule; its assertions hold under both semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a statistical bias in the `mean` aggregation mode for Harbor multi-attempt scoring: previously, attempts with `exception_info` (agent timeout, non-zero exit) were excluded even when Harbor had still run the verifier and produced a scored 0.0 reward, causing the mean to estimate P(pass | attempt finished cleanly) rather than the true per-attempt pass probability.

- **Core fix in `runner.py`**: The `not t.get("exception_info")` gate is removed from the scored-trials filter; only attempts with no rewards at all are excluded from the mean. The new `n_clean` metric is added alongside `n_scored`/`n_attempts` so dirty-but-scored attempts remain visible.
- **Three new / updated tests** cover the live-GAIA failure shape (`[1.0, 0.0-timeout, 0.0-timeout]` → 1/3, not 1.0), the all-dirty mean path, and the correct exclusion of attempts with no rewards; the renamed test reflects the actual rule.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line filter removal with new observability metric, and the failure mode it fixes (systematically forgiving slow-agent candidates) is well-documented and regression-tested.

The fix is minimal and correct: removing the exception_info gate from the scored-trials filter and adding n_clean for observability. Three new tests directly cover the GAIA regression shape, the all-dirty mean path, and the unchanged no-reward exclusion, leaving no untested branch in the changed logic path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/runner.py | Removes the exception_info exclusion filter from the scored-trials list; adds n_clean metric. Logic is correct and well-commented. |
| vero/src/vero/harbor/config.py | Docstring updated to accurately describe the new mean semantics (dirty-but-scored attempts count; only no-reward attempts are excluded). |
| vero/tests/test_harbor_runner.py | Adds two new regression tests and renames an existing one; assertions correctly cover the GAIA failure shape, all-dirty mean path, and no-reward exclusion. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[attempts list] --> B{attempts non-empty?}
    B -- No --> F[single best-trial path]
    B -- Yes --> C["scored_trials = attempts where\nverifier_result.rewards is truthy"]
    C --> D{scored_trials non-empty?}
    D -- No --> F
    D -- Yes --> E["scored = [_extract_reward(t) for t in scored_trials]\nn_clean = count(t for t if not t.exception_info)"]
    E --> G["SampleResult(\n  score = mean(scored),\n  metrics = {reward_mean, n_attempts, n_scored, n_clean}\n)"]

    style G fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[attempts list] --> B{attempts non-empty?}
    B -- No --> F[single best-trial path]
    B -- Yes --> C["scored_trials = attempts where\nverifier_result.rewards is truthy"]
    C --> D{scored_trials non-empty?}
    D -- No --> F
    D -- Yes --> E["scored = [_extract_reward(t) for t in scored_trials]\nn_clean = count(t for t if not t.exception_info)"]
    E --> G["SampleResult(\n  score = mean(scored),\n  metrics = {reward_mean, n_attempts, n_scored, n_clean}\n)"]

    style G fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(harbor): mean aggregation counts sco..."](https://github.com/scaleapi/vero/commit/4698439cbbff1dd37b6121ed3b5feea367fd040e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41627448)</sub>

<!-- /greptile_comment -->