### PR TITLE
fix(harbor): salvage completed trials when the nested run times out

### DIFF
--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -23,7 +23,7 @@ from vero.core.sessions import (
     save_sample_result,
 )
 from vero.harbor.config import HarborConfig
-from vero.utils import run_subprocess_with_tee
+from vero.utils import SubprocessTimeoutError, run_subprocess_with_tee
 
 if TYPE_CHECKING:
     from vero.core.evaluation import EvaluationParameters
@@ -118,9 +118,21 @@ class HarborRunner:
     ) -> None:
         cmd = self._build_command(project_path, params, task_names, jobs_dir)
         logger.info(f"Mode B: {' '.join(cmd)}")
-        result = await run_subprocess_with_tee(
-            cmd, timeout=params.timeout, cwd=project_path
-        )
+        try:
+            result = await run_subprocess_with_tee(
+                cmd, timeout=params.timeout, cwd=project_path
+            )
+        except SubprocessTimeoutError as e:
+            # A timed-out nested run is not fatal either: the eval's budget is
+            # already spent and completed trials are on disk, so salvage them.
+            # Propagating instead would return the agent a bare 500 with zero
+            # information for a fully-debited eval.
+            logger.warning(
+                f"`harbor run` timed out after {params.timeout}s; collating "
+                f"the trials that completed before the cutoff. stderr tail: "
+                f"{(e.result.stderr or '')[-500:]}"
+            )
+            return
         # Non-zero is not fatal: partial trials may still exist; collation fills gaps.
         if result.returncode != 0:
             logger.warning(
@@ -282,6 +294,15 @@ class HarborRunner:
                 n_clean = sum(
                     1 for t in scored_trials if not t.get("exception_info")
                 )
+                if len(scored) < self.config.n_attempts:
+                    # Fewer measurements than configured (attempts died before
+                    # scoring, or the nested run was cut off): the mean is
+                    # noisier than the config promises. Never let k shrink
+                    # silently; n_scored in the metrics records the actual k.
+                    logger.warning(
+                        f"Task '{task_name}': mean over {len(scored)} scored "
+                        f"attempt(s) of {self.config.n_attempts} configured."
+                    )
                 return SampleResult(
                     score=sum(scored) / len(scored),
                     metrics={

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -18,6 +18,8 @@ from vero.core.sessions import (
 )
 from vero.harbor.config import HarborConfig
 from vero.harbor.runner import HarborRunner
+from vero.utils import SubprocessTimeoutError
+from vero.utils.asyncio import SubprocessResult
 
 
 def _runner(reward_key=None, task_source="org/ds@1"):
@@ -383,3 +385,72 @@ class TestAggregateAttemptsValidation:
                 aggregate_attempts=value,
             )
             assert cfg.aggregate_attempts == value
+
+
+class TestTimeoutSalvage:
+    """A nested `harbor run` cut off by the vero-side timeout must salvage the
+    trials that completed instead of erroring the whole (already-debited)
+    eval with nothing."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_collates_partials(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VERO_HOME_DIR", str(tmp_path / "vh"))
+        runner = _runner()
+        params = _params()
+        result_dir = tmp_path / "result"
+        # t0 finished before the cutoff; t1 did not.
+        _write_trial(result_dir / "jobs", "trial0", "t0", {"pass": 1.0})
+        monkeypatch.setattr(runner, "_task_names_for", lambda p: [(0, "t0"), (1, "t1")])
+
+        async def _timeout(*args, **kwargs):
+            raise SubprocessTimeoutError(SubprocessResult(
+                args=["harbor", "run"], returncode=None, stdout="", stderr="",
+                timed_out=True,
+            ))
+
+        monkeypatch.setattr("vero.harbor.runner.run_subprocess_with_tee", _timeout)
+
+        ws = MagicMock(project_path="/wt")
+        await runner.produce_sample_results(workspace=ws, params=params, result_dir=result_dir)
+
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[0].score == 1.0
+        assert results[1].error is not None  # cut-off task -> error sample
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_zero_trials_still_raises(self, tmp_path, monkeypatch):
+        # Nothing completed before the cutoff: the collate guard must still
+        # fail loudly rather than record an all-zero/all-error experiment.
+        monkeypatch.setenv("VERO_HOME_DIR", str(tmp_path / "vh"))
+        runner = _runner()
+        params = _params()
+        monkeypatch.setattr(runner, "_task_names_for", lambda p: [(0, "t0"), (1, "t1")])
+
+        async def _timeout(*args, **kwargs):
+            raise SubprocessTimeoutError(SubprocessResult(
+                args=["harbor", "run"], returncode=None, stdout="", stderr="",
+                timed_out=True,
+            ))
+
+        monkeypatch.setattr("vero.harbor.runner.run_subprocess_with_tee", _timeout)
+        ws = MagicMock(project_path="/wt")
+        with pytest.raises(RuntimeError, match="no trial results"):
+            await runner.produce_sample_results(
+                workspace=ws, params=params, result_dir=tmp_path / "result"
+            )
+
+    def test_partial_k_mean_warns(self, tmp_path, caplog):
+        # 2 of 3 configured attempts scored: the mean must not shrink k silently.
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds", agent_import_path="p:m",
+            n_attempts=3, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"; run = jobs / "2026-01-01__00-00-00"
+        w = TestMeanAttemptAggregation()
+        w._write(run, "t0a", "t0", rewards={"reward": 1.0})
+        w._write(run, "t0b", "t0", rewards={"reward": 0.0})
+        groups = runner._trial_groups(jobs)
+        with caplog.at_level("WARNING", logger="vero.harbor.runner"):
+            r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.metrics["n_scored"] == 2.0
+        assert any("2 scored attempt(s) of 3 configured" in m for m in caplog.messages)


### PR DESCRIPTION
Stacked on #22.

## The bug

A vero-side timeout on the nested `harbor run` raised `SubprocessTimeoutError` uncaught: the agent got a bare HTTP 500, no partial results were collated, and the already-reserved budget (never refunded by design) bought zero information. With mean-of-k (n_attempts=3) tripling nested-run wall clock, this failure mode gets strictly more likely.

## The fix

- Treat a timeout like a non-zero exit: warn (including the captured stderr tail) and collate whatever trials completed before the cutoff; tasks that were cut off become error samples. With zero completed trials, the collate mismatch guard (#16) still fails loudly rather than recording an all-error experiment (pinned by a test).
- Warn whenever a mean-of-k sample scored fewer attempts than configured, so k never shrinks silently (`n_scored` in the metrics records the actual k).

Tests: timeout with partial trials collates the survivor and errors the cut-off task; timeout with zero trials raises; partial-k mean warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `SubprocessTimeoutError` from a timed-out nested `harbor run` being propagated as an uncaught HTTP 500. The fix catches the exception in `_run_harbor`, warns with the stderr tail, and returns early so `_collate` can salvage whatever trials landed on disk before the cutoff. A second change adds a `WARNING` log whenever mean-aggregation uses fewer scored attempts than `n_attempts` configures, so k-shrinkage is never silent.

- **Timeout salvage** (`_run_harbor`): `SubprocessTimeoutError` is now caught; the zero-trial case still raises via the existing `_collate` guard, while partial-completion cases score what finished and emit error samples for the rest.
- **Partial-k warning** (`_sample_result`): fires whenever `len(scored) < self.config.n_attempts` in mean-aggregation mode; `n_scored` in metrics records the actual k.
- **Tests** cover timeout with one completed trial (salvage), timeout with no trials (guard raises), and partial-k mean (warning fires + `n_scored` correct).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the stated fix; a known edge case in the resume-after-repeated-timeout path (already captured in a prior review comment) misfires the wrong collate guard and should be addressed before that flow is exercised in production.

The timeout-salvage logic is correct for first-time invocations: caught exceptions return early, the zero-trial guard still raises, and partial-completion trials are collated correctly. The partial-k warning fires correctly for mean-aggregation mode. The unresolved issue is the resume path: when a task has already been saved as an error sample and retried, its second timeout leaves only the first run's other task results in the shared jobs_dir; the guard's name-match check raises with a misleading 'task names must use canonical form' message instead of the true 'task kept timing out' diagnosis. This was documented in the previous review round and is still present in the current code.

vero/src/vero/harbor/runner.py — specifically the _collate guard interaction with the resume-after-timeout flow when jobs_dir contains stale results from a prior run.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/runner.py | Adds SubprocessTimeoutError catch in _run_harbor (returns early for salvage) and partial-k warning in _sample_result; the resume + repeated-timeout case can still trigger the wrong "none match the requested task names" guard (noted in previous comments). |
| vero/tests/test_harbor_runner.py | Adds TestTimeoutSalvage with three well-targeted cases: partial-completion salvage, zero-trial guard, and partial-k warning; all correctly patch at the module-level import site. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PSR as produce_sample_results
    participant RH as _run_harbor
    participant Sub as run_subprocess_with_tee
    participant Col as _collate

    PSR->>RH: await _run_harbor(pending_tasks, jobs_dir)
    RH->>Sub: await run_subprocess_with_tee(cmd, timeout)
    alt "normal exit (rc=0)"
        Sub-->>RH: "SubprocessResult(rc=0)"
        RH-->>PSR: return
    else non-zero exit
        Sub-->>RH: SubprocessResult(rc≠0)
        RH->>RH: logger.warning(stderr[:500])
        RH-->>PSR: return
    else timeout (NEW)
        Sub-->>RH: raise SubprocessTimeoutError(result)
        RH->>RH: logger.warning(stderr[-500:])
        RH-->>PSR: return (early, no raise)
    end
    PSR->>Col: "_collate(jobs_dir, pairs, ran=pending_tasks)"
    Col->>Col: _load_trials(jobs_dir)
    alt no trials on disk
        Col-->>PSR: raise RuntimeError(no trial results)
    else trials exist but none match ran tasks
        Col-->>PSR: raise RuntimeError(none match requested)
    else one or more matching trials
        loop each (sample_id, task_name)
            alt trial found on disk
                Col->>Col: "_sample_result -> SampleResult(score)"
            else task timed out / never ran
                Col->>Col: SampleResult(error)
            end
            Col->>Col: save_sample_result
        end
        Col-->>PSR: return
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PSR as produce_sample_results
    participant RH as _run_harbor
    participant Sub as run_subprocess_with_tee
    participant Col as _collate

    PSR->>RH: await _run_harbor(pending_tasks, jobs_dir)
    RH->>Sub: await run_subprocess_with_tee(cmd, timeout)
    alt "normal exit (rc=0)"
        Sub-->>RH: "SubprocessResult(rc=0)"
        RH-->>PSR: return
    else non-zero exit
        Sub-->>RH: SubprocessResult(rc≠0)
        RH->>RH: logger.warning(stderr[:500])
        RH-->>PSR: return
    else timeout (NEW)
        Sub-->>RH: raise SubprocessTimeoutError(result)
        RH->>RH: logger.warning(stderr[-500:])
        RH-->>PSR: return (early, no raise)
    end
    PSR->>Col: "_collate(jobs_dir, pairs, ran=pending_tasks)"
    Col->>Col: _load_trials(jobs_dir)
    alt no trials on disk
        Col-->>PSR: raise RuntimeError(no trial results)
    else trials exist but none match ran tasks
        Col-->>PSR: raise RuntimeError(none match requested)
    else one or more matching trials
        loop each (sample_id, task_name)
            alt trial found on disk
                Col->>Col: "_sample_result -> SampleResult(score)"
            else task timed out / never ran
                Col->>Col: SampleResult(error)
            end
            Col->>Col: save_sample_result
        end
        Col-->>PSR: return
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vero/src/vero/harbor/runner.py`, line 61 ([link](https://github.com/scaleapi/vero/blob/b81a90204be01e5255604203d9381096c0f6b91f/vero/src/vero/harbor/runner.py#L61)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Resume + complete-timeout triggers wrong guard message**

   When `produce_sample_results` is retried after a partial-completion timeout (e.g., `t0` finished and was saved with a score, `t1` got an error sample and will be retried), the second invocation sets `pending = [(1, "t1")]` and `ran = ["t1"]`. If `t1` times out again with nothing written to disk, `_load_trials` scans the shared `jobs_dir` and finds `t0`'s `result.json` from the first run — so `trials = {"t0": ...}`. The guard then checks `not any(t in trials for t in ran)` → `not ("t1" in {"t0": ...})` → `True` and raises:

   > *"produced 1 trial result(s), but none match the requested task names (requested e.g. 't1'; recorded e.g. 't0'). Task names must use harbor's canonical `<org>/<name>` form"*

   This is the wrong diagnosis — there is no keying mismatch; `t1` just keeps timing out. Before this PR the `SubprocessTimeoutError` propagated directly and gave the correct signal. The guard was designed to fire when ALL ran-task results are absent from `trials`, but it cannot distinguish "absent because never written by this run" from "absent because a prior run wrote something else". A targeted fix is to restrict the guard's `trials` view to only those entries whose keys appear in `ran`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vero/src/vero/harbor/runner.py
   Line: 61

   Comment:
   **Resume + complete-timeout triggers wrong guard message**

   When `produce_sample_results` is retried after a partial-completion timeout (e.g., `t0` finished and was saved with a score, `t1` got an error sample and will be retried), the second invocation sets `pending = [(1, "t1")]` and `ran = ["t1"]`. If `t1` times out again with nothing written to disk, `_load_trials` scans the shared `jobs_dir` and finds `t0`'s `result.json` from the first run — so `trials = {"t0": ...}`. The guard then checks `not any(t in trials for t in ran)` → `not ("t1" in {"t0": ...})` → `True` and raises:

   > *"produced 1 trial result(s), but none match the requested task names (requested e.g. 't1'; recorded e.g. 't0'). Task names must use harbor's canonical `<org>/<name>` form"*

   This is the wrong diagnosis — there is no keying mismatch; `t1` just keeps timing out. Before this PR the `SubprocessTimeoutError` propagated directly and gave the correct signal. The guard was designed to fire when ALL ran-task results are absent from `trials`, but it cannot distinguish "absent because never written by this run" from "absent because a prior run wrote something else". A targeted fix is to restrict the guard's `trials` view to only those entries whose keys appear in `ran`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2Fsrc%2Fvero%2Fharbor%2Frunner.py%0ALine%3A%2061%0A%0AComment%3A%0A**Resume%20%2B%20complete-timeout%20triggers%20wrong%20guard%20message**%0A%0AWhen%20%60produce_sample_results%60%20is%20retried%20after%20a%20partial-completion%20timeout%20%28e.g.%2C%20%60t0%60%20finished%20and%20was%20saved%20with%20a%20score%2C%20%60t1%60%20got%20an%20error%20sample%20and%20will%20be%20retried%29%2C%20the%20second%20invocation%20sets%20%60pending%20%3D%20%5B%281%2C%20%22t1%22%29%5D%60%20and%20%60ran%20%3D%20%5B%22t1%22%5D%60.%20If%20%60t1%60%20times%20out%20again%20with%20nothing%20written%20to%20disk%2C%20%60_load_trials%60%20scans%20the%20shared%20%60jobs_dir%60%20and%20finds%20%60t0%60's%20%60result.json%60%20from%20the%20first%20run%20%E2%80%94%20so%20%60trials%20%3D%20%7B%22t0%22%3A%20...%7D%60.%20The%20guard%20then%20checks%20%60not%20any%28t%20in%20trials%20for%20t%20in%20ran%29%60%20%E2%86%92%20%60not%20%28%22t1%22%20in%20%7B%22t0%22%3A%20...%7D%29%60%20%E2%86%92%20%60True%60%20and%20raises%3A%0A%0A%3E%20*%22produced%201%20trial%20result%28s%29%2C%20but%20none%20match%20the%20requested%20task%20names%20%28requested%20e.g.%20't1'%3B%20recorded%20e.g.%20't0'%29.%20Task%20names%20must%20use%20harbor's%20canonical%20%60%3Corg%3E%2F%3Cname%3E%60%20form%22*%0A%0AThis%20is%20the%20wrong%20diagnosis%20%E2%80%94%20there%20is%20no%20keying%20mismatch%3B%20%60t1%60%20just%20keeps%20timing%20out.%20Before%20this%20PR%20the%20%60SubprocessTimeoutError%60%20propagated%20directly%20and%20gave%20the%20correct%20signal.%20The%20guard%20was%20designed%20to%20fire%20when%20ALL%20ran-task%20results%20are%20absent%20from%20%60trials%60%2C%20but%20it%20cannot%20distinguish%20%22absent%20because%20never%20written%20by%20this%20run%22%20from%20%22absent%20because%20a%20prior%20run%20wrote%20something%20else%22.%20A%20targeted%20fix%20is%20to%20restrict%20the%20guard's%20%60trials%60%20view%20to%20only%20those%20entries%20whose%20keys%20appear%20in%20%60ran%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=23&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2Fsrc%2Fvero%2Fharbor%2Frunner.py%0ALine%3A%2061%0A%0AComment%3A%0A**Resume%20%2B%20complete-timeout%20triggers%20wrong%20guard%20message**%0A%0AWhen%20%60produce_sample_results%60%20is%20retried%20after%20a%20partial-completion%20timeout%20%28e.g.%2C%20%60t0%60%20finished%20and%20was%20saved%20with%20a%20score%2C%20%60t1%60%20got%20an%20error%20sample%20and%20will%20be%20retried%29%2C%20the%20second%20invocation%20sets%20%60pending%20%3D%20%5B%281%2C%20%22t1%22%29%5D%60%20and%20%60ran%20%3D%20%5B%22t1%22%5D%60.%20If%20%60t1%60%20times%20out%20again%20with%20nothing%20written%20to%20disk%2C%20%60_load_trials%60%20scans%20the%20shared%20%60jobs_dir%60%20and%20finds%20%60t0%60's%20%60result.json%60%20from%20the%20first%20run%20%E2%80%94%20so%20%60trials%20%3D%20%7B%22t0%22%3A%20...%7D%60.%20The%20guard%20then%20checks%20%60not%20any%28t%20in%20trials%20for%20t%20in%20ran%29%60%20%E2%86%92%20%60not%20%28%22t1%22%20in%20%7B%22t0%22%3A%20...%7D%29%60%20%E2%86%92%20%60True%60%20and%20raises%3A%0A%0A%3E%20*%22produced%201%20trial%20result%28s%29%2C%20but%20none%20match%20the%20requested%20task%20names%20%28requested%20e.g.%20't1'%3B%20recorded%20e.g.%20't0'%29.%20Task%20names%20must%20use%20harbor's%20canonical%20%60%3Corg%3E%2F%3Cname%3E%60%20form%22*%0A%0AThis%20is%20the%20wrong%20diagnosis%20%E2%80%94%20there%20is%20no%20keying%20mismatch%3B%20%60t1%60%20just%20keeps%20timing%20out.%20Before%20this%20PR%20the%20%60SubprocessTimeoutError%60%20propagated%20directly%20and%20gave%20the%20correct%20signal.%20The%20guard%20was%20designed%20to%20fire%20when%20ALL%20ran-task%20results%20are%20absent%20from%20%60trials%60%2C%20but%20it%20cannot%20distinguish%20%22absent%20because%20never%20written%20by%20this%20run%22%20from%20%22absent%20because%20a%20prior%20run%20wrote%20something%20else%22.%20A%20targeted%20fix%20is%20to%20restrict%20the%20guard's%20%60trials%60%20view%20to%20only%20those%20entries%20whose%20keys%20appear%20in%20%60ran%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fvero&pr=23&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-3-timeout-salvage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-3-timeout-salvage%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2Fsrc%2Fvero%2Fharbor%2Frunner.py%0ALine%3A%2061%0A%0AComment%3A%0A**Resume%20%2B%20complete-timeout%20triggers%20wrong%20guard%20message**%0A%0AWhen%20%60produce_sample_results%60%20is%20retried%20after%20a%20partial-completion%20timeout%20%28e.g.%2C%20%60t0%60%20finished%20and%20was%20saved%20with%20a%20score%2C%20%60t1%60%20got%20an%20error%20sample%20and%20will%20be%20retried%29%2C%20the%20second%20invocation%20sets%20%60pending%20%3D%20%5B%281%2C%20%22t1%22%29%5D%60%20and%20%60ran%20%3D%20%5B%22t1%22%5D%60.%20If%20%60t1%60%20times%20out%20again%20with%20nothing%20written%20to%20disk%2C%20%60_load_trials%60%20scans%20the%20shared%20%60jobs_dir%60%20and%20finds%20%60t0%60's%20%60result.json%60%20from%20the%20first%20run%20%E2%80%94%20so%20%60trials%20%3D%20%7B%22t0%22%3A%20...%7D%60.%20The%20guard%20then%20checks%20%60not%20any%28t%20in%20trials%20for%20t%20in%20ran%29%60%20%E2%86%92%20%60not%20%28%22t1%22%20in%20%7B%22t0%22%3A%20...%7D%29%60%20%E2%86%92%20%60True%60%20and%20raises%3A%0A%0A%3E%20*%22produced%201%20trial%20result%28s%29%2C%20but%20none%20match%20the%20requested%20task%20names%20%28requested%20e.g.%20't1'%3B%20recorded%20e.g.%20't0'%29.%20Task%20names%20must%20use%20harbor's%20canonical%20%60%3Corg%3E%2F%3Cname%3E%60%20form%22*%0A%0AThis%20is%20the%20wrong%20diagnosis%20%E2%80%94%20there%20is%20no%20keying%20mismatch%3B%20%60t1%60%20just%20keeps%20timing%20out.%20Before%20this%20PR%20the%20%60SubprocessTimeoutError%60%20propagated%20directly%20and%20gave%20the%20correct%20signal.%20The%20guard%20was%20designed%20to%20fire%20when%20ALL%20ran-task%20results%20are%20absent%20from%20%60trials%60%2C%20but%20it%20cannot%20distinguish%20%22absent%20because%20never%20written%20by%20this%20run%22%20from%20%22absent%20because%20a%20prior%20run%20wrote%20something%20else%22.%20A%20targeted%20fix%20is%20to%20restrict%20the%20guard's%20%60trials%60%20view%20to%20only%20those%20entries%20whose%20keys%20appear%20in%20%60ran%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fvero&pr=23&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(harbor): salvage completed trials wh..."](https://github.com/scaleapi/vero/commit/3dd10b8ac4cefc345fd08218a3fbe4028726a024) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41627520)</sub>

<!-- /greptile_comment -->