### PR TITLE
feat(harbor): expose score_baseline in the build YAML

### DIFF
--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -178,6 +178,7 @@ def _serve_config(config: BuildConfig, dataset_id: str | None, base_commit: str)
         "targets": targets,
         "base_commit": base_commit,
         "submit_enabled": config.submit_enabled,
+        "score_baseline": config.score_baseline,
         "agent_volume": AGENT_VOLUME,
         "admin_volume": ADMIN_VOLUME,
         "admin_token_path": TOKEN_PATH,

--- a/vero/src/vero/harbor/build/config.py
+++ b/vero/src/vero/harbor/build/config.py
@@ -66,6 +66,10 @@ class BuildConfig(BaseModel):
     selection_split: str = "validation"
     targets: list[TargetSpec] = Field(default_factory=list)
     submit_enabled: bool = False
+    # Also admin-score the unmodified baseline on every target at finalize and
+    # write it to <admin_volume>/baseline.json, so a candidate that generalizes
+    # WORSE than the untouched repo is visible as a regression.
+    score_baseline: bool = False
 
     # write-access: paths in the target repo the optimizer may NOT edit
     # (the scorer, by default). Applied as unix perms in main before the agent runs.

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -104,6 +104,30 @@ def test_serve_config_validates(built):
     assert cfg.budgets[0]["dataset_id"] == cfg.dataset_id
 
 
+def test_score_baseline_reaches_serve_json(built):
+    # Raw JSON on purpose: the key must be present in the compiler <-> serve
+    # contract even where the local ServeConfig predates the field.
+    raw = json.loads((built / "environment" / "sidecar" / "serve.json").read_text())
+    assert raw["score_baseline"] is False  # default off
+
+
+def test_score_baseline_true_emitted():
+    # Through the actual YAML path (not just the BuildConfig constructor), so
+    # the headline claim "reachable from build.yaml" is what is tested.
+    from vero.harbor.build.compiler import _serve_config
+
+    config = BuildConfig.model_validate(yaml.safe_load(
+        "name: o/n\n"
+        "agent_repo: .\n"
+        "splits:\n"
+        "  - {split: validation, access: non_viewable}\n"
+        "score_baseline: true\n"
+    ))
+    assert config.score_baseline is True
+    raw = _serve_config(config, "ds", "sha")
+    assert raw["score_baseline"] is True
+
+
 def test_rendered_files_parse(built):
     tomllib.loads((built / "task.toml").read_text())  # valid TOML
     compose = yaml.safe_load((built / "environment/docker-compose.yaml").read_text())

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -128,6 +128,24 @@ def test_score_baseline_true_emitted():
     assert raw["score_baseline"] is True
 
 
+def test_score_baseline_true_through_compile_task(tmp_path, monkeypatch):
+    # Full pipeline: a True value must survive compile_task into the written
+    # serve.json, not just the _serve_config helper.
+    monkeypatch.setenv("VERO_SKIP_SECRET_CHECK", "1")
+    config = BuildConfig(
+        name="vero/gsm8k-opt",
+        agent_repo=str(_agent_repo(tmp_path)),
+        mode="A",
+        task="gsm8k",
+        dataset=str(_dataset(tmp_path)),
+        splits=[{"split": "validation", "access": "non_viewable"}],
+        score_baseline=True,
+    )
+    out = compile_task(config, tmp_path / "task", vero_root=_stub_vero(tmp_path))
+    raw = json.loads((out / "environment" / "sidecar" / "serve.json").read_text())
+    assert raw["score_baseline"] is True
+
+
 def test_rendered_files_parse(built):
     tomllib.loads((built / "task.toml").read_text())  # valid TOML
     compose = yaml.safe_load((built / "environment/docker-compose.yaml").read_text())


### PR DESCRIPTION
Companion to #19 (sidecar stack); based on the compiler stack.

`ServeConfig.score_baseline` (admin-score the unmodified baseline at finalize, write `<admin_volume>/baseline.json` so regressions are visible) exists on the sidecar branch but was unreachable: `BuildConfig` had no such field, pydantic silently dropped it from YAML, and the compiler never emitted the key, so it was always False in a compiled task. The regression it detects is real: in our weak-model trial, auto_best's winner scored 0.2 on validation against the untouched repo's 0.3, invisibly.

This adds the field to `BuildConfig` and emits it into `serve.json`. Merge-order safe in both directions: where `ServeConfig` predates the field, the extra key is ignored (pydantic `extra=ignore`, pinned by a raw-JSON test); once #19 lands, the knob becomes live with no further change.

Tests: default `false` reaches serve.json through a full `compile_task`; `score_baseline: true` travels the actual YAML path (`yaml.safe_load` -> `model_validate` -> `_serve_config`).

Follow-ups deliberately not in scope: `extra="forbid"` on BuildConfig (a typo'd key anywhere in build.yaml is still silently dropped, worth its own PR), and documenting the knob in the harbor-4 docs branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes `score_baseline` from `build.yaml` through the full compiler pipeline into `serve.json`, fixing a silent Pydantic drop that had kept the feature permanently `False` in compiled tasks.

- **`config.py`**: Adds `score_baseline: bool = False` to `BuildConfig` with an explanatory comment.
- **`compiler.py`**: Emits `"score_baseline": config.score_baseline` into the `_serve_config` dict, wiring it into the compiler-to-sidecar contract.
- **`test_harbor_build.py`**: Adds three tests — default-`False` via raw JSON, `True` through the YAML→`model_validate`→`_serve_config` path, and `True` through the full `compile_task` pipeline — addressing the previous review comment about the `True` path lacking end-to-end coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, additive field that defaults to `False`, leaving all existing behavior unchanged.

The diff is a one-field addition to `BuildConfig`, one-line addition to `_serve_config`, and three well-layered tests. The default is `False`, so no existing compiled tasks change behavior. Forward compatibility is covered by pydantic `extra=ignore` on `ServeConfig`. The previously flagged gap (True path not tested through `compile_task`) is now closed by `test_score_baseline_true_through_compile_task`.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/config.py | Adds `score_baseline: bool = False` field to `BuildConfig` with a clear inline comment explaining its purpose; minimal and correct change. |
| vero/src/vero/harbor/build/compiler.py | Emits `score_baseline` into the `_serve_config` dict alongside `submit_enabled`; one-line change, correctly placed in the compiler-to-serve contract dict. |
| vero/tests/test_harbor_build.py | Adds three new tests covering default-False in raw JSON, True through YAML→`_serve_config`, and True through the full `compile_task` pipeline (addressing the previous review comment). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant YAML as build.yaml
    participant BC as BuildConfig
    participant SC as _serve_config()
    participant SJ as serve.json
    participant SVC as ServeConfig (sidecar)

    YAML->>BC: "yaml.safe_load → model_validate<br/>(score_baseline: true)"
    BC->>SC: config.score_baseline passed in
    SC->>SJ: "{"score_baseline": true, ...}"
    SJ->>SVC: "parsed at sidecar runtime<br/>(extra=ignore if field absent)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant YAML as build.yaml
    participant BC as BuildConfig
    participant SC as _serve_config()
    participant SJ as serve.json
    participant SVC as ServeConfig (sidecar)

    YAML->>BC: "yaml.safe_load → model_validate<br/>(score_baseline: true)"
    BC->>SC: config.score_baseline passed in
    SC->>SJ: "{"score_baseline": true, ...}"
    SJ->>SVC: "parsed at sidecar runtime<br/>(extra=ignore if field absent)"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(harbor): drive score\_baseline=True ..."](https://github.com/scaleapi/vero/commit/7f15d700919f7cd9ef111895417976593d71acbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41627532)</sub>

<!-- /greptile_comment -->