### PR TITLE
fix(harbor): instruction advertises the free baseline eval, gated on sidecar support

### DIFF
--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -24,6 +24,13 @@ logger = logging.getLogger(__name__)
 
 _TEMPLATES = Path(__file__).parent / "templates"
 
+# The StatusSummary field the sidecar sets to signal it grants the agent a free
+# baseline eval. The compiler renders the free-baseline instruction bullet only
+# when this field exists on the protocol shipping in the same tree (see the
+# free_baseline ctx entry). Kept as a named constant so the compiler<->protocol
+# coupling has one source: rename this and StatusSummary.<field> together.
+_FREE_BASELINE_FIELD = "free_baseline_available"
+
 # Container paths (must match the templates).
 VERO_DIR = "/opt/vero"
 AGENT_BASELINE = "/opt/agent-baseline"  # sidecar engine workspace
@@ -285,8 +292,11 @@ def compile_task(
         # different PR chain than the compiler, and an instruction that promises
         # it without it would send the agent to burn a metered eval on a commit
         # auto_best cannot select. Introspecting the protocol keeps the
-        # instruction truthful under any merge order.
-        free_baseline="free_baseline_available"
+        # instruction truthful under any merge order. _FREE_BASELINE_FIELD is the
+        # single source of the coupled field name: rename StatusSummary.<field> and
+        # this constant together (they cannot import-assert each other, since the
+        # field is absent on this branch's base until the sidecar PR merges).
+        free_baseline=_FREE_BASELINE_FIELD
         in {f.name for f in dataclasses.fields(StatusSummary)},
     )
     _render(jenv, "task.toml.j2", out / "task.toml", **ctx)

--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -8,6 +8,7 @@ with `harbor run -p <task-dir> -a <optimizer> -m <model> -e docker`.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import re
 import shutil
@@ -17,6 +18,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 from vero.harbor.build.config import BuildConfig
+from vero.harbor.protocol import StatusSummary
 
 logger = logging.getLogger(__name__)
 
@@ -278,6 +280,14 @@ def compile_task(
         submit_enabled=config.submit_enabled,
         eval_num_samples=None,
         bake_inner_task=bool(config.inner_task),
+        # The free-baseline bullet may only render when the sidecar shipping in
+        # this same tree actually grants the free eval; the feature lives on a
+        # different PR chain than the compiler, and an instruction that promises
+        # it without it would send the agent to burn a metered eval on a commit
+        # auto_best cannot select. Introspecting the protocol keeps the
+        # instruction truthful under any merge order.
+        free_baseline="free_baseline_available"
+        in {f.name for f in dataclasses.fields(StatusSummary)},
     )
     _render(jenv, "task.toml.j2", out / "task.toml", **ctx)
     _render(jenv, "instruction.md.j2", out / "instruction.md", **ctx)

--- a/vero/src/vero/harbor/build/templates/instruction.md.j2
+++ b/vero/src/vero/harbor/build/templates/instruction.md.j2
@@ -19,13 +19,24 @@ progress on the splits you *are* allowed to evaluate, within a fixed budget.
 {% if submit_enabled %}5. When done, nominate your best commit: `vero harbor submit`.{% else %}
 The best commit you evaluate on `{{ selection_split }}` is selected automatically and
 scored on the hidden test split at the end. Only commits *other than the seeded
-baseline* are selectable: evaluating the unmodified baseline spends budget without
-creating a candidate, so make sure at least one eval is of a commit that contains
-your changes.{% endif %}
+baseline* are selectable: baseline evals create no candidate, so make sure at least
+one eval is of a commit that contains your changes.{% endif %}
 
 ## Rules
 
 - Budget is finite and metered per split — spend it wisely.
+{% if free_baseline %}
+- Your first eval of the seeded baseline (the commit you started from) is
+  budget-free: once per task, not once per split, and it stays free after you have
+  made commits (`vero harbor eval --commit <baseline-sha> ...`). Take it on
+  `{{ selection_split }}` before your first candidate eval: it is the
+  reference score you must beat, and without it you cannot tell an improvement
+  from a regression. Repeat baseline evals are metered. `vero harbor status`
+  shows the baseline sha and whether the free eval is still available.
+{% endif %}
+- Scores are noisy. Unspent budget is wasted: if you finish with evals left, spend
+  them re-measuring your best candidate to confirm its score, or trying one more
+  variant, rather than stopping early.
 - The test split is hidden: you cannot evaluate it, and its labels never reach this
   container. Trying to read it will fail.
 - The scorer is locked. Only the eval sidecar scores.

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -4,6 +4,7 @@ task.toml / compose / scripts parse. No Docker (that's the e2e)."""
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import subprocess
 import tomllib
@@ -13,7 +14,15 @@ import pytest
 import yaml
 
 from vero.harbor.build import BuildConfig, compile_task
+from vero.harbor.protocol import StatusSummary
 from vero.harbor.serve import ServeConfig
+
+# Whether the sidecar in THIS tree grants the budget-free first baseline eval.
+# The feature and the compiler live on different PR chains; the instruction
+# tests below run the arm that matches whichever chains are merged here.
+_HAS_FREE_BASELINE = "free_baseline_available" in {
+    f.name for f in dataclasses.fields(StatusSummary)
+}
 
 
 def _stub_vero(root: Path) -> Path:
@@ -175,12 +184,52 @@ def test_instruction_warns_baseline_not_selectable(built):
     # baseline died with "no candidate experiments" at finalize).
     text = (built / "instruction.md").read_text()
     assert "other than the seeded" in text
-    assert "spends budget without" in text
+    assert "create no candidate" in text
+
+
+@pytest.mark.skipif(
+    not _HAS_FREE_BASELINE, reason="sidecar in this tree has no free baseline eval"
+)
+def test_instruction_advertises_free_baseline_eval(built):
+    # The sidecar gives the first baseline eval away free; the instruction must
+    # say so or the offer goes unclaimed (found live: an optimizer produced only
+    # regressing candidates and never learned where zero was, because the old
+    # wording told it baseline evals waste budget).
+    text = (built / "instruction.md").read_text()
+    assert "budget-free" in text
+    assert "reference score" in text
+    # ...and it must aim the one-per-task freebie at the split where candidates
+    # are compared, or a multi-split task can waste it.
+    assert "once per task" in text
+
+
+@pytest.mark.skipif(
+    _HAS_FREE_BASELINE, reason="sidecar in this tree grants the free baseline eval"
+)
+def test_instruction_omits_free_baseline_claim_when_unsupported(built):
+    # Merge-order guard: if the compiler chain lands without the free-baseline
+    # chain, the instruction must not promise a freebie the sidecar will meter;
+    # acting on that promise burns a metered eval on a commit auto_best cannot
+    # select (fatal on a run_budget=1 task).
+    text = (built / "instruction.md").read_text()
+    assert "budget-free" not in text
+
+
+def test_instruction_tells_agent_to_spend_whole_budget(built):
+    # Two live runs ended with nearly half the eval budget unspent; the
+    # instruction must state that unspent evals are wasted and re-measurement
+    # is a legitimate spend.
+    text = (built / "instruction.md").read_text()
+    assert "Unspent budget is wasted" in text
+    assert "re-measuring your best candidate" in text
 
 
 def test_submit_mode_instruction_has_no_baseline_warning(tmp_path, monkeypatch):
-    # The warning belongs to the auto_best branch only; pin the conditional
-    # boundary so a template refactor cannot leak it into submit-mode tasks.
+    # The not-selectable warning belongs to the auto_best branch only; pin the
+    # conditional boundary so a template refactor cannot leak it into
+    # submit-mode tasks. The free-baseline and spend-the-budget rules are
+    # mode-agnostic (metering does not depend on the selection mode) and must
+    # survive in both.
     monkeypatch.setenv("VERO_SKIP_SECRET_CHECK", "1")
     config = BuildConfig(
         name="vero/gsm8k-opt",
@@ -195,4 +244,6 @@ def test_submit_mode_instruction_has_no_baseline_warning(tmp_path, monkeypatch):
     out = compile_task(config, tmp_path / "task", vero_root=_stub_vero(tmp_path))
     text = (out / "instruction.md").read_text()
     assert "other than the seeded" not in text
-    assert "spends budget without" not in text
+    assert "create no candidate" not in text
+    assert ("budget-free" in text) == _HAS_FREE_BASELINE
+    assert "Unspent budget is wasted" in text


### PR DESCRIPTION
**Order-safe companion to #25.** The free-baseline bullet renders only when the vero tree being compiled actually grants the free eval (introspected from `StatusSummary`), so this PR merges safely in any order relative to #25; the bullet activates once both chains are in.

## Problem (two live findings, same root cause)

The compiled instruction under-informs the optimizer about budget economics:

1. **The instruction contradicts #25.** The auto_best paragraph (from #12) says baseline evals "spend budget without creating a candidate". Once #25 grants the first baseline eval budget-free, that wording actively steers the optimizer away from the free reference measurement. Observed live (GAIA weak-model run, 2026-07-03): the optimizer never claimed its free baseline (`free_baseline_available: true` the whole run) and produced three monotonically regressing candidates (0.25 -> 0.194 -> 0.167 on train) without ever learning that all of them were underwater vs the 0.317 baseline.
2. **Optimizers quit with budget unspent.** Two live runs ended with roughly half the eval budget unused (3 of 5; 3 of 7, plus 4 of 7 on the run above). Nothing tells the agent that unspent evals are wasted, or that re-measuring a noisy best candidate is a legitimate spend.

## Fix

- Reword the auto_best paragraph: "baseline evals create no candidate" (true both with and without #25) replaces the metering claim that #25 falsifies.
- New Rules bullet (rendered **only when the tree grants it**): first baseline eval is budget-free, once per task not per split, take it on the selection split before the first candidate eval, stays free after commits (`--commit <baseline-sha>`), repeats are metered.
- New Rules bullet (unconditional): scores are noisy; unspent budget is wasted; re-measure your best candidate or try one more variant rather than stopping early.
- Compiler passes `free_baseline` into the template context by introspecting `StatusSummary` for `free_baseline_available`, so the instruction can never promise an unmetered eval the sidecar would meter (acting on that promise burns a metered eval on a commit auto_best cannot select; fatal on a `total_run_budget: 1` task).

## Tests

Two-armed, honest on every chain: `test_instruction_advertises_free_baseline_eval` (skips where the tree lacks #25), `test_instruction_omits_free_baseline_claim_when_unsupported` (the merge-order guard; skips where the tree has #25), `test_instruction_tells_agent_to_spend_whole_budget` (unconditional), and the submit-mode boundary test now pins the mode-agnostic bullets with `== _HAS_FREE_BASELINE`. Verified green on both arms: this branch (12 passed, 1 skipped) and the #25-merged integration tree (21 passed, 1 skipped); the tests were also verified to fail against the old template.

## Review

Pre-open adversarial panel (3 lenses + blocker verification): 2 BLOCK verdicts, both the same verified merge-order hazard (an earlier draft rendered the bullet unconditionally); resolved by the conditional render + guard test above. Wording nits applied: once-per-task-not-per-split, freebie aimed at the selection split, removed a "(before any commits)" parenthetical that read as a validity condition.

Stacked on #12 (`harbor-3-compiler-instruction-warning`), whose warning text this updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Harbor optimizer instruction so it accurately describes baseline-eval economics. It rewrites the auto_best "spends budget without creating a candidate" paragraph (corrected to "create no candidate"), adds a conditionally-rendered free-baseline bullet (only when the current tree's `StatusSummary` includes the `free_baseline_available` field from PR #25), and adds an unconditional "unspent budget is wasted" bullet to stop optimizers from quitting early.

- **Compiler (`compiler.py`)**: Introspects `StatusSummary` at build time via `dataclasses.fields()` and passes `free_baseline` (bool) into the Jinja2 template context; the coupling is named via `_FREE_BASELINE_FIELD`.
- **Template (`instruction.md.j2`)**: Two new rule bullets — the free-baseline bullet is gated on `{% if free_baseline %}` and the spend-the-budget bullet is unconditional; both appear regardless of `submit_enabled`.
- **Tests (`test_harbor_build.py`)**: Two-armed skipif coverage for the free-baseline bullet, a new unconditional spend-budget test, and an updated submit-mode boundary test — all tied to a module-level `_HAS_FREE_BASELINE` flag derived from the same `StatusSummary` introspection.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the conditional render correctly prevents the instruction from advertising a free eval the sidecar does not yet grant.

The merge-order hazard was caught pre-open and resolved by introspecting `StatusSummary` at compile time. Both test arms are covered with skipif guards, the template whitespace is correct, and the unconditional spend-the-budget bullet is straightforward.

No files require special attention; the string-literal duplication in `test_harbor_build.py` is a maintenance nit that does not affect correctness on either merge-order branch today.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/compiler.py | Adds `_FREE_BASELINE_FIELD` constant and `free_baseline` template-context entry computed via `dataclasses.fields(StatusSummary)`; logic is correct and merge-order safe. |
| vero/src/vero/harbor/build/templates/instruction.md.j2 | Adds conditional free-baseline bullet and unconditional spend-the-budget bullet; template whitespace with `trim_blocks`/`lstrip_blocks` is correct. |
| vero/tests/test_harbor_build.py | Solid two-armed skipif coverage; `_HAS_FREE_BASELINE` duplicates the `"free_baseline_available"` string literal from the compiler rather than importing `_FREE_BASELINE_FIELD`, creating a silent divergence risk if the constant is ever renamed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["compile_task()"] --> B["dataclasses.fields(StatusSummary)"]
    B --> C{"'free_baseline_available'\nin field names?"}
    C -- "Yes (PR #25 merged)" --> D["free_baseline = True"]
    C -- "No (PR #25 absent)" --> E["free_baseline = False"]
    D --> F["Render instruction.md.j2\nwith free-baseline bullet"]
    E --> G["Render instruction.md.j2\nwithout free-baseline bullet"]
    F --> H["Agent sees: budget-free first baseline eval + unspent budget is wasted"]
    G --> I["Agent sees: unspent budget is wasted (no free-eval promise)"]

    style D fill:#c8e6c9
    style E fill:#fff9c4
    style H fill:#c8e6c9
    style I fill:#fff9c4
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["compile_task()"] --> B["dataclasses.fields(StatusSummary)"]
    B --> C{"'free_baseline_available'\nin field names?"}
    C -- "Yes (PR #25 merged)" --> D["free_baseline = True"]
    C -- "No (PR #25 absent)" --> E["free_baseline = False"]
    D --> F["Render instruction.md.j2\nwith free-baseline bullet"]
    E --> G["Render instruction.md.j2\nwithout free-baseline bullet"]
    F --> H["Agent sees: budget-free first baseline eval + unspent budget is wasted"]
    G --> I["Agent sees: unspent budget is wasted (no free-eval promise)"]

    style D fill:#c8e6c9
    style E fill:#fff9c4
    style H fill:#c8e6c9
    style I fill:#fff9c4
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(harbor): name the free-baseline..."](https://github.com/scaleapi/vero/commit/38f1195ca5395d57f9ab24686e1885820df707eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41686891)</sub>

<!-- /greptile_comment -->