### PR TITLE
fix(harbor): auto_best reverts to the baseline when no candidate beats it

### DIFF
--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -74,6 +74,9 @@ class ServeConfig(BaseModel):
     # Total attempts for the finalize baseline eval (>=1): a transient nested-run
     # failure once silently dropped the regression check.
     baseline_score_attempts: int = 2
+    # auto_best never ships a candidate that fails to beat the untouched baseline
+    # on the selection split; it reverts to base_commit instead (needs base_commit).
+    auto_best_baseline_floor: bool = True
 
     # volumes / token
     agent_volume: str
@@ -237,6 +240,7 @@ async def build_components(config: ServeConfig) -> tuple[EvaluationSidecar, Veri
         selection_dataset_id=config.dataset_id,
         score_baseline=config.score_baseline,
         baseline_score_attempts=config.baseline_score_attempts,
+        auto_best_baseline_floor=config.auto_best_baseline_floor,
     )
 
     token = generate_token()

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -54,6 +54,7 @@ class Verifier:
         rescore_top_k: int = 3,
         score_baseline: bool = False,
         baseline_score_attempts: int = 2,
+        auto_best_baseline_floor: bool = True,
     ):
         self.engine = engine
         self.admin_volume = Path(admin_volume)
@@ -68,6 +69,12 @@ class Verifier:
         self.selection_dataset_id = selection_dataset_id
         self.rescore_top_k = rescore_top_k
         self.score_baseline = score_baseline
+        # auto_best selection floor: never ship a candidate that fails to beat the
+        # untouched baseline on the selection split. Without it, auto_best (which
+        # excludes base_commit from the candidate pool) selects the least-bad
+        # candidate even when every candidate regressed, shipping a regression
+        # (observed live: a weak inner model, every candidate below baseline).
+        self.auto_best_baseline_floor = auto_best_baseline_floor
         # Baseline scoring is retried this many times total before its outcome is
         # reported as an error; the nested eval can fail transiently (a nested
         # harbor run crashing right after a large eval), and a single blip must
@@ -284,4 +291,36 @@ class Verifier:
             )
         # Highest admin score wins; ties break to the earliest shortlist position.
         rescored.sort(key=lambda t: (-t[0], t[1]))
-        return rescored[0][2]
+        best_score, _, best_commit = rescored[0]
+
+        # Selection floor: never ship a candidate that fails to beat the untouched
+        # baseline on the selection split. auto_best excludes base_commit from the
+        # candidate pool, so without this it selects the least-bad candidate even
+        # when every candidate regressed. Revert to the seed instead. Strict '>' so
+        # a statistical tie also reverts: if the optimizer cannot show an
+        # improvement, shipping the seed is the safe outcome. Needs a base_commit to
+        # compare against; costs one extra admin eval on the selection split.
+        if self.auto_best_baseline_floor and self.base_commit is not None:
+            base_dataset_id = self.selection_dataset_id
+            if base_dataset_id is None:
+                base_dataset_id = shortlist.iloc[0].get("dataset_subset_dataset_id")
+            base_exp = await self.engine.evaluate_admin(
+                task=self.selection_task,
+                dataset_id=base_dataset_id,
+                split=self.selection_split,
+                commit=self.base_commit,
+            )
+            base_s = base_exp.result.score()
+            base_score = float(base_s) if base_s is not None else default_minimum_score
+            if best_score <= base_score:
+                logger.info(
+                    "auto_best floor: best candidate %s (admin_score=%s) does not beat "
+                    "baseline %s (admin_score=%s); reverting to base_commit.",
+                    best_commit, best_score, self.base_commit, base_score,
+                )
+                return self.base_commit
+            logger.info(
+                "auto_best floor: best candidate %s (%s) beats baseline (%s); keeping it.",
+                best_commit, best_score, base_score,
+            )
+        return best_commit

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -111,7 +111,9 @@ class TestAutoBestSelection:
         assert rewards["reward"] == 0.95
 
     @pytest.mark.asyncio
-    async def test_auto_best_excludes_baseline_after_rescore(self, tmp_path):
+    async def test_auto_best_excludes_baseline_from_ranking(self, tmp_path):
+        # base_commit is excluded from the candidate ranking pool. Floor off here so
+        # the test isolates ranking-exclusion (the floor is covered separately below).
         engine = MagicMock()
         engine.db.get_experiments_df.return_value = pd.DataFrame(
             {
@@ -134,12 +136,176 @@ class TestAutoBestSelection:
             selection_split="validation",
             base_commit="base",
             selection_task="math",
+            auto_best_baseline_floor=False,
             targets=[VerificationTarget(task="math", dataset_id="ds1", split="test", reward_key="reward")],
         )
         await v.finalize()
         # baseline 'base' was never re-scored; 'agent' is selected + target-scored
         rescored_commits = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
         assert "base" not in rescored_commits
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"
+
+
+class TestAutoBestBaselineFloor:
+    """auto_best never ships a candidate that fails to beat the baseline.
+
+    auto_best excludes base_commit from the candidate pool, so without a floor it
+    selects the least-bad candidate even when every candidate regressed (observed
+    live: a weak inner model, every candidate below baseline, shipped a -0.10
+    regression despite the free baseline being available). The floor reverts to the
+    seed instead.
+    """
+
+    def _df(self):
+        return pd.DataFrame(
+            {
+                "dataset_subset_split": ["train", "train"],
+                "dataset_subset_dataset_id": ["ds1", "ds1"],
+                "candidate_commit": ["base", "agent"],
+                "mean_score": [0.3, 0.9],  # agent inflated its own recorded score
+                "candidate_created_at": [1, 2],
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_reverts_to_base_when_no_candidate_beats_baseline(self, tmp_path):
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = self._df()
+
+        # agent admin-scores 0.2 on the selection split; base admin-scores 0.3;
+        # the reverted base scores 0.35 on the target split (distinct values so the
+        # assertions can tell the target eval apart from the floor comparison).
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            if commit == "base":
+                score = 0.35 if split == "validation" else 0.3
+            else:
+                score = 0.2
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=score)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            base_commit="base",
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="validation", reward_key="reward")],
+        )
+        result = await v.finalize()
+        # winner reverted to base -> the emitted reward is the SEED's target-split
+        # score, not the regressed candidate's
+        assert result["rewards"] == {"reward": 0.35}
+        rescored = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
+        assert "base" in rescored  # base was admin-scored for the floor comparison
+        # the final call is the target eval of the reverted commit (validation split),
+        # not the floor comparison (train split)
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "base"
+        assert engine.evaluate_admin.await_args.kwargs["split"] == "validation"
+
+    @pytest.mark.asyncio
+    async def test_exact_tie_reverts_to_base(self, tmp_path):
+        # The floor uses '<=': a statistical tie reverts. If the optimizer cannot
+        # show an improvement, shipping the seed is the safe outcome. Pins the
+        # boundary so a refactor to '<' regresses loudly.
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = self._df()
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=0.3)))  # all equal
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            base_commit="base",
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="validation", reward_key="reward")],
+        )
+        await v.finalize()
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "base"
+
+    @pytest.mark.asyncio
+    async def test_floor_noop_without_base_commit(self, tmp_path):
+        # floor on (default) but base_commit=None: the floor must silently no-op,
+        # never issuing an eval with commit=None, and the best candidate ships.
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = pd.DataFrame(
+            {
+                "dataset_subset_split": ["train"],
+                "dataset_subset_dataset_id": ["ds1"],
+                "candidate_commit": ["agent"],
+                "mean_score": [0.9],
+                "candidate_created_at": [1],
+            }
+        )
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=0.5)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="validation", reward_key="reward")],
+        )
+        await v.finalize()
+        commits = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
+        assert None not in commits
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_keeps_candidate_that_beats_baseline(self, tmp_path):
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = self._df()
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            score = 0.3 if commit == "base" else 0.6  # agent genuinely improves
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=score)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            base_commit="base",
+            selection_task="math",
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="validation", reward_key="reward")],
+        )
+        await v.finalize()
+        # 'agent' beats base -> it is selected and target-scored
+        assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_floor_off_ships_least_bad_candidate(self, tmp_path):
+        # With the floor disabled, the old behavior stands: the best candidate is
+        # shipped even if it did not beat the baseline (base is never scored).
+        engine = MagicMock()
+        engine.db.get_experiments_df.return_value = self._df()
+
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+            return MagicMock(result=MagicMock(score=MagicMock(return_value=0.2)))
+
+        engine.evaluate_admin = AsyncMock(side_effect=_admin)
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="auto_best",
+            selection_split="train",
+            base_commit="base",
+            selection_task="math",
+            auto_best_baseline_floor=False,
+            targets=[VerificationTarget(task="math", dataset_id="ds1", split="validation", reward_key="reward")],
+        )
+        await v.finalize()
+        rescored = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
+        assert "base" not in rescored
         assert engine.evaluate_admin.await_args.kwargs["commit"] == "agent"
 
 
@@ -212,7 +378,8 @@ class TestNoCandidateFallback:
 
     @pytest.mark.asyncio
     async def test_candidates_present_keeps_normal_selection(self, tmp_path):
-        # Regression guard: the fallback must not swallow the normal path.
+        # Regression guard: the fallback must not swallow the normal path. Floor off
+        # so this isolates candidate selection (the floor is covered separately).
         engine = MagicMock()
         engine.db.get_experiments_df.return_value = pd.DataFrame(
             {
@@ -234,6 +401,7 @@ class TestNoCandidateFallback:
             reward_mode="auto_best",
             selection_split="train",
             base_commit="base",
+            auto_best_baseline_floor=False,
             targets=[VerificationTarget(task=None, dataset_id="ds1", split="validation", reward_key="accuracy")],
         )
         rewards = (await v.finalize())["rewards"]


### PR DESCRIPTION
## Problem (observed live, twice)

`auto_best` excludes `base_commit` from the candidate pool, so when every candidate regressed it still selected the least-bad one and shipped a regression. Observed in two independent weak-inner-model trials: candidates 0.25/0.194/0.167 shipped 0.267 vs a 0.367 baseline; then, **with the free-baseline reference available and actually claimed by the optimizer**, candidates 0.25/0.222/0.167 still shipped 0.167 vs a 0.267 baseline. Knowing where zero is did not stop the harm, because nothing acted on it: visibility without a selection floor.

## Fix

A selection floor in `_best_from_db`: after the admin re-score picks the best candidate, admin-score the untouched `base_commit` on the selection split and **revert to the seed when the best candidate does not strictly beat it**. A statistical tie also reverts: if the optimizer cannot demonstrate an improvement, shipping the unmodified seed is the safe outcome for the customer.

- `auto_best_baseline_floor` (default **on**), wired through `ServeConfig`; no-ops when `base_commit` is unset
- Uses the trusted admin scorer for the base eval (same trust posture as the shortlist re-score); costs one extra admin eval
- Logged either way (revert or keep) with both scores

## Tests

- reverts when the best candidate loses to the baseline: asserts the emitted reward is the seed's target-split score (not the regression) and the final eval is the target eval of the reverted commit
- exact tie reverts (pins the `<=` boundary against a refactor to `<`)
- candidate that beats the baseline is kept
- floor off restores the old behavior (base never scored)
- floor on with no `base_commit` silently no-ops (never evaluates `commit=None`)

Stacked on #27 (`harbor-2-baseline-durable`). An adversarial review panel (4 lenses + verification) ran pre-open; all confirmed findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a selection floor to `auto_best` mode: after admin re-scoring the candidate shortlist, the untouched `base_commit` is also admin-scored on the selection split, and the winner is reverted to the seed if it does not strictly beat it. The fix closes a real production path where every candidate regressed but the least-bad one was still shipped.

- **`verifier.py`**: New `auto_best_baseline_floor` flag (default `True`); in `_best_from_db`, after picking the best candidate, the base commit is admin-evaluated on the selection split and a `<=` comparison triggers a revert to `base_commit`. A `None` base_commit silently no-ops.
- **`serve.py`**: `ServeConfig` exposes the new flag and wires it through `build_components`.
- **`test_harbor_verifier.py`**: Five new tests cover revert-on-regression, exact-tie revert, floor no-op without base_commit, candidate-beats-baseline keep, and floor-off backward compatibility; existing tests updated to set `auto_best_baseline_floor=False` where they isolate unrelated ranking behavior.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The floor logic is sound and closes a real regression path; the one edge case (cross-dataset floor comparison when selection_dataset_id is unconfigured and the admin re-scoring reorders the shortlist) is unlikely to fire in well-configured deployments and has no effect when selection_dataset_id is set.

The core revert logic, the <= tie-break, and the base_commit=None no-op are all correct and well-tested. The dataset_id used for the base floor eval is borrowed from the top recorded-score shortlist entry rather than from the actual winner's row, which can make the comparison cross-dataset in the unconstrained-dataset scenario.

The dataset_id fallback in the floor block of vero/src/vero/harbor/verifier.py (lines 304-306) deserves a second look if selection_dataset_id is ever left unset in production configs.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/verifier.py | Adds the baseline floor in `_best_from_db`; one edge case in the `base_dataset_id` fallback can produce a cross-dataset floor comparison when `selection_dataset_id` is None and the admin re-scoring promotes a non-first shortlist entry. |
| vero/src/vero/harbor/serve.py | Adds `auto_best_baseline_floor: bool = True` to `ServeConfig` and passes it through to `Verifier`; straightforward wiring, no issues. |
| vero/tests/test_harbor_verifier.py | Five well-structured new tests cover the key floor boundaries (revert, tie, no-op, keep, floor-off); existing tests correctly updated with `auto_best_baseline_floor=False` to isolate their original concerns. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant F as finalize()
    participant B as _best_from_db()
    participant E as EvaluationEngine

    F->>B: _best_from_db()
    B->>E: get_experiments_df()
    E-->>B: df
    note over B: filter to selection_split,<br/>exclude base_commit,<br/>shortlist top-K by recorded score
    loop for each shortlisted candidate
        B->>E: "evaluate_admin(commit=candidate, split=selection_split)"
        E-->>B: admin_score
    end
    note over B: sort by admin_score -> best_commit

    alt "auto_best_baseline_floor=True AND base_commit set"
        B->>E: "evaluate_admin(commit=base_commit, split=selection_split)"
        E-->>B: base_score
        alt "best_score <= base_score"
            B-->>F: return base_commit (revert to seed)
        else "best_score > base_score"
            B-->>F: return best_commit
        end
    else floor disabled or no base_commit
        B-->>F: return best_commit
    end

    loop for each VerificationTarget
        F->>E: "evaluate_admin(commit=sha, split=target.split)"
        E-->>F: target score
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant F as finalize()
    participant B as _best_from_db()
    participant E as EvaluationEngine

    F->>B: _best_from_db()
    B->>E: get_experiments_df()
    E-->>B: df
    note over B: filter to selection_split,<br/>exclude base_commit,<br/>shortlist top-K by recorded score
    loop for each shortlisted candidate
        B->>E: "evaluate_admin(commit=candidate, split=selection_split)"
        E-->>B: admin_score
    end
    note over B: sort by admin_score -> best_commit

    alt "auto_best_baseline_floor=True AND base_commit set"
        B->>E: "evaluate_admin(commit=base_commit, split=selection_split)"
        E-->>B: base_score
        alt "best_score <= base_score"
            B-->>F: return base_commit (revert to seed)
        else "best_score > base_score"
            B-->>F: return best_commit
        end
    else floor disabled or no base_commit
        B-->>F: return best_commit
    end

    loop for each VerificationTarget
        F->>E: "evaluate_admin(commit=sha, split=target.split)"
        E-->>F: target score
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vero/src/vero/harbor/verifier.py`, line 270-306 ([link](https://github.com/scaleapi/vero/blob/9cce15bebfa86f40f2dcd54fdc847646b42541d5/vero/src/vero/harbor/verifier.py#L270-L306)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> When `selection_dataset_id` is `None`, `base_dataset_id` falls back to `shortlist.iloc[0].get("dataset_subset_dataset_id")` — the dataset of the highest *recorded-score* candidate. But the admin re-scoring can promote a different shortlist entry as `best_commit`, and each candidate is evaluated on its own row's `dataset_subset_dataset_id`. When those two entries differ, the floor compares `best_score` (scored on the winner's dataset) against `base_score` (scored on the first shortlist entry's dataset) — a cross-dataset comparison that can falsely keep or falsely revert. Storing the dataset_id in the `rescored` tuple and using the winner's own dataset_id for the base eval keeps the comparison apples-to-apples.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vero/src/vero/harbor/verifier.py
   Line: 270-306

   Comment:
   When `selection_dataset_id` is `None`, `base_dataset_id` falls back to `shortlist.iloc[0].get("dataset_subset_dataset_id")` — the dataset of the highest *recorded-score* candidate. But the admin re-scoring can promote a different shortlist entry as `best_commit`, and each candidate is evaluated on its own row's `dataset_subset_dataset_id`. When those two entries differ, the floor compares `best_score` (scored on the winner's dataset) against `base_score` (scored on the first shortlist entry's dataset) — a cross-dataset comparison that can falsely keep or falsely revert. Storing the dataset_id in the `rescored` tuple and using the winner's own dataset_id for the base eval keeps the comparison apples-to-apples.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%0ALine%3A%20270-306%0A%0AComment%3A%0AWhen%20%60selection_dataset_id%60%20is%20%60None%60%2C%20%60base_dataset_id%60%20falls%20back%20to%20%60shortlist.iloc%5B0%5D.get%28%22dataset_subset_dataset_id%22%29%60%20%E2%80%94%20the%20dataset%20of%20the%20highest%20*recorded-score*%20candidate.%20But%20the%20admin%20re-scoring%20can%20promote%20a%20different%20shortlist%20entry%20as%20%60best_commit%60%2C%20and%20each%20candidate%20is%20evaluated%20on%20its%20own%20row's%20%60dataset_subset_dataset_id%60.%20When%20those%20two%20entries%20differ%2C%20the%20floor%20compares%20%60best_score%60%20%28scored%20on%20the%20winner's%20dataset%29%20against%20%60base_score%60%20%28scored%20on%20the%20first%20shortlist%20entry's%20dataset%29%20%E2%80%94%20a%20cross-dataset%20comparison%20that%20can%20falsely%20keep%20or%20falsely%20revert.%20Storing%20the%20dataset_id%20in%20the%20%60rescored%60%20tuple%20and%20using%20the%20winner's%20own%20dataset_id%20for%20the%20base%20eval%20keeps%20the%20comparison%20apples-to-apples.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20rescored%3A%20list%5Btuple%5Bfloat%2C%20int%2C%20str%2C%20str%20%7C%20None%5D%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20idx%2C%20%28_%2C%20row%29%20in%20enumerate%28shortlist.iterrows%28%29%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20commit%20%3D%20row%5B%22candidate_commit%22%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%20%3D%20row.get%28%22dataset_subset_dataset_id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20exp%20%3D%20await%20self.engine.evaluate_admin%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20task%3Dself.selection_task%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%3Ddataset_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20split%3Dself.selection_split%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%3Dcommit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20exp.result.score%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20admin_score%20%3D%20float%28score%29%20if%20score%20is%20not%20None%20else%20default_minimum_score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Tie-break%20by%20shortlist%20position%20%28already%20ordered%20by%20recorded%20score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20then%20recency%29%2C%20so%20ties%20resolve%20deterministically%20without%20depending%20on%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20the%20type%20of%20candidate_created_at%20%28a%20datetime%20in%20the%20real%20DB%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20rescored.append%28%28admin_score%2C%20idx%2C%20commit%2C%20dataset_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22auto_best%20re-score%3A%20commit%3D%25s%20admin_score%3D%25s%20%28recorded%3D%25s%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20admin_score%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20row%5B%22mean_score%22%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%23%20Highest%20admin%20score%20wins%3B%20ties%20break%20to%20the%20earliest%20shortlist%20position.%0A%20%20%20%20%20%20%20%20rescored.sort%28key%3Dlambda%20t%3A%20%28-t%5B0%5D%2C%20t%5B1%5D%29%29%0A%20%20%20%20%20%20%20%20best_score%2C%20_%2C%20best_commit%2C%20best_dataset_id%20%3D%20rescored%5B0%5D%0A%0A%20%20%20%20%20%20%20%20%23%20Selection%20floor%3A%20never%20ship%20a%20candidate%20that%20fails%20to%20beat%20the%20untouched%0A%20%20%20%20%20%20%20%20%23%20baseline%20on%20the%20selection%20split.%20auto_best%20excludes%20base_commit%20from%20the%0A%20%20%20%20%20%20%20%20%23%20candidate%20pool%2C%20so%20without%20this%20it%20selects%20the%20least-bad%20candidate%20even%0A%20%20%20%20%20%20%20%20%23%20when%20every%20candidate%20regressed.%20Revert%20to%20the%20seed%20instead.%20Strict%20'%3E'%20so%0A%20%20%20%20%20%20%20%20%23%20a%20statistical%20tie%20also%20reverts%3A%20if%20the%20optimizer%20cannot%20show%20an%0A%20%20%20%20%20%20%20%20%23%20improvement%2C%20shipping%20the%20seed%20is%20the%20safe%20outcome.%20Needs%20a%20base_commit%20to%0A%20%20%20%20%20%20%20%20%23%20compare%20against%3B%20costs%20one%20extra%20admin%20eval%20on%20the%20selection%20split.%0A%20%20%20%20%20%20%20%20if%20self.auto_best_baseline_floor%20and%20self.base_commit%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20base_dataset_id%20%3D%20self.selection_dataset_id%20or%20best_dataset_id%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%0ALine%3A%20270-306%0A%0AComment%3A%0AWhen%20%60selection_dataset_id%60%20is%20%60None%60%2C%20%60base_dataset_id%60%20falls%20back%20to%20%60shortlist.iloc%5B0%5D.get%28%22dataset_subset_dataset_id%22%29%60%20%E2%80%94%20the%20dataset%20of%20the%20highest%20*recorded-score*%20candidate.%20But%20the%20admin%20re-scoring%20can%20promote%20a%20different%20shortlist%20entry%20as%20%60best_commit%60%2C%20and%20each%20candidate%20is%20evaluated%20on%20its%20own%20row's%20%60dataset_subset_dataset_id%60.%20When%20those%20two%20entries%20differ%2C%20the%20floor%20compares%20%60best_score%60%20%28scored%20on%20the%20winner's%20dataset%29%20against%20%60base_score%60%20%28scored%20on%20the%20first%20shortlist%20entry's%20dataset%29%20%E2%80%94%20a%20cross-dataset%20comparison%20that%20can%20falsely%20keep%20or%20falsely%20revert.%20Storing%20the%20dataset_id%20in%20the%20%60rescored%60%20tuple%20and%20using%20the%20winner's%20own%20dataset_id%20for%20the%20base%20eval%20keeps%20the%20comparison%20apples-to-apples.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20rescored%3A%20list%5Btuple%5Bfloat%2C%20int%2C%20str%2C%20str%20%7C%20None%5D%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20idx%2C%20%28_%2C%20row%29%20in%20enumerate%28shortlist.iterrows%28%29%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20commit%20%3D%20row%5B%22candidate_commit%22%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%20%3D%20row.get%28%22dataset_subset_dataset_id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20exp%20%3D%20await%20self.engine.evaluate_admin%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20task%3Dself.selection_task%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%3Ddataset_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20split%3Dself.selection_split%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%3Dcommit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20exp.result.score%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20admin_score%20%3D%20float%28score%29%20if%20score%20is%20not%20None%20else%20default_minimum_score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Tie-break%20by%20shortlist%20position%20%28already%20ordered%20by%20recorded%20score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20then%20recency%29%2C%20so%20ties%20resolve%20deterministically%20without%20depending%20on%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20the%20type%20of%20candidate_created_at%20%28a%20datetime%20in%20the%20real%20DB%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20rescored.append%28%28admin_score%2C%20idx%2C%20commit%2C%20dataset_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22auto_best%20re-score%3A%20commit%3D%25s%20admin_score%3D%25s%20%28recorded%3D%25s%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20admin_score%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20row%5B%22mean_score%22%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%23%20Highest%20admin%20score%20wins%3B%20ties%20break%20to%20the%20earliest%20shortlist%20position.%0A%20%20%20%20%20%20%20%20rescored.sort%28key%3Dlambda%20t%3A%20%28-t%5B0%5D%2C%20t%5B1%5D%29%29%0A%20%20%20%20%20%20%20%20best_score%2C%20_%2C%20best_commit%2C%20best_dataset_id%20%3D%20rescored%5B0%5D%0A%0A%20%20%20%20%20%20%20%20%23%20Selection%20floor%3A%20never%20ship%20a%20candidate%20that%20fails%20to%20beat%20the%20untouched%0A%20%20%20%20%20%20%20%20%23%20baseline%20on%20the%20selection%20split.%20auto_best%20excludes%20base_commit%20from%20the%0A%20%20%20%20%20%20%20%20%23%20candidate%20pool%2C%20so%20without%20this%20it%20selects%20the%20least-bad%20candidate%20even%0A%20%20%20%20%20%20%20%20%23%20when%20every%20candidate%20regressed.%20Revert%20to%20the%20seed%20instead.%20Strict%20'%3E'%20so%0A%20%20%20%20%20%20%20%20%23%20a%20statistical%20tie%20also%20reverts%3A%20if%20the%20optimizer%20cannot%20show%20an%0A%20%20%20%20%20%20%20%20%23%20improvement%2C%20shipping%20the%20seed%20is%20the%20safe%20outcome.%20Needs%20a%20base_commit%20to%0A%20%20%20%20%20%20%20%20%23%20compare%20against%3B%20costs%20one%20extra%20admin%20eval%20on%20the%20selection%20split.%0A%20%20%20%20%20%20%20%20if%20self.auto_best_baseline_floor%20and%20self.base_commit%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20base_dataset_id%20%3D%20self.selection_dataset_id%20or%20best_dataset_id%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fvero&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-2-autobest-baseline-floor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-2-autobest-baseline-floor%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%0ALine%3A%20270-306%0A%0AComment%3A%0AWhen%20%60selection_dataset_id%60%20is%20%60None%60%2C%20%60base_dataset_id%60%20falls%20back%20to%20%60shortlist.iloc%5B0%5D.get%28%22dataset_subset_dataset_id%22%29%60%20%E2%80%94%20the%20dataset%20of%20the%20highest%20*recorded-score*%20candidate.%20But%20the%20admin%20re-scoring%20can%20promote%20a%20different%20shortlist%20entry%20as%20%60best_commit%60%2C%20and%20each%20candidate%20is%20evaluated%20on%20its%20own%20row's%20%60dataset_subset_dataset_id%60.%20When%20those%20two%20entries%20differ%2C%20the%20floor%20compares%20%60best_score%60%20%28scored%20on%20the%20winner's%20dataset%29%20against%20%60base_score%60%20%28scored%20on%20the%20first%20shortlist%20entry's%20dataset%29%20%E2%80%94%20a%20cross-dataset%20comparison%20that%20can%20falsely%20keep%20or%20falsely%20revert.%20Storing%20the%20dataset_id%20in%20the%20%60rescored%60%20tuple%20and%20using%20the%20winner's%20own%20dataset_id%20for%20the%20base%20eval%20keeps%20the%20comparison%20apples-to-apples.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20rescored%3A%20list%5Btuple%5Bfloat%2C%20int%2C%20str%2C%20str%20%7C%20None%5D%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20idx%2C%20%28_%2C%20row%29%20in%20enumerate%28shortlist.iterrows%28%29%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20commit%20%3D%20row%5B%22candidate_commit%22%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%20%3D%20row.get%28%22dataset_subset_dataset_id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20exp%20%3D%20await%20self.engine.evaluate_admin%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20task%3Dself.selection_task%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%3Ddataset_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20split%3Dself.selection_split%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%3Dcommit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20exp.result.score%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20admin_score%20%3D%20float%28score%29%20if%20score%20is%20not%20None%20else%20default_minimum_score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Tie-break%20by%20shortlist%20position%20%28already%20ordered%20by%20recorded%20score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20then%20recency%29%2C%20so%20ties%20resolve%20deterministically%20without%20depending%20on%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20the%20type%20of%20candidate_created_at%20%28a%20datetime%20in%20the%20real%20DB%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20rescored.append%28%28admin_score%2C%20idx%2C%20commit%2C%20dataset_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22auto_best%20re-score%3A%20commit%3D%25s%20admin_score%3D%25s%20%28recorded%3D%25s%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20admin_score%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20row%5B%22mean_score%22%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%23%20Highest%20admin%20score%20wins%3B%20ties%20break%20to%20the%20earliest%20shortlist%20position.%0A%20%20%20%20%20%20%20%20rescored.sort%28key%3Dlambda%20t%3A%20%28-t%5B0%5D%2C%20t%5B1%5D%29%29%0A%20%20%20%20%20%20%20%20best_score%2C%20_%2C%20best_commit%2C%20best_dataset_id%20%3D%20rescored%5B0%5D%0A%0A%20%20%20%20%20%20%20%20%23%20Selection%20floor%3A%20never%20ship%20a%20candidate%20that%20fails%20to%20beat%20the%20untouched%0A%20%20%20%20%20%20%20%20%23%20baseline%20on%20the%20selection%20split.%20auto_best%20excludes%20base_commit%20from%20the%0A%20%20%20%20%20%20%20%20%23%20candidate%20pool%2C%20so%20without%20this%20it%20selects%20the%20least-bad%20candidate%20even%0A%20%20%20%20%20%20%20%20%23%20when%20every%20candidate%20regressed.%20Revert%20to%20the%20seed%20instead.%20Strict%20'%3E'%20so%0A%20%20%20%20%20%20%20%20%23%20a%20statistical%20tie%20also%20reverts%3A%20if%20the%20optimizer%20cannot%20show%20an%0A%20%20%20%20%20%20%20%20%23%20improvement%2C%20shipping%20the%20seed%20is%20the%20safe%20outcome.%20Needs%20a%20base_commit%20to%0A%20%20%20%20%20%20%20%20%23%20compare%20against%3B%20costs%20one%20extra%20admin%20eval%20on%20the%20selection%20split.%0A%20%20%20%20%20%20%20%20if%20self.auto_best_baseline_floor%20and%20self.base_commit%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20base_dataset_id%20%3D%20self.selection_dataset_id%20or%20best_dataset_id%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fvero&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A270-306%0AWhen%20%60selection_dataset_id%60%20is%20%60None%60%2C%20%60base_dataset_id%60%20falls%20back%20to%20%60shortlist.iloc%5B0%5D.get%28%22dataset_subset_dataset_id%22%29%60%20%E2%80%94%20the%20dataset%20of%20the%20highest%20*recorded-score*%20candidate.%20But%20the%20admin%20re-scoring%20can%20promote%20a%20different%20shortlist%20entry%20as%20%60best_commit%60%2C%20and%20each%20candidate%20is%20evaluated%20on%20its%20own%20row's%20%60dataset_subset_dataset_id%60.%20When%20those%20two%20entries%20differ%2C%20the%20floor%20compares%20%60best_score%60%20%28scored%20on%20the%20winner's%20dataset%29%20against%20%60base_score%60%20%28scored%20on%20the%20first%20shortlist%20entry's%20dataset%29%20%E2%80%94%20a%20cross-dataset%20comparison%20that%20can%20falsely%20keep%20or%20falsely%20revert.%20Storing%20the%20dataset_id%20in%20the%20%60rescored%60%20tuple%20and%20using%20the%20winner's%20own%20dataset_id%20for%20the%20base%20eval%20keeps%20the%20comparison%20apples-to-apples.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20rescored%3A%20list%5Btuple%5Bfloat%2C%20int%2C%20str%2C%20str%20%7C%20None%5D%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20idx%2C%20%28_%2C%20row%29%20in%20enumerate%28shortlist.iterrows%28%29%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20commit%20%3D%20row%5B%22candidate_commit%22%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%20%3D%20row.get%28%22dataset_subset_dataset_id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20exp%20%3D%20await%20self.engine.evaluate_admin%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20task%3Dself.selection_task%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%3Ddataset_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20split%3Dself.selection_split%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%3Dcommit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20exp.result.score%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20admin_score%20%3D%20float%28score%29%20if%20score%20is%20not%20None%20else%20default_minimum_score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Tie-break%20by%20shortlist%20position%20%28already%20ordered%20by%20recorded%20score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20then%20recency%29%2C%20so%20ties%20resolve%20deterministically%20without%20depending%20on%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20the%20type%20of%20candidate_created_at%20%28a%20datetime%20in%20the%20real%20DB%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20rescored.append%28%28admin_score%2C%20idx%2C%20commit%2C%20dataset_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22auto_best%20re-score%3A%20commit%3D%25s%20admin_score%3D%25s%20%28recorded%3D%25s%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20admin_score%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20row%5B%22mean_score%22%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%23%20Highest%20admin%20score%20wins%3B%20ties%20break%20to%20the%20earliest%20shortlist%20position.%0A%20%20%20%20%20%20%20%20rescored.sort%28key%3Dlambda%20t%3A%20%28-t%5B0%5D%2C%20t%5B1%5D%29%29%0A%20%20%20%20%20%20%20%20best_score%2C%20_%2C%20best_commit%2C%20best_dataset_id%20%3D%20rescored%5B0%5D%0A%0A%20%20%20%20%20%20%20%20%23%20Selection%20floor%3A%20never%20ship%20a%20candidate%20that%20fails%20to%20beat%20the%20untouched%0A%20%20%20%20%20%20%20%20%23%20baseline%20on%20the%20selection%20split.%20auto_best%20excludes%20base_commit%20from%20the%0A%20%20%20%20%20%20%20%20%23%20candidate%20pool%2C%20so%20without%20this%20it%20selects%20the%20least-bad%20candidate%20even%0A%20%20%20%20%20%20%20%20%23%20when%20every%20candidate%20regressed.%20Revert%20to%20the%20seed%20instead.%20Strict%20'%3E'%20so%0A%20%20%20%20%20%20%20%20%23%20a%20statistical%20tie%20also%20reverts%3A%20if%20the%20optimizer%20cannot%20show%20an%0A%20%20%20%20%20%20%20%20%23%20improvement%2C%20shipping%20the%20seed%20is%20the%20safe%20outcome.%20Needs%20a%20base_commit%20to%0A%20%20%20%20%20%20%20%20%23%20compare%20against%3B%20costs%20one%20extra%20admin%20eval%20on%20the%20selection%20split.%0A%20%20%20%20%20%20%20%20if%20self.auto_best_baseline_floor%20and%20self.base_commit%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20base_dataset_id%20%3D%20self.selection_dataset_id%20or%20best_dataset_id%0A%60%60%60%0A%0A&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A270-306%0AWhen%20%60selection_dataset_id%60%20is%20%60None%60%2C%20%60base_dataset_id%60%20falls%20back%20to%20%60shortlist.iloc%5B0%5D.get%28%22dataset_subset_dataset_id%22%29%60%20%E2%80%94%20the%20dataset%20of%20the%20highest%20*recorded-score*%20candidate.%20But%20the%20admin%20re-scoring%20can%20promote%20a%20different%20shortlist%20entry%20as%20%60best_commit%60%2C%20and%20each%20candidate%20is%20evaluated%20on%20its%20own%20row's%20%60dataset_subset_dataset_id%60.%20When%20those%20two%20entries%20differ%2C%20the%20floor%20compares%20%60best_score%60%20%28scored%20on%20the%20winner's%20dataset%29%20against%20%60base_score%60%20%28scored%20on%20the%20first%20shortlist%20entry's%20dataset%29%20%E2%80%94%20a%20cross-dataset%20comparison%20that%20can%20falsely%20keep%20or%20falsely%20revert.%20Storing%20the%20dataset_id%20in%20the%20%60rescored%60%20tuple%20and%20using%20the%20winner's%20own%20dataset_id%20for%20the%20base%20eval%20keeps%20the%20comparison%20apples-to-apples.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20rescored%3A%20list%5Btuple%5Bfloat%2C%20int%2C%20str%2C%20str%20%7C%20None%5D%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20idx%2C%20%28_%2C%20row%29%20in%20enumerate%28shortlist.iterrows%28%29%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20commit%20%3D%20row%5B%22candidate_commit%22%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%20%3D%20row.get%28%22dataset_subset_dataset_id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20exp%20%3D%20await%20self.engine.evaluate_admin%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20task%3Dself.selection_task%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%3Ddataset_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20split%3Dself.selection_split%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%3Dcommit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20exp.result.score%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20admin_score%20%3D%20float%28score%29%20if%20score%20is%20not%20None%20else%20default_minimum_score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Tie-break%20by%20shortlist%20position%20%28already%20ordered%20by%20recorded%20score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20then%20recency%29%2C%20so%20ties%20resolve%20deterministically%20without%20depending%20on%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20the%20type%20of%20candidate_created_at%20%28a%20datetime%20in%20the%20real%20DB%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20rescored.append%28%28admin_score%2C%20idx%2C%20commit%2C%20dataset_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22auto_best%20re-score%3A%20commit%3D%25s%20admin_score%3D%25s%20%28recorded%3D%25s%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20admin_score%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20row%5B%22mean_score%22%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%23%20Highest%20admin%20score%20wins%3B%20ties%20break%20to%20the%20earliest%20shortlist%20position.%0A%20%20%20%20%20%20%20%20rescored.sort%28key%3Dlambda%20t%3A%20%28-t%5B0%5D%2C%20t%5B1%5D%29%29%0A%20%20%20%20%20%20%20%20best_score%2C%20_%2C%20best_commit%2C%20best_dataset_id%20%3D%20rescored%5B0%5D%0A%0A%20%20%20%20%20%20%20%20%23%20Selection%20floor%3A%20never%20ship%20a%20candidate%20that%20fails%20to%20beat%20the%20untouched%0A%20%20%20%20%20%20%20%20%23%20baseline%20on%20the%20selection%20split.%20auto_best%20excludes%20base_commit%20from%20the%0A%20%20%20%20%20%20%20%20%23%20candidate%20pool%2C%20so%20without%20this%20it%20selects%20the%20least-bad%20candidate%20even%0A%20%20%20%20%20%20%20%20%23%20when%20every%20candidate%20regressed.%20Revert%20to%20the%20seed%20instead.%20Strict%20'%3E'%20so%0A%20%20%20%20%20%20%20%20%23%20a%20statistical%20tie%20also%20reverts%3A%20if%20the%20optimizer%20cannot%20show%20an%0A%20%20%20%20%20%20%20%20%23%20improvement%2C%20shipping%20the%20seed%20is%20the%20safe%20outcome.%20Needs%20a%20base_commit%20to%0A%20%20%20%20%20%20%20%20%23%20compare%20against%3B%20costs%20one%20extra%20admin%20eval%20on%20the%20selection%20split.%0A%20%20%20%20%20%20%20%20if%20self.auto_best_baseline_floor%20and%20self.base_commit%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20base_dataset_id%20%3D%20self.selection_dataset_id%20or%20best_dataset_id%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22harbor-2-autobest-baseline-floor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harbor-2-autobest-baseline-floor%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Avero%2Fsrc%2Fvero%2Fharbor%2Fverifier.py%3A270-306%0AWhen%20%60selection_dataset_id%60%20is%20%60None%60%2C%20%60base_dataset_id%60%20falls%20back%20to%20%60shortlist.iloc%5B0%5D.get%28%22dataset_subset_dataset_id%22%29%60%20%E2%80%94%20the%20dataset%20of%20the%20highest%20*recorded-score*%20candidate.%20But%20the%20admin%20re-scoring%20can%20promote%20a%20different%20shortlist%20entry%20as%20%60best_commit%60%2C%20and%20each%20candidate%20is%20evaluated%20on%20its%20own%20row's%20%60dataset_subset_dataset_id%60.%20When%20those%20two%20entries%20differ%2C%20the%20floor%20compares%20%60best_score%60%20%28scored%20on%20the%20winner's%20dataset%29%20against%20%60base_score%60%20%28scored%20on%20the%20first%20shortlist%20entry's%20dataset%29%20%E2%80%94%20a%20cross-dataset%20comparison%20that%20can%20falsely%20keep%20or%20falsely%20revert.%20Storing%20the%20dataset_id%20in%20the%20%60rescored%60%20tuple%20and%20using%20the%20winner's%20own%20dataset_id%20for%20the%20base%20eval%20keeps%20the%20comparison%20apples-to-apples.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20rescored%3A%20list%5Btuple%5Bfloat%2C%20int%2C%20str%2C%20str%20%7C%20None%5D%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20idx%2C%20%28_%2C%20row%29%20in%20enumerate%28shortlist.iterrows%28%29%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20commit%20%3D%20row%5B%22candidate_commit%22%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%20%3D%20row.get%28%22dataset_subset_dataset_id%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20exp%20%3D%20await%20self.engine.evaluate_admin%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20task%3Dself.selection_task%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataset_id%3Ddataset_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20split%3Dself.selection_split%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%3Dcommit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20exp.result.score%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20admin_score%20%3D%20float%28score%29%20if%20score%20is%20not%20None%20else%20default_minimum_score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Tie-break%20by%20shortlist%20position%20%28already%20ordered%20by%20recorded%20score%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20then%20recency%29%2C%20so%20ties%20resolve%20deterministically%20without%20depending%20on%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20the%20type%20of%20candidate_created_at%20%28a%20datetime%20in%20the%20real%20DB%29.%0A%20%20%20%20%20%20%20%20%20%20%20%20rescored.append%28%28admin_score%2C%20idx%2C%20commit%2C%20dataset_id%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22auto_best%20re-score%3A%20commit%3D%25s%20admin_score%3D%25s%20%28recorded%3D%25s%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20commit%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20admin_score%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20row%5B%22mean_score%22%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%23%20Highest%20admin%20score%20wins%3B%20ties%20break%20to%20the%20earliest%20shortlist%20position.%0A%20%20%20%20%20%20%20%20rescored.sort%28key%3Dlambda%20t%3A%20%28-t%5B0%5D%2C%20t%5B1%5D%29%29%0A%20%20%20%20%20%20%20%20best_score%2C%20_%2C%20best_commit%2C%20best_dataset_id%20%3D%20rescored%5B0%5D%0A%0A%20%20%20%20%20%20%20%20%23%20Selection%20floor%3A%20never%20ship%20a%20candidate%20that%20fails%20to%20beat%20the%20untouched%0A%20%20%20%20%20%20%20%20%23%20baseline%20on%20the%20selection%20split.%20auto_best%20excludes%20base_commit%20from%20the%0A%20%20%20%20%20%20%20%20%23%20candidate%20pool%2C%20so%20without%20this%20it%20selects%20the%20least-bad%20candidate%20even%0A%20%20%20%20%20%20%20%20%23%20when%20every%20candidate%20regressed.%20Revert%20to%20the%20seed%20instead.%20Strict%20'%3E'%20so%0A%20%20%20%20%20%20%20%20%23%20a%20statistical%20tie%20also%20reverts%3A%20if%20the%20optimizer%20cannot%20show%20an%0A%20%20%20%20%20%20%20%20%23%20improvement%2C%20shipping%20the%20seed%20is%20the%20safe%20outcome.%20Needs%20a%20base_commit%20to%0A%20%20%20%20%20%20%20%20%23%20compare%20against%3B%20costs%20one%20extra%20admin%20eval%20on%20the%20selection%20split.%0A%20%20%20%20%20%20%20%20if%20self.auto_best_baseline_floor%20and%20self.base_commit%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20base_dataset_id%20%3D%20self.selection_dataset_id%20or%20best_dataset_id%0A%60%60%60%0A%0A&repo=scaleapi%2Fvero&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vero/src/vero/harbor/verifier.py:270-306
When `selection_dataset_id` is `None`, `base_dataset_id` falls back to `shortlist.iloc[0].get("dataset_subset_dataset_id")` — the dataset of the highest *recorded-score* candidate. But the admin re-scoring can promote a different shortlist entry as `best_commit`, and each candidate is evaluated on its own row's `dataset_subset_dataset_id`. When those two entries differ, the floor compares `best_score` (scored on the winner's dataset) against `base_score` (scored on the first shortlist entry's dataset) — a cross-dataset comparison that can falsely keep or falsely revert. Storing the dataset_id in the `rescored` tuple and using the winner's own dataset_id for the base eval keeps the comparison apples-to-apples.

```suggestion
        rescored: list[tuple[float, int, str, str | None]] = []
        for idx, (_, row) in enumerate(shortlist.iterrows()):
            commit = row["candidate_commit"]
            dataset_id = row.get("dataset_subset_dataset_id")
            exp = await self.engine.evaluate_admin(
                task=self.selection_task,
                dataset_id=dataset_id,
                split=self.selection_split,
                commit=commit,
            )
            score = exp.result.score()
            admin_score = float(score) if score is not None else default_minimum_score
            # Tie-break by shortlist position (already ordered by recorded score
            # then recency), so ties resolve deterministically without depending on
            # the type of candidate_created_at (a datetime in the real DB).
            rescored.append((admin_score, idx, commit, dataset_id))
            logger.info(
                "auto_best re-score: commit=%s admin_score=%s (recorded=%s)",
                commit,
                admin_score,
                row["mean_score"],
            )
        # Highest admin score wins; ties break to the earliest shortlist position.
        rescored.sort(key=lambda t: (-t[0], t[1]))
        best_score, _, best_commit, best_dataset_id = rescored[0]

        # Selection floor: never ship a candidate that fails to beat the untouched
        # baseline on the selection split. auto_best excludes base_commit from the
        # candidate pool, so without this it selects the least-bad candidate even
        # when every candidate regressed. Revert to the seed instead. Strict '>' so
        # a statistical tie also reverts: if the optimizer cannot show an
        # improvement, shipping the seed is the safe outcome. Needs a base_commit to
        # compare against; costs one extra admin eval on the selection split.
        if self.auto_best_baseline_floor and self.base_commit is not None:
            base_dataset_id = self.selection_dataset_id or best_dataset_id
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(harbor): auto\_best reverts to the ba..."](https://github.com/scaleapi/vero/commit/9cce15bebfa86f40f2dcd54fdc847646b42541d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41818502)</sub>

<!-- /greptile_comment -->