### PR TITLE
feat(harbor): operator dashboard for watching optimization trials live

### DIFF
--- a/vero/src/vero/harbor/cli.py
+++ b/vero/src/vero/harbor/cli.py
@@ -125,3 +125,26 @@ def finalize_cmd(token_file, output):
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(reward))
     click.echo(json.dumps(reward, indent=2))
+
+
+@harbor.command("dashboard")
+@click.option("--meta", "meta_path", type=click.Path(path_type=Path), default=None,
+              help="JSON with experiment questions, pre-registered bars, and a scorecard.")
+@click.option("--jobs", "jobs_dirs", type=click.Path(path_type=Path), multiple=True,
+              help="Harbor jobs dir(s) to scan for reward.json finals. Repeatable.")
+@click.option("--host", default="127.0.0.1", show_default=True,
+              help="Bind address. Ledger rows include hidden-split scores; keep it local.")
+@click.option("--port", default=8300, show_default=True)
+def dashboard_cmd(meta_path, jobs_dirs, host, port):
+    """Operator dashboard: watch running optimization trials live (host-side).
+
+    Discovers eval-sidecar containers via docker, tails each trial's ledger
+    through the admin /experiments endpoint, scans jobs dirs for finals, and
+    serves a self-refreshing status page. Admin-side tool: run it where the
+    trials run, not inside a task container.
+    """
+    from vero.harbor.dashboard import DashboardConfig, serve_dashboard
+
+    serve_dashboard(DashboardConfig(
+        meta_path=meta_path, jobs_dirs=list(jobs_dirs), host=host, port=port,
+    ))

--- a/vero/src/vero/harbor/dashboard.py
+++ b/vero/src/vero/harbor/dashboard.py
@@ -290,10 +290,14 @@ async function refresh() {
     </div>`;
   }).join("");
   const h = d.history || [];
-  document.getElementById("hist").innerHTML = h.length ? `<h1>scorecard</h1><table>
-    <tr><th>exp</th><th>question</th><th>baseline</th><th>bar</th><th>final</th><th>verdict</th></tr>` +
+  document.getElementById("hist").innerHTML = h.length ? `<h1>scorecard: finished experiments</h1>
+    <div class="sub">baseline = the unmodified agent's score before optimization &middot;
+    bar = the pre-registered score the optimized agent had to beat &middot;
+    final = what the optimized agent actually scored on the hidden test set</div><table>
+    <tr><th>exp</th><th>question</th><th>baseline</th><th>bar</th><th>final</th><th>outcome</th><th>what happened</th></tr>` +
     h.map(x => `<tr><td>${x.exp}</td><td>${x.question}</td><td>${x.baseline ?? "-"}</td>
-      <td>${x.bar ?? "-"}</td><td>${x.final ?? "-"}</td><td>${x.verdict ?? "-"}</td></tr>`).join("") + "</table>" : "";
+      <td>${x.bar ?? "-"}</td><td>${x.final ?? "-"}</td><td>${x.verdict ?? "-"}</td>
+      <td>${x.summary ?? "-"}</td></tr>`).join("") + "</table>" : "";
   document.getElementById("ts").textContent = "updated " + new Date().toLocaleTimeString();
 }
 refresh(); setInterval(refresh, 20000);

--- a/vero/src/vero/harbor/dashboard.py
+++ b/vero/src/vero/harbor/dashboard.py
@@ -1,0 +1,345 @@
+"""Local dashboard for watching Harbor optimization trials.
+
+``vero harbor dashboard`` serves a single-page UI (stdlib HTTP server, no new
+dependencies) that answers, at a glance: which experiments are running, what
+each one is doing right now, and how finished ones scored against their
+pre-registered bars.
+
+Data sources, all local to the operator's machine:
+
+- ``docker ps`` discovers live eval-sidecar containers (one per running trial).
+- Each sidecar's admin ``/experiments`` endpoint (via ``docker exec``, using the
+  in-container admin token) provides the live ledger: one row per recorded
+  eval (commit, split, score, error rate). This is the same admin-observability
+  surface the ``/experiments`` endpoint was added for; the dashboard never
+  reaches into agent volumes.
+- ``/status`` (agent-facing, unauthenticated) provides remaining budget.
+- Harbor jobs directories are scanned for ``reward.json`` (the trial's final).
+- An optional ``--meta`` JSON file supplies display context the containers
+  cannot know: the experiment's question, pre-registered bars (baseline /
+  win bar / healthy ceiling), notes, and a scorecard of finished experiments.
+
+The server binds 127.0.0.1 by default: ledger rows include hidden-split scores,
+so the page is for the operator's eyes, not the network's.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SIDECAR_SUFFIX = "-eval-sidecar-1"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested; no docker, no filesystem)
+# ---------------------------------------------------------------------------
+
+
+def experiment_key(container_name: str) -> str | None:
+    """``<task>__<runid>-eval-sidecar-1`` -> ``<task>`` (None if not a sidecar).
+
+    Harbor composes container names as ``<project>-eval-sidecar-1`` where the
+    project is ``<task-dir-name>__<random>``; the task dir name is the stable
+    key an operator recognizes (e.g. ``gaia-exp11-task``).
+    """
+    if not container_name.endswith(SIDECAR_SUFFIX):
+        return None
+    project = container_name[: -len(SIDECAR_SUFFIX)]
+    return project.split("__")[0] if "__" in project else project
+
+
+def derive_phase(*, has_container: bool, n_rounds: int, final: dict | None) -> str:
+    """One word for where a trial is: building -> running -> done (or gone).
+
+    ``gone`` = no live container and no reward.json: either torn down abnormally
+    or never started; the operator should look at the launch log.
+    """
+    if final is not None:
+        return "done"
+    if has_container:
+        return "running" if n_rounds > 0 else "building"
+    return "gone"
+
+
+def verdict(final: dict | None, bars: dict | None) -> str | None:
+    """WIN / MISS against the pre-registered win bar, when both are known."""
+    if not final or not bars or "win_bar" not in bars:
+        return None
+    scores = [v for v in final.values() if isinstance(v, (int, float))]
+    if not scores:
+        return None
+    return "WIN" if scores[0] > bars["win_bar"] else "MISS"
+
+
+def normalize_rounds(payload: dict | None) -> list[dict]:
+    """/experiments payload -> display rows (newest last), tolerant of Nones."""
+    rows = []
+    for e in (payload or {}).get("experiments", []):
+        rows.append(
+            {
+                "commit": str(e.get("commit") or "")[:10],
+                "split": e.get("split"),
+                "score": e.get("mean_score"),
+                "error_rate": e.get("error_rate"),
+                "created_at": e.get("created_at"),
+            }
+        )
+    return rows
+
+
+def merge_status(
+    *,
+    meta: dict,
+    sidecars: dict[str, dict],
+    finals: dict[str, dict],
+) -> dict:
+    """Join meta-declared experiments with live containers and finished rewards.
+
+    Experiments the meta file does not mention still appear (key only), so a
+    running trial is never invisible just because the operator forgot to list
+    it. Meta-only entries appear too, phase ``gone``, so a crashed launch is
+    conspicuous rather than silently absent.
+    """
+    keys = list(
+        dict.fromkeys(
+            [e["key"] for e in meta.get("experiments", [])]
+            + list(sidecars)
+            + list(finals)
+        )
+    )
+    by_key = {e["key"]: e for e in meta.get("experiments", [])}
+    out = []
+    for key in keys:
+        m = by_key.get(key, {})
+        live = sidecars.get(key)
+        final = finals.get(key)
+        rounds = normalize_rounds(live.get("experiments") if live else None)
+        out.append(
+            {
+                "key": key,
+                "title": m.get("title", key),
+                "question": m.get("question"),
+                "bars": m.get("bars"),
+                "note": m.get("note"),
+                "phase": derive_phase(
+                    has_container=live is not None,
+                    n_rounds=len(rounds),
+                    final=final,
+                ),
+                "rounds": rounds,
+                "budget": (live or {}).get("status", {}).get("splits"),
+                "final": final,
+                "verdict": verdict(final, m.get("bars")),
+            }
+        )
+    return {"experiments": out, "history": meta.get("history", [])}
+
+
+# ---------------------------------------------------------------------------
+# Collectors (thin side-effecting shims around docker + the filesystem)
+# ---------------------------------------------------------------------------
+
+
+def _docker(*args: str, timeout: int = 15) -> str:
+    res = subprocess.run(
+        ["docker", *args], capture_output=True, text=True, timeout=timeout
+    )
+    return res.stdout if res.returncode == 0 else ""
+
+
+def discover_sidecars() -> dict[str, str]:
+    """{experiment key: container name} for every live eval sidecar."""
+    out = {}
+    for name in _docker("ps", "--format", "{{.Names}}").splitlines():
+        key = experiment_key(name.strip())
+        if key:
+            out[key] = name.strip()
+    return out
+
+
+_TOKEN_SNIPPET = (
+    "import json;"
+    "print(open(json.load(open('/opt/serve.json'))['admin_token_path']).read().strip())"
+)
+
+
+def snapshot_sidecar(container: str) -> dict:
+    """Live ledger + budget for one sidecar, via docker exec (admin-side)."""
+    snap: dict = {}
+    token = _docker("exec", container, "python3", "-c", _TOKEN_SNIPPET).strip()
+    if token:
+        raw = _docker(
+            "exec", container, "curl", "-s",
+            "-H", f"Authorization: Bearer {token}",
+            "http://localhost:8000/experiments",
+        )
+        try:
+            snap["experiments"] = json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+    raw = _docker("exec", container, "curl", "-s", "http://localhost:8000/status")
+    try:
+        snap["status"] = json.loads(raw)
+    except json.JSONDecodeError:
+        snap["status"] = {}
+    return snap
+
+
+def scan_finals(jobs_dirs: list[Path]) -> dict[str, dict]:
+    """{experiment key: reward dict} from every reward.json under the jobs dirs.
+
+    The experiment key is recovered from the trial directory name harbor writes
+    (``<task>__<runid>``), so finals keep matching after containers are gone.
+    """
+    finals: dict[str, dict] = {}
+    for jd in jobs_dirs:
+        for rj in Path(jd).glob("**/reward.json"):
+            key = None
+            for part in rj.parts:
+                if "__" in part:
+                    key = part.split("__")[0]
+            if key is None:
+                key = Path(jd).name
+            try:
+                finals[key] = json.loads(rj.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+    return finals
+
+
+def collect(meta_path: Path | None, jobs_dirs: list[Path]) -> dict:
+    meta: dict = {}
+    if meta_path and Path(meta_path).exists():
+        try:
+            meta = json.loads(Path(meta_path).read_text())
+        except json.JSONDecodeError:
+            logger.warning("meta file %s is not valid JSON; ignoring", meta_path)
+    sidecars = {
+        key: snapshot_sidecar(container)
+        for key, container in discover_sidecars().items()
+    }
+    return merge_status(meta=meta, sidecars=sidecars, finals=scan_finals(jobs_dirs))
+
+
+# ---------------------------------------------------------------------------
+# HTTP server + page
+# ---------------------------------------------------------------------------
+
+PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>vero harbor: experiments</title>
+<style>
+  :root { color-scheme: dark; }
+  body { font: 14px/1.5 -apple-system, "Segoe UI", sans-serif; background:#111418;
+         color:#dfe3e8; margin:0; padding:24px; }
+  h1 { font-size:18px; margin:0 0 4px; } .sub { color:#8a94a1; margin-bottom:20px; }
+  .grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(430px,1fr)); gap:16px; }
+  .card { background:#1a1f26; border:1px solid #2a3038; border-radius:10px; padding:16px; }
+  .hdr { display:flex; justify-content:space-between; align-items:center; }
+  .name { font-weight:600; font-size:15px; }
+  .chip { font-size:11px; padding:2px 10px; border-radius:999px; font-weight:600; }
+  .running { background:#0d3a2e; color:#4ade80; } .building { background:#3a2e0d; color:#fbbf24; }
+  .done { background:#12304d; color:#60a5fa; } .gone { background:#3d1a1a; color:#f87171; }
+  .q { color:#aeb7c2; margin:8px 0; font-size:13px; }
+  .bars { color:#8a94a1; font-size:12px; margin-bottom:8px; }
+  table { width:100%; border-collapse:collapse; font-size:12px; margin-top:6px; }
+  th { text-align:left; color:#8a94a1; font-weight:500; padding:2px 6px; }
+  td { padding:2px 6px; border-top:1px solid #232932; font-variant-numeric:tabular-nums; }
+  .final { margin-top:10px; padding:8px 10px; border-radius:8px; font-weight:600; }
+  .WIN { background:#0d3a2e; color:#4ade80; } .MISS { background:#3d2a12; color:#fbbf24; }
+  .noverdict { background:#12304d; color:#60a5fa; }
+  .hist { margin-top:28px; } .hist table { font-size:12px; }
+  .note { color:#8a94a1; font-size:12px; margin-top:6px; }
+  .ts { color:#5c6672; font-size:11px; margin-top:16px; }
+</style></head>
+<body>
+<h1>vero harbor: experiments</h1>
+<div class="sub">live trials, pre-registered bars, and the campaign scorecard. Auto-refreshes.</div>
+<div class="grid" id="grid"></div>
+<div class="hist" id="hist"></div>
+<div class="ts" id="ts"></div>
+<script>
+const fmt = v => (v === null || v === undefined) ? "-" : (typeof v === "number" ? v.toFixed(3) : v);
+async function refresh() {
+  const r = await fetch("/api/status"); const d = await r.json();
+  document.getElementById("grid").innerHTML = d.experiments.map(e => {
+    const rounds = e.rounds.slice(-10).map(x =>
+      `<tr><td>${x.commit}</td><td>${x.split ?? "-"}</td><td>${fmt(x.score)}</td><td>${fmt(x.error_rate)}</td></tr>`).join("");
+    const bars = e.bars ? `baseline ${fmt(e.bars.baseline)} &middot; win &gt; ${fmt(e.bars.win_bar)}` +
+      (e.bars.healthy !== undefined ? ` &middot; healthy ${fmt(e.bars.healthy)}` : "") : "";
+    const budget = (e.budget || []).map(s =>
+      s.remaining_run_budget !== undefined && s.remaining_run_budget !== null
+        ? `${s.split}: ${s.remaining_run_budget} evals left` : "").filter(Boolean).join(" &middot; ");
+    const final = e.final ? `<div class="final ${e.verdict ?? "noverdict"}">final ${
+      Object.entries(e.final).map(([k,v]) => k+" = "+fmt(v)).join(", ")}${
+      e.verdict ? " &middot; " + e.verdict : ""}</div>` : "";
+    return `<div class="card">
+      <div class="hdr"><span class="name">${e.title}</span><span class="chip ${e.phase}">${e.phase}</span></div>
+      ${e.question ? `<div class="q">${e.question}</div>` : ""}
+      ${bars ? `<div class="bars">${bars}</div>` : ""}
+      ${budget ? `<div class="bars">${budget}</div>` : ""}
+      ${e.rounds.length ? `<table><tr><th>commit</th><th>split</th><th>score</th><th>err</th></tr>${rounds}</table>` : ""}
+      ${final}
+      ${e.note ? `<div class="note">${e.note}</div>` : ""}
+    </div>`;
+  }).join("");
+  const h = d.history || [];
+  document.getElementById("hist").innerHTML = h.length ? `<h1>scorecard</h1><table>
+    <tr><th>exp</th><th>question</th><th>baseline</th><th>bar</th><th>final</th><th>verdict</th></tr>` +
+    h.map(x => `<tr><td>${x.exp}</td><td>${x.question}</td><td>${x.baseline ?? "-"}</td>
+      <td>${x.bar ?? "-"}</td><td>${x.final ?? "-"}</td><td>${x.verdict ?? "-"}</td></tr>`).join("") + "</table>" : "";
+  document.getElementById("ts").textContent = "updated " + new Date().toLocaleTimeString();
+}
+refresh(); setInterval(refresh, 20000);
+</script>
+</body></html>
+"""
+
+
+@dataclass
+class DashboardConfig:
+    meta_path: Path | None = None
+    jobs_dirs: list[Path] = field(default_factory=list)
+    host: str = "127.0.0.1"
+    port: int = 8300
+
+
+def make_handler(config: DashboardConfig):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+            if self.path.startswith("/api/status"):
+                body = json.dumps(
+                    collect(config.meta_path, config.jobs_dirs)
+                ).encode()
+                ctype = "application/json"
+            elif self.path == "/" or self.path.startswith("/index"):
+                body = PAGE.encode()
+                ctype = "text/html; charset=utf-8"
+            else:
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):  # quiet: one poll every 20s per client
+            pass
+
+    return Handler
+
+
+def serve_dashboard(config: DashboardConfig) -> None:
+    server = ThreadingHTTPServer(
+        (config.host, config.port), make_handler(config)
+    )
+    logger.info("dashboard on http://%s:%d", config.host, config.port)
+    print(f"vero harbor dashboard: http://{config.host}:{config.port}")
+    server.serve_forever()

--- a/vero/src/vero/harbor/dashboard.py
+++ b/vero/src/vero/harbor/dashboard.py
@@ -69,13 +69,13 @@ def derive_phase(*, has_container: bool, n_rounds: int, final: dict | None) -> s
 
 
 def verdict(final: dict | None, bars: dict | None) -> str | None:
-    """WIN / MISS against the pre-registered win bar, when both are known."""
+    """PASSED / FAILED against the pre-registered win bar, when both are known."""
     if not final or not bars or "win_bar" not in bars:
         return None
     scores = [v for v in final.values() if isinstance(v, (int, float))]
     if not scores:
         return None
-    return "WIN" if scores[0] > bars["win_bar"] else "MISS"
+    return "PASSED" if scores[0] > bars["win_bar"] else "FAILED"
 
 
 def normalize_rounds(payload: dict | None) -> list[dict]:
@@ -252,8 +252,11 @@ PAGE = """<!doctype html>
   th { text-align:left; color:#8a94a1; font-weight:500; padding:2px 6px; }
   td { padding:2px 6px; border-top:1px solid #232932; font-variant-numeric:tabular-nums; }
   .final { margin-top:10px; padding:8px 10px; border-radius:8px; font-weight:600; }
-  .WIN { background:#0d3a2e; color:#4ade80; } .MISS { background:#3d2a12; color:#fbbf24; }
+  .PASSED { background:#0d3a2e; color:#4ade80; } .FAILED { background:#3d1a1a; color:#f87171; }
   .noverdict { background:#12304d; color:#60a5fa; }
+  .vchip { font-size:11px; padding:2px 8px; border-radius:999px; font-weight:600; white-space:nowrap; }
+  .v-passed { background:#0d3a2e; color:#4ade80; } .v-failed { background:#3d1a1a; color:#f87171; }
+  .v-nochange { background:#232932; color:#aeb7c2; } .v-cancelled { background:#2a2440; color:#a78bfa; }
   .hist { margin-top:28px; } .hist table { font-size:12px; }
   .note { color:#8a94a1; font-size:12px; margin-top:6px; }
   .ts { color:#5c6672; font-size:11px; margin-top:16px; }
@@ -289,14 +292,17 @@ async function refresh() {
       ${e.note ? `<div class="note">${e.note}</div>` : ""}
     </div>`;
   }).join("");
+  const vclass = r => ({passed:"v-passed", failed:"v-failed", "no change":"v-nochange",
+                        cancelled:"v-cancelled"}[String(r||"").toLowerCase()] ?? "v-nochange");
   const h = d.history || [];
   document.getElementById("hist").innerHTML = h.length ? `<h1>scorecard: finished experiments</h1>
     <div class="sub">baseline = the unmodified agent's score before optimization &middot;
     bar = the pre-registered score the optimized agent had to beat &middot;
     final = what the optimized agent actually scored on the hidden test set</div><table>
-    <tr><th>exp</th><th>question</th><th>baseline</th><th>bar</th><th>final</th><th>outcome</th><th>what happened</th></tr>` +
+    <tr><th>exp</th><th>question</th><th>baseline</th><th>bar</th><th>final</th><th>verdict</th><th>what happened</th></tr>` +
     h.map(x => `<tr><td>${x.exp}</td><td>${x.question}</td><td>${x.baseline ?? "-"}</td>
-      <td>${x.bar ?? "-"}</td><td>${x.final ?? "-"}</td><td>${x.verdict ?? "-"}</td>
+      <td>${x.bar ?? "-"}</td><td>${x.final ?? "-"}</td>
+      <td><span class="vchip ${vclass(x.result)}">${(x.result ?? "-").toUpperCase()}</span></td>
       <td>${x.summary ?? "-"}</td></tr>`).join("") + "</table>" : "";
   document.getElementById("ts").textContent = "updated " + new Date().toLocaleTimeString();
 }

--- a/vero/tests/test_harbor_dashboard.py
+++ b/vero/tests/test_harbor_dashboard.py
@@ -1,0 +1,128 @@
+"""Tests for vero.harbor.dashboard: the pure status-assembly layer.
+
+The docker/HTTP collectors are thin shims; everything that decides what the
+operator sees (key derivation, phase, verdicts, the meta/live/final join) is
+pure and covered here without docker.
+"""
+
+import json
+
+from vero.harbor.dashboard import (
+    derive_phase,
+    experiment_key,
+    merge_status,
+    normalize_rounds,
+    scan_finals,
+    verdict,
+)
+
+
+class TestExperimentKey:
+    def test_sidecar_name_maps_to_task_key(self):
+        assert experiment_key("gaia-exp11-task__nxkmtjb-eval-sidecar-1") == "gaia-exp11-task"
+
+    def test_non_sidecar_containers_ignored(self):
+        assert experiment_key("gaia-exp11-task__nxkmtjb-main-1") is None
+        assert experiment_key("k8s_coredns_whatever") is None
+
+    def test_sidecar_without_run_suffix_still_keys(self):
+        assert experiment_key("plain-task-eval-sidecar-1") == "plain-task"
+
+
+class TestPhase:
+    def test_container_without_rounds_is_building(self):
+        assert derive_phase(has_container=True, n_rounds=0, final=None) == "building"
+
+    def test_container_with_rounds_is_running(self):
+        assert derive_phase(has_container=True, n_rounds=3, final=None) == "running"
+
+    def test_reward_json_wins_over_everything(self):
+        assert derive_phase(has_container=False, n_rounds=0, final={"accuracy": 0.4}) == "done"
+        assert derive_phase(has_container=True, n_rounds=9, final={"accuracy": 0.4}) == "done"
+
+    def test_no_container_no_final_is_gone(self):
+        # A crashed launch must be conspicuous, not silently absent.
+        assert derive_phase(has_container=False, n_rounds=0, final=None) == "gone"
+
+
+class TestVerdict:
+    def test_win_when_above_bar(self):
+        assert verdict({"accuracy": 0.6}, {"win_bar": 0.41}) == "WIN"
+
+    def test_miss_when_at_or_below_bar(self):
+        assert verdict({"accuracy": 0.40}, {"win_bar": 0.41}) == "MISS"
+        assert verdict({"accuracy": 0.41}, {"win_bar": 0.41}) == "MISS"  # bar is strict
+
+    def test_no_bars_no_verdict(self):
+        assert verdict({"accuracy": 0.6}, None) is None
+        assert verdict(None, {"win_bar": 0.41}) is None
+
+
+class TestNormalizeRounds:
+    def test_rows_truncate_commit_and_carry_scores(self):
+        payload = {"experiments": [
+            {"commit": "d5a5facb994912345678", "split": "train",
+             "mean_score": 0.5555, "error_rate": 0.0, "created_at": "t1"},
+            {"commit": None, "split": None, "mean_score": None, "error_rate": None},
+        ]}
+        rows = normalize_rounds(payload)
+        assert rows[0]["commit"] == "d5a5facb99"
+        assert rows[0]["score"] == 0.5555
+        assert rows[1]["commit"] == ""  # tolerant of null ledger rows
+        assert normalize_rounds(None) == []
+
+
+class TestMergeStatus:
+    META = {
+        "experiments": [
+            {"key": "gaia-exp11-task", "title": "Exp11: floor dogfood",
+             "question": "Does the floor revert harm?",
+             "bars": {"baseline": 0.317, "win_bar": 0.454}},
+            {"key": "gaia-exp12-task", "title": "Exp12: queued"},
+        ],
+        "history": [{"exp": "7", "question": "positive control", "final": "0.6", "verdict": "WIN"}],
+    }
+
+    def test_meta_live_and_final_join_by_key(self):
+        sidecars = {"gaia-exp11-task": {
+            "experiments": {"experiments": [
+                {"commit": "abc1234500", "split": "train", "mean_score": 0.25, "error_rate": 0.0}]},
+            "status": {"splits": [{"split": "train", "remaining_run_budget": 5}]},
+        }}
+        out = merge_status(meta=self.META, sidecars=sidecars, finals={})
+        e11 = next(e for e in out["experiments"] if e["key"] == "gaia-exp11-task")
+        assert e11["phase"] == "running"
+        assert e11["rounds"][0]["score"] == 0.25
+        assert e11["budget"] == [{"split": "train", "remaining_run_budget": 5}]
+        # meta-only experiment shows as gone (conspicuous, not hidden)
+        e12 = next(e for e in out["experiments"] if e["key"] == "gaia-exp12-task")
+        assert e12["phase"] == "gone"
+        assert out["history"] == self.META["history"]
+
+    def test_unlisted_live_trial_still_appears(self):
+        # A running trial the meta forgot must never be invisible.
+        sidecars = {"gaia-expX-task": {"experiments": {"experiments": []}, "status": {}}}
+        out = merge_status(meta=self.META, sidecars=sidecars, finals={})
+        ex = next(e for e in out["experiments"] if e["key"] == "gaia-expX-task")
+        assert ex["phase"] == "building"
+        assert ex["title"] == "gaia-expX-task"  # falls back to the key
+
+    def test_final_produces_done_and_verdict(self):
+        finals = {"gaia-exp11-task": {"accuracy": 0.5}}
+        out = merge_status(meta=self.META, sidecars={}, finals=finals)
+        e11 = next(e for e in out["experiments"] if e["key"] == "gaia-exp11-task")
+        assert e11["phase"] == "done"
+        assert e11["final"] == {"accuracy": 0.5}
+        assert e11["verdict"] == "WIN"  # 0.5 > 0.454
+
+
+class TestScanFinals:
+    def test_reward_json_keyed_by_trial_dir_task_name(self, tmp_path):
+        trial = tmp_path / "jobs" / "2026-07-04__x" / "gaia-exp11-task__AbCdEf" / "verifier"
+        trial.mkdir(parents=True)
+        (trial / "reward.json").write_text(json.dumps({"accuracy": 0.4}))
+        finals = scan_finals([tmp_path / "jobs"])
+        assert finals == {"gaia-exp11-task": {"accuracy": 0.4}}
+
+    def test_missing_dir_is_empty(self, tmp_path):
+        assert scan_finals([tmp_path / "nope"]) == {}

--- a/vero/tests/test_harbor_dashboard.py
+++ b/vero/tests/test_harbor_dashboard.py
@@ -46,12 +46,12 @@ class TestPhase:
 
 
 class TestVerdict:
-    def test_win_when_above_bar(self):
-        assert verdict({"accuracy": 0.6}, {"win_bar": 0.41}) == "WIN"
+    def test_passed_when_above_bar(self):
+        assert verdict({"accuracy": 0.6}, {"win_bar": 0.41}) == "PASSED"
 
-    def test_miss_when_at_or_below_bar(self):
-        assert verdict({"accuracy": 0.40}, {"win_bar": 0.41}) == "MISS"
-        assert verdict({"accuracy": 0.41}, {"win_bar": 0.41}) == "MISS"  # bar is strict
+    def test_failed_when_at_or_below_bar(self):
+        assert verdict({"accuracy": 0.40}, {"win_bar": 0.41}) == "FAILED"
+        assert verdict({"accuracy": 0.41}, {"win_bar": 0.41}) == "FAILED"  # bar is strict
 
     def test_no_bars_no_verdict(self):
         assert verdict({"accuracy": 0.6}, None) is None
@@ -113,7 +113,7 @@ class TestMergeStatus:
         e11 = next(e for e in out["experiments"] if e["key"] == "gaia-exp11-task")
         assert e11["phase"] == "done"
         assert e11["final"] == {"accuracy": 0.5}
-        assert e11["verdict"] == "WIN"  # 0.5 > 0.454
+        assert e11["verdict"] == "PASSED"  # 0.5 > 0.454
 
 
 class TestScanFinals:


### PR DESCRIPTION
## What

`vero harbor dashboard` serves a local, self-refreshing status page for Harbor optimization trials: which experiments are running, what each is doing right now, and how finished ones scored against their pre-registered bars. Built while operating a 13-experiment campaign where "what's running and where is it?" was answered by hand-rolled shell monitors; this replaces them with one page.

## How it works

- **Live trials**: discovers `*-eval-sidecar-1` containers via `docker ps`, then tails each trial's ledger through the admin `/experiments` endpoint (this PR stacks on the observability PR that added it), using the in-container admin token via `docker exec`. Remaining budget comes from `/status`.
- **Finals**: scans harbor jobs dirs (`--jobs`, repeatable) for `reward.json`, keyed by the trial dir's task name so finished trials stay visible after teardown.
- **Context**: an optional `--meta` JSON supplies what containers cannot know: each experiment's question, pre-registered bars (baseline / win bar / healthy ceiling), notes, and a scorecard of completed experiments. Verdicts (WIN/MISS) are computed against the win bar.
- **Phases are derived, not guessed**: `building` (container up, no ledger rows) -> `running` -> `done` (reward.json), and `gone` when there is no container and no final, so a crashed launch is conspicuous instead of silently absent. Live trials missing from the meta file still appear.

## Design constraints

- Zero new dependencies: stdlib `http.server` + inline HTML/JS, `subprocess` for docker.
- Binds `127.0.0.1` by default: ledger rows include hidden-split scores, so the page is for the operator, not the network.
- Host-side admin tool (same trust posture as the `/experiments` endpoint it consumes); it never reads agent volumes.

## Usage

```
vero harbor dashboard --meta exp-meta.json --jobs /tmp/gaia-exp10-jobs --jobs /tmp/gaia-exp11-jobs
# -> http://127.0.0.1:8300
```

## Tests

The status-assembly layer is pure and covered without docker (16 tests): container-name to experiment-key derivation, phase transitions, WIN/MISS verdicts, the meta/live/final join (including unlisted-live-trial and meta-only-gone cases), ledger normalization with null rows, and reward.json scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `vero harbor dashboard`, a zero-dependency local status page for watching Harbor optimization trials live — discovering sidecar containers via `docker ps`, tailing ledgers through the admin `/experiments` endpoint, scanning jobs dirs for `reward.json` finals, and joining everything with an optional `--meta` context file. The pure status-assembly layer is well-separated and covered by 16 tests, but several issues identified in the review remain open.

- **History scorecard field name mismatch**: the frontend template reads `x.result` for the verdict chip, but the test fixture (and therefore the effective meta-file documentation) uses `"verdict"` — the column will silently show `"-"` for every historical experiment in any meta file following the example. Values like "WIN"/"MISS" also won't match the `vclass` lookup.
- **Error handling gaps in `_docker`**: `subprocess.TimeoutExpired` and `FileNotFoundError` are uncaught and propagate through `collect()` into `do_GET`, causing the browser to receive a network error for the entire poll cycle rather than partial data when a container shell stalls.
- **Admin token on command line**: the Bearer token is passed as a `-H` argument in the `docker exec curl` call, making it readable via `ps`/`/proc/<pid>/cmdline` inside the container.
- **`verdict()` picks the first numeric value** from `reward.json` regardless of field name; `scan_finals` silently overwrites on key collision when multiple reward files share the same task key.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to run locally but the history scorecard will silently malfunction for any meta file written following the test example, and unhandled docker-exec timeouts can blank the dashboard entirely during active trials.

The history scorecard's verdict column will show "-" for every historical experiment in any meta file an operator writes using the "verdict" key demonstrated by the test fixture — the frontend reads x.result. Several other issues from prior review rounds (unhandled TimeoutExpired crashing the HTTP handler, admin token in the container process table, innerHTML injection, first-value verdict pick) are also still unresolved, compounding the overall risk for a decision-critical operator tool.

The history fixture in test_harbor_dashboard.py and the frontend template in dashboard.py (around the x.result / vclass lines) are the immediate focus; the _docker error-handling and verdict() key-selection issues in dashboard.py also warrant attention before this lands.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/dashboard.py | New dashboard module: clean pure-layer / side-effect separation, but several flagged issues remain open — unhandled TimeoutExpired/FileNotFoundError crashes the handler thread, admin token exposed on container process list, innerHTML injection from operator-controlled strings, first-numeric-value pick in verdict(), and last-writer-wins in scan_finals(). |
| vero/tests/test_harbor_dashboard.py | Good coverage of pure helpers and join logic; test fixture uses wrong field key ("verdict" vs "result") that will cause silent rendering failure in the history scorecard. |
| vero/src/vero/harbor/cli.py | Adds the "dashboard" CLI command with appropriate options; straightforward delegation to dashboard.py with no issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Handler as HTTP Handler (ThreadingHTTPServer)
    participant Collect as collect()
    participant Docker as docker CLI
    participant FS as Filesystem

    Browser->>Handler: GET /api/status (every 20s)
    Handler->>Collect: collect(meta_path, jobs_dirs)
    Collect->>FS: read meta JSON (optional)
    Collect->>Docker: "docker ps --format {{.Names}}"
    Docker-->>Collect: container list
    loop for each sidecar (sequential)
        Collect->>Docker: docker exec python3 -c _TOKEN_SNIPPET
        Docker-->>Collect: admin token
        Collect->>Docker: docker exec curl /experiments (Bearer token)
        Docker-->>Collect: ledger JSON
        Collect->>Docker: docker exec curl /status
        Docker-->>Collect: budget JSON
    end
    Collect->>FS: "glob **/reward.json in jobs_dirs"
    FS-->>Collect: reward.json files
    Collect-->>Handler: merged status dict
    Handler-->>Browser: 200 application/json

    Browser->>Handler: GET /
    Handler-->>Browser: 200 text/html (inline PAGE template)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Handler as HTTP Handler (ThreadingHTTPServer)
    participant Collect as collect()
    participant Docker as docker CLI
    participant FS as Filesystem

    Browser->>Handler: GET /api/status (every 20s)
    Handler->>Collect: collect(meta_path, jobs_dirs)
    Collect->>FS: read meta JSON (optional)
    Collect->>Docker: "docker ps --format {{.Names}}"
    Docker-->>Collect: container list
    loop for each sidecar (sequential)
        Collect->>Docker: docker exec python3 -c _TOKEN_SNIPPET
        Docker-->>Collect: admin token
        Collect->>Docker: docker exec curl /experiments (Bearer token)
        Docker-->>Collect: ledger JSON
        Collect->>Docker: docker exec curl /status
        Docker-->>Collect: budget JSON
    end
    Collect->>FS: "glob **/reward.json in jobs_dirs"
    FS-->>Collect: reward.json files
    Collect-->>Handler: merged status dict
    Handler-->>Browser: 200 application/json

    Browser->>Handler: GET /
    Handler-->>Browser: 200 text/html (inline PAGE template)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(harbor): PASSED/FAILED verdict chip..."](https://github.com/scaleapi/vero/commit/1d4b033b70fddc06188915e514a9fd117e14e036) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41821921)</sub>

<!-- /greptile_comment -->