### PR TITLE
feat: [no-ticket] harbor - transfer targets (per-target executor-model override at finalize)

### DIFF
--- a/vero/src/vero/evaluation/engine.py
+++ b/vero/src/vero/evaluation/engine.py
@@ -193,6 +193,7 @@ class EvaluationEngine:
         split: str,
         commit: str,
         sample_ids: list[int] | None = None,
+        model: str | None = None,
     ) -> Experiment:
         """Admin/verifier evaluation: explicit ``task``, no budget, no allowlist.
 
@@ -200,7 +201,23 @@ class EvaluationEngine:
         this scores an arbitrary ``(task, dataset_id, split)`` — including held-out
         tasks/splits the agent never had access to. Used by the verifier to score
         the selected commit on its configured targets.
+
+        ``model`` overrides the executor model for this one eval (rides
+        ``task_params`` so the eval strategy can honor it; the Mode-B
+        HarborRunner does, the Mode-A vero-task path ignores it). Used for
+        transfer targets: scoring the champion under a model it was NOT
+        optimized on.
         """
+        params = self.run_constraints
+        if model is not None:
+            params = params.model_copy(
+                update={
+                    "task_params": {
+                        **(params.task_params or {}),
+                        "harbor_model_override": model,
+                    }
+                }
+            )
         return await self.evaluator.evaluate(
             commit=commit,
             dataset_id=dataset_id,
@@ -208,7 +225,7 @@ class EvaluationEngine:
             task=task,
             sample_ids=sample_ids,
             db=self.db,
-            evaluation_parameters=self.run_constraints,
+            evaluation_parameters=params,
         )
 
     def status(self) -> dict[tuple[str, str], SplitBudget]:

--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -236,6 +236,7 @@ def _serve_config(
                 "split": t.split,
                 "reward_key": t.reward_key,
                 "sample_ids": t.sample_ids,
+                "model": t.model,
             }
             for t in config.targets
         ],

--- a/vero/src/vero/harbor/build/config.py
+++ b/vero/src/vero/harbor/build/config.py
@@ -36,6 +36,12 @@ class TargetSpec(BaseModel):
     split: str
     reward_key: str = "reward"
     sample_ids: list[int] | None = None
+    # Executor-model override for this target (transfer probe; Mode B only):
+    # score the selected commit AND the baseline under a model it was not
+    # optimized on, so model-specific couplings (measured live: hardcoded
+    # temperature=0 crashing 72/72 on an executor that rejects it) surface at
+    # finalize instead of one substrate away.
+    model: str | None = None
 
 
 class _BuildConfigBase(BaseModel):

--- a/vero/src/vero/harbor/config.py
+++ b/vero/src/vero/harbor/config.py
@@ -76,6 +76,18 @@ class HarborConfig:
                 f"aggregate_attempts must be 'best' or 'mean', got "
                 f"{self.aggregate_attempts!r}"
             )
+        if self.infra_retry_rounds < 0:
+            raise ValueError(
+                f"infra_retry_rounds must be >= 0, got {self.infra_retry_rounds}"
+            )
+        # A zero (or negative) delay silently nullifies the backoff, and an
+        # instant retry re-enters the same outage: 6 of 8 run attempts once
+        # burned inside a single live DNS blip for exactly this reason.
+        if self.infra_retry_rounds > 0 and self.infra_retry_delay_s <= 0:
+            raise ValueError(
+                f"infra_retry_delay_s must be > 0 when infra retries are "
+                f"enabled, got {self.infra_retry_delay_s}"
+            )
 
     @property
     def is_registry(self) -> bool:

--- a/vero/src/vero/harbor/config.py
+++ b/vero/src/vero/harbor/config.py
@@ -40,6 +40,32 @@ class HarborConfig:
     # without running anything). None keeps the current behavior: the
     # candidate env supplies harbor, and is trusted to.
     harbor_requirement: str | None = None
+    # Bounded within-eval retry for infra-destroyed samples. A sample whose
+    # EVERY attempt died of a transient infrastructure cause (connection,
+    # timeout, rate limit, 5xx) was never measured at all: re-run it after a
+    # backoff instead of booking the outage as a permanent error. Measured
+    # live: a 65-second host DNS blip killed 44 of 72 attempts of one eval
+    # with ConnectionError, and nothing in the record distinguished the blip
+    # from a bad candidate.
+    #
+    # OFF BY DEFAULT, and it must stay off when the candidate is an
+    # adversarial optimizer. The qualifying predicate is built from exception
+    # types raised inside candidate code, and agents are stochastic: a
+    # candidate that raises an allowlisted exception whenever an attempt is
+    # going badly loses nothing on partially-good samples (its fakes
+    # zero-fill like honest failures) but converts every all-bad sample from
+    # a booked 0.0 into a fresh re-roll. That is one-sided selection over
+    # attempt sets, exactly what the zero-fill invariant exists to prevent.
+    # Enable only for trusted-candidate evaluations (frozen agents,
+    # operator-run matrices), where re-measuring an outage is pure signal
+    # recovery. Candidate crashes and exhausted key budgets never retry
+    # regardless (a crash is a result; a spent key cannot recover by
+    # waiting), and recovered samples carry an ``infra_retry`` audit marker.
+    infra_retry_rounds: int = 0
+    # Backoff before retry round N is N times this many seconds. Transient
+    # infra needs time, not immediacy: instant retries burned 6 of 8 run
+    # attempts inside one live DNS blip.
+    infra_retry_delay_s: float = 30.0
     extra_args: list[str] = field(default_factory=list)  # passthrough harbor run flags
 
     def __post_init__(self) -> None:

--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -10,6 +10,7 @@ as plain dicts, so ``vero`` itself needs no ``harbor`` dependency at runtime.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -30,6 +31,68 @@ if TYPE_CHECKING:
     from vero.workspace import Workspace
 
 logger = logging.getLogger(__name__)
+
+# Dead-attempt classification. An attempt that died of one of these exception
+# types never got a fair shot at the task: the model endpoint, the network, or
+# the key quota failed before the candidate could be measured. Classification
+# is diagnostic and retry-gating ONLY: every dead attempt still scores 0.0
+# regardless of class, because excusing infra-labeled deaths from the score
+# would hand the candidate a lever (raise ConnectionError on hard tasks and
+# have those attempts dropped). Conservative allowlist: anything unlisted
+# counts against the candidate.
+_INFRA_EXCEPTION_TYPES = frozenset({
+    "APIConnectionError",
+    "APITimeoutError",
+    "ConnectTimeout",
+    "ConnectionError",
+    "InternalServerError",
+    "RateLimitError",
+    "ReadTimeout",
+    "ServiceUnavailableError",
+    "Timeout",
+    "TimeoutError",
+})
+_INFRA_SUFFIX = "[infra]"
+# litellm surfaces a spent key budget as a BadRequestError; only the message
+# distinguishes it from a candidate-caused bad request. Infra, but PERSISTENT:
+# waiting cannot refill a key, so it alarms instead of retrying. (Measured
+# live: a key crossed its spend cap mid-matrix and two cells of BadRequestError
+# zeros were nearly booked as a portability finding.)
+_KEY_BUDGET_MARKER = "budget has been exceeded"
+_KEY_BUDGET_SUFFIX = "[infra:llm-key-budget]"
+
+
+def _dead_attempt_label(exception_info: dict | None) -> str:
+    """Cause label for one dead attempt; infra causes carry a class suffix so
+    every downstream record (metrics, error strings, per-sample output) shows
+    at a glance whether the deaths measure the candidate or the plumbing. An
+    attempt can die with no recorded exception at all (the verifier simply
+    produced no rewards); keep it countable."""
+    info = exception_info or {}
+    exc = info.get("exception_type")
+    if not exc:
+        return "no_rewards_recorded"
+    # The class suffixes below are load-bearing (retry gating, the
+    # n_dead_infra metric, the key-budget alarm) and round-trip through
+    # persisted output, while the exception type name is candidate-authored:
+    # a class literally named "XError[infra]" must not walk in pre-suffixed.
+    # Neutralize brackets before classifying; genuine types contain none.
+    exc = exc.replace("[", "(").replace("]", ")")
+    if exc == "BadRequestError" and _KEY_BUDGET_MARKER in (
+        info.get("exception_message") or ""
+    ).lower():
+        return f"{exc}{_KEY_BUDGET_SUFFIX}"
+    if exc in _INFRA_EXCEPTION_TYPES:
+        return f"{exc}{_INFRA_SUFFIX}"
+    return exc
+
+
+def _is_infra(label: str) -> bool:
+    return label.endswith((_INFRA_SUFFIX, _KEY_BUDGET_SUFFIX))
+
+
+def _is_transient_infra(label: str) -> bool:
+    return label.endswith(_INFRA_SUFFIX)
 
 
 class HarborRunner:
@@ -76,6 +139,147 @@ class HarborRunner:
                 str(workspace.project_path), params, [t for _, t in pending], jobs_dir
             )
         self._collate(jobs_dir, pairs, params, ran=[t for _, t in pending])
+        await self._retry_transient_infra(workspace, params, pairs, jobs_dir)
+
+    async def _retry_transient_infra(
+        self,
+        workspace: Workspace,
+        params: EvaluationParameters,
+        pairs: list[tuple[int, str]],
+        jobs_dir: Path,
+    ) -> None:
+        """Bounded re-run of samples that were outaged, not measured.
+
+        Scope is deliberately narrow: only samples whose EVERY attempt died of
+        a transient infra cause qualify. A partially scored sample is a noisy
+        measurement whose infra-dead attempts stay zero-filled; a candidate
+        crash is a result; an exhausted key budget cannot recover by waiting.
+        Measured live: a 65-second host DNS blip killed 44 of 72 attempts of
+        one eval with ConnectionError, and with no pause between attempts the
+        whole burst fit inside the blip, booking a near-zero that nothing in
+        the record distinguished from a bad candidate.
+
+        OFF BY DEFAULT (see HarborConfig.infra_retry_rounds), because against
+        an adversarial candidate this is a re-roll lever: the qualifying
+        predicate is built from exception types raised inside candidate code,
+        so a stochastic candidate that raises an allowlisted exception
+        whenever an attempt is going badly converts its all-bad samples from
+        booked zeros into fresh re-rolls. Enable only for trusted-candidate
+        evaluations. Two record-integrity rules hold either way: each round
+        runs in a fresh SIBLING of the jobs dir and collates from there alone
+        (never inside it: resume-path collations rglob the whole jobs dir, and
+        nested round dirs would pool this round's dead attempts into a later
+        resumed mean), and a recovered sample's booked output carries an
+        ``infra_retry`` audit marker naming the discarded dead attempts, so
+        the re-measurement is never invisible in the durable record.
+        """
+        for round_no in range(1, self.config.infra_retry_rounds + 1):
+            retry: list[tuple[int, str]] = []
+            prior_dead: dict[int, dict[str, int]] = {}
+            for sid, t in pairs:
+                dead = self._transient_infra_dead(params, sid)
+                if dead:
+                    retry.append((sid, t))
+                    prior_dead[sid] = dead
+            if not retry:
+                return
+            delay = self.config.infra_retry_delay_s * round_no
+            logger.warning(
+                f"{len(retry)} sample(s) lost every attempt to transient infra "
+                f"causes; retry round {round_no}/{self.config.infra_retry_rounds} "
+                f"in {delay:.0f}s."
+            )
+            await asyncio.sleep(delay)
+            # Sibling of the jobs dir, never a subdir (see docstring), with a
+            # globally fresh ordinal: a dir left over from an earlier eval of
+            # the same result_dir must never leak its stale trials into this
+            # round's collation.
+            ordinal = len(list(jobs_dir.parent.glob("jobs-infra-retry-*"))) + 1
+            round_dir = jobs_dir.parent / f"jobs-infra-retry-{ordinal}"
+            await self._run_harbor(
+                str(workspace.project_path), params, [t for _, t in retry], round_dir
+            )
+            # Collate only what the round actually produced: overwriting a
+            # cause-rich infra error with "no Harbor trial result" (because the
+            # retry round itself died early) would degrade the record.
+            produced = set(self._load_trials(round_dir))
+            got = [(sid, t) for sid, t in retry if t in produced]
+            if not got:
+                logger.warning(
+                    f"infra retry round {round_no} produced no trials; keeping "
+                    f"the recorded errors."
+                )
+                continue
+            self._collate(round_dir, got, params, ran=[t for _, t in got])
+            self._mark_recovered(params, got, prior_dead, round_no)
+
+    def _mark_recovered(
+        self,
+        params: EvaluationParameters,
+        got: list[tuple[int, str]],
+        prior_dead: dict[int, dict[str, int]],
+        round_no: int,
+    ) -> None:
+        """Stamp the audit marker onto samples the retry round recovered.
+
+        A successful retry rebooks the sample from the fresh round alone, so
+        without this the durable record would show a clean measurement with no
+        trace that a full round of dead attempts was discarded, and a
+        discarded round is exactly the kind of fact an auditor of the scores
+        must be able to see."""
+        for sid, _ in got:
+            result = self._existing(params, sid)
+            if result is None or result.is_error():
+                continue  # still failed; the error itself is the audit trail
+            output = result.output if isinstance(result.output, dict) else {}
+            output["infra_retry"] = {
+                "round": round_no,
+                "discarded_dead_attempts": prior_dead.get(sid, {}),
+            }
+            result.output = output
+            save_sample_result(
+                get_vero_home_dir() / "sessions",
+                params.session_id,
+                params.result_id,
+                sample_id=sid,
+                result=result,
+            )
+
+    def _transient_infra_dead(
+        self, params: EvaluationParameters, sample_id: int
+    ) -> dict[str, int] | None:
+        """The persisted dead-cause dict when the sample was never measured
+        (it errored AND every dead attempt carries a transient-infra label),
+        else None. Samples with no structured cause record are not retryable:
+        the conservative default is "measured", the same fail-closed direction
+        as zero-filling."""
+        existing = self._existing(params, sample_id)
+        if existing is None or not existing.is_error():
+            return None
+        output = existing.output if isinstance(existing.output, dict) else {}
+        dead = output.get("dead_exception_types") or {}
+        if dead and all(_is_transient_infra(k) for k in dead):
+            return dead
+        return None
+
+    @staticmethod
+    def _alarm_key_budget(task_name: str, dead: dict[str, int]) -> None:
+        """The one infra cause that deserves its own alarm: an exhausted key
+        budget fails every subsequent LLM call identically, so from the first
+        occurrence onward the run is measuring the outage, not the agent, and
+        neither retrying nor waiting fixes it. ERROR level: this is the line
+        an operator greps for after a run full of inexplicable zeros."""
+        n = sum(v for k, v in dead.items() if k.endswith(_KEY_BUDGET_SUFFIX))
+        if n:
+            logger.error(
+                f"Task '{task_name}': {n} attempt(s) report the LLM key's "
+                f"spend budget as exhausted. If real, every call on this key "
+                f"fails the same way until it is refilled or swapped, and "
+                f"scores recorded meanwhile measure the outage, not the "
+                f"candidate. The signature is read from candidate-process "
+                f"exceptions, so corroborate against the key's own spend "
+                f"records before invalidating results."
+            )
 
     # ------------------------------------------------------------------
     # Task selection (host-side; just task names)
@@ -209,6 +413,9 @@ class HarborRunner:
             self.config.aggregate_attempts == "mean"
             or self.feedback_transcripts
             or self.expose_attempt_detail
+            # The infra retry decides from per-attempt death causes, which are
+            # only recorded when attempts are loaded at collation.
+            or self.config.infra_retry_rounds > 0
         )
         groups = self._trial_groups(jobs_dir) if need_attempts else {}
         for sample_id, task_name in pairs:
@@ -374,10 +581,7 @@ class HarborRunner:
                 else:
                     measured.append(0.0)
                     n_dead += 1
-                    exc = (t.get("exception_info") or {}).get("exception_type")
-                    # An attempt can die without a recorded exception (the
-                    # verifier simply produced no rewards); keep it countable.
-                    key = exc or "no_rewards_recorded"
+                    key = _dead_attempt_label(t.get("exception_info"))
                     dead_types[key] = dead_types.get(key, 0) + 1
             if n_scored:
                 if len(measured) < self.config.n_attempts or n_dead:
@@ -398,6 +602,7 @@ class HarborRunner:
                 if dead_types:
                     # dict, not metrics: metrics are float-valued by contract.
                     mean_output["dead_exception_types"] = dead_types
+                self._alarm_key_budget(task_name, dead_types)
                 return SampleResult(
                     score=mean,
                     feedback=self._failure_feedback(mean, attempts),
@@ -406,6 +611,15 @@ class HarborRunner:
                         "n_attempts": float(len(attempts)),
                         "n_scored": float(n_scored),
                         "n_dead": float(n_dead),
+                        # Zeros with an infra-labeled cause: still counted in
+                        # the mean (see the classification note at module top)
+                        # but split out for the analyst deciding whether a
+                        # cell's zeros measured the plumbing. Labels derive
+                        # from candidate-process exceptions: corroborating
+                        # evidence for invalidating a cell, not proof.
+                        "n_dead_infra": float(
+                            sum(v for k, v in dead_types.items() if _is_infra(k))
+                        ),
                         "n_clean": float(n_clean),
                     },
                     output=_out(mean_output),
@@ -417,22 +631,32 @@ class HarborRunner:
             # that flows everywhere (DB, per-sample files, the verifier's
             # target_errors), and "no verifier rewards" alone cannot separate
             # a champion that crashes deterministically on this executor from
-            # an infra outage — a distinction that decides whether the cell is
+            # an infra outage: a distinction that decides whether the cell is
             # a measurement or a re-run.
             cause = ""
+            dead: dict[str, int] = {}
             if attempts:
-                dead = {}
                 for t in attempts:
                     if (t.get("verifier_result") or {}).get("rewards"):
                         continue
-                    exc = (t.get("exception_info") or {}).get("exception_type")
-                    key = exc or "no_rewards_recorded"
+                    key = _dead_attempt_label(t.get("exception_info"))
                     dead[key] = dead.get(key, 0) + 1
                 if dead:
                     causes = ", ".join(
                         f"{k} x{v}" for k, v in sorted(dead.items(), key=lambda i: -i[1])
                     )
                     cause = f" (attempts died: {causes})"
+            self._alarm_key_budget(task_name, dead)
+            no_rewards_output = {
+                "task_name": task_name,
+                "trial_name": trial.get("trial_name"),
+            }
+            if dead:
+                # Structured twin of the error string above: the within-eval
+                # infra retry reads this to decide whether the sample was
+                # measured or merely outaged (string parsing would be the
+                # fragile alternative).
+                no_rewards_output["dead_exception_types"] = dead
             return SampleResult(
                 error=f"No verifier rewards for task '{task_name}'.{cause}",
                 # The agent died before scoring. A candidate edit that CRASHES
@@ -441,9 +665,7 @@ class HarborRunner:
                 # does. Passed as score 0.0: an unscored attempt counts as a
                 # failure everywhere else too.
                 feedback=self._failure_feedback(0.0, attempts),
-                output=_out(
-                    {"task_name": task_name, "trial_name": trial.get("trial_name")}
-                ),
+                output=_out(no_rewards_output),
                 **common,
             )
         score = self._extract_reward(rewards)

--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -129,8 +129,12 @@ class HarborRunner:
             "--n-attempts", str(c.n_attempts),
             "--max-retries", str(c.max_retries),
         ]
-        if c.model:
-            cmd += ["-m", c.model]
+        # Per-eval executor override (transfer targets): the verifier scores
+        # the champion under a model it was not optimized on. Rides
+        # task_params so it needs no runner state.
+        model = (params.task_params or {}).get("harbor_model_override") or c.model
+        if model:
+            cmd += ["-m", str(model)]
         for task_name in task_names:
             cmd += ["-i", task_name]
         cmd += ["--jobs-dir", str(jobs_dir), *c.extra_args]

--- a/vero/src/vero/harbor/runner.py
+++ b/vero/src/vero/harbor/runner.py
@@ -173,14 +173,17 @@ class HarborRunner:
         ``infra_retry`` audit marker naming the discarded dead attempts, so
         the re-measurement is never invisible in the durable record.
         """
+        # Every discarded round per sample, in round order: a sample that
+        # rides several retry rounds before recovering must surface ALL the
+        # rounds it burned, not just the last one before recovery.
+        discard_history: dict[int, list[dict[str, int]]] = {}
         for round_no in range(1, self.config.infra_retry_rounds + 1):
             retry: list[tuple[int, str]] = []
-            prior_dead: dict[int, dict[str, int]] = {}
             for sid, t in pairs:
                 dead = self._transient_infra_dead(params, sid)
                 if dead:
                     retry.append((sid, t))
-                    prior_dead[sid] = dead
+                    discard_history.setdefault(sid, []).append(dead)
             if not retry:
                 return
             delay = self.config.infra_retry_delay_s * round_no
@@ -211,30 +214,31 @@ class HarborRunner:
                 )
                 continue
             self._collate(round_dir, got, params, ran=[t for _, t in got])
-            self._mark_recovered(params, got, prior_dead, round_no)
+            self._mark_recovered(params, got, discard_history, round_no)
 
     def _mark_recovered(
         self,
         params: EvaluationParameters,
         got: list[tuple[int, str]],
-        prior_dead: dict[int, dict[str, int]],
+        discard_history: dict[int, list[dict[str, int]]],
         round_no: int,
     ) -> None:
         """Stamp the audit marker onto samples the retry round recovered.
 
         A successful retry rebooks the sample from the fresh round alone, so
         without this the durable record would show a clean measurement with no
-        trace that a full round of dead attempts was discarded, and a
+        trace that full rounds of dead attempts were discarded, and a
         discarded round is exactly the kind of fact an auditor of the scores
-        must be able to see."""
+        must be able to see. ``discarded_rounds`` lists every burned round in
+        order, not just the one immediately before recovery."""
         for sid, _ in got:
             result = self._existing(params, sid)
             if result is None or result.is_error():
                 continue  # still failed; the error itself is the audit trail
             output = result.output if isinstance(result.output, dict) else {}
             output["infra_retry"] = {
-                "round": round_no,
-                "discarded_dead_attempts": prior_dead.get(sid, {}),
+                "recovered_round": round_no,
+                "discarded_rounds": discard_history.get(sid, []),
             }
             result.output = output
             save_sample_result(

--- a/vero/src/vero/harbor/serve.py
+++ b/vero/src/vero/harbor/serve.py
@@ -43,6 +43,8 @@ class _TargetCfg(BaseModel):
     split: str
     reward_key: str = "reward"
     sample_ids: list[int] | None = None
+    # Executor-model override for this target (transfer probe; Mode B only).
+    model: str | None = None
 
 
 class _ServeConfigBase(BaseModel):

--- a/vero/src/vero/harbor/verifier.py
+++ b/vero/src/vero/harbor/verifier.py
@@ -39,6 +39,15 @@ class VerificationTarget:
     split: str
     reward_key: str
     sample_ids: list[int] | None = None  # None = full split
+    # Executor-model override for this target (Mode B): score the selected
+    # commit under a DIFFERENT model than the one it was optimized on. This is
+    # the transfer probe: home-model evals cannot see model-specific couplings
+    # the optimizer bakes in (measured live: three champions independently
+    # hardcoded temperature=0 and scored 0/72 on an executor that rejects it,
+    # while looking healthy on every home-model eval). None = the task's
+    # configured model. The baseline is scored under the same override, so the
+    # comparison stays like-for-like.
+    model: str | None = None
 
 
 class Verifier:
@@ -144,6 +153,7 @@ class Verifier:
                 split=target.split,
                 commit=sha,
                 sample_ids=target.sample_ids,
+                model=target.model,
                 what=f"target '{target.reward_key}'",
             )
             if score is None:
@@ -177,6 +187,7 @@ class Verifier:
         split: str,
         commit: str,
         sample_ids: list[int] | None = None,
+        model: str | None = None,
         what: str,
     ) -> tuple[float | None, str | None]:
         """One reward-critical admin eval with bounded retry.
@@ -201,6 +212,7 @@ class Verifier:
                     split=split,
                     commit=commit,
                     sample_ids=sample_ids,
+                    model=model,
                 )
                 if exp.result.score(fill_score=None) is None:
                     last_error = (
@@ -293,12 +305,15 @@ class Verifier:
             try:
                 baselines: dict[str, float] = {}
                 for target in self.targets:
+                    # Same executor override as the candidate's target eval, or
+                    # the baseline comparison is not like-for-like.
                     exp = await self.engine.evaluate_admin(
                         task=target.task,
                         dataset_id=target.dataset_id,
                         split=target.split,
                         commit=self.base_commit,
                         sample_ids=target.sample_ids,
+                        model=target.model,
                     )
                     if exp.result.score(fill_score=None) is None:
                         # All-error/empty is an outage, not a 0.0 baseline: a

--- a/vero/tests/test_engine.py
+++ b/vero/tests/test_engine.py
@@ -183,6 +183,25 @@ class TestFreeEval:
         assert svc.status()[("dev", "ds1")].remaining_sample_budget == 100
 
     @pytest.mark.asyncio
+    async def test_admin_model_override_rides_task_params(self, monkeypatch):
+        # Transfer targets: evaluate_admin(model=...) must reach the eval
+        # strategy via task_params without mutating the shared run_constraints.
+        svc = _make_service(monkeypatch=monkeypatch)
+        await svc.evaluate_admin(
+            task="t", dataset_id="ds1", split="dev", commit="c1", model="openai/gpt-4o"
+        )
+        params = svc.evaluator.evaluate.await_args.kwargs["evaluation_parameters"]
+        assert params.task_params["harbor_model_override"] == "openai/gpt-4o"
+        assert svc.run_constraints.task_params.get("harbor_model_override") is None
+
+    @pytest.mark.asyncio
+    async def test_admin_no_override_keeps_shared_constraints(self, monkeypatch):
+        svc = _make_service(monkeypatch=monkeypatch)
+        await svc.evaluate_admin(task="t", dataset_id="ds1", split="dev", commit="c1")
+        params = svc.evaluator.evaluate.await_args.kwargs["evaluation_parameters"]
+        assert params is svc.run_constraints
+
+    @pytest.mark.asyncio
     async def test_free_does_not_bypass_no_access_gate(self, monkeypatch):
         from vero.core.dataset import SplitAccess
 

--- a/vero/tests/test_harbor_build.py
+++ b/vero/tests/test_harbor_build.py
@@ -363,6 +363,34 @@ def test_instruction_omits_free_baseline_claim_when_unsupported(built):
     assert "budget-free" not in text
 
 
+def test_target_model_reaches_serve_json(tmp_path, monkeypatch):
+    # Transfer probe: a target's executor-model override must survive the
+    # compile into serve.json and validate back through ServeConfig.
+    monkeypatch.setenv("VERO_SKIP_SECRET_CHECK", "1")
+    config = BuildConfigA(
+        name="vero/gsm8k-opt",
+        agent_repo=str(_agent_repo(tmp_path)),
+        task="gsm8k",
+        task_module="gsm8k_agent.vero_tasks",
+        dataset=str(_dataset(tmp_path)),
+        splits=[
+            {"split": "validation", "access": "non_viewable"},
+            {"split": "test", "access": "no_access"},
+        ],
+        budgets=[{"split": "validation", "total_run_budget": 5}],
+        selection_split="validation",
+        targets=[
+            {"split": "test", "reward_key": "reward"},
+            {"split": "test", "reward_key": "reward_4o", "model": "openai/gpt-4o"},
+        ],
+    )
+    out = compile_task(config, tmp_path / "task", vero_root=_stub_vero(tmp_path))
+    cfg = load_serve_config(out / "environment" / "sidecar" / "serve.json")
+    by_key = {t.reward_key: t for t in cfg.targets}
+    assert by_key["reward_4o"].model == "openai/gpt-4o"
+    assert by_key["reward"].model is None
+
+
 def test_instruction_renders_exhaust_budget_by_default(built):
     text = (built / "instruction.md").read_text()
     assert "Unspent budget is wasted" in text

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -997,6 +997,21 @@ class TestInfraResilience:
         monkeypatch.setattr("asyncio.sleep", _fast_sleep)
         return runner, calls, sleeps
 
+    def test_config_rejects_zero_delay_when_retries_enabled(self):
+        # A zero delay silently nullifies the backoff and an instant retry
+        # re-enters the same outage; misconfiguration must fail loudly.
+        with pytest.raises(ValueError, match="infra_retry_delay_s"):
+            HarborConfig(task_source="org/ds@1", agent_import_path="p:m",
+                         infra_retry_rounds=1, infra_retry_delay_s=0.0)
+        # with retries off the delay is never used, so 0 is not an error
+        HarborConfig(task_source="org/ds@1", agent_import_path="p:m",
+                     infra_retry_rounds=0, infra_retry_delay_s=0.0)
+
+    def test_config_rejects_negative_rounds(self):
+        with pytest.raises(ValueError, match="infra_retry_rounds"):
+            HarborConfig(task_source="org/ds@1", agent_import_path="p:m",
+                         infra_retry_rounds=-1)
+
     def test_infra_deaths_labeled_and_counted_but_still_zero_filled(self, tmp_path):
         # One scored attempt, one infra death, one candidate crash: the mean
         # zero-fills BOTH deaths (classification must never move the score),
@@ -1103,8 +1118,8 @@ class TestInfraResilience:
         assert results[0].score == 1.0
         assert results[1].error is None and results[1].score == 0.5
         assert results[1].output["infra_retry"] == {
-            "round": 1,
-            "discarded_dead_attempts": {"ConnectionError[infra]": 2},
+            "recovered_round": 1,
+            "discarded_rounds": [{"ConnectionError[infra]": 2}],
         }
         assert "infra_retry" not in (results[0].output or {})
         assert len(calls) == 2
@@ -1231,9 +1246,9 @@ class TestInfraResilience:
         assert results[1].score == 1.0
         assert results[1].metrics["n_scored"] == 2.0
         assert results[1].metrics["n_dead"] == 0.0
-        assert results[1].output["infra_retry"]["discarded_dead_attempts"] == {
-            "ConnectionError[infra]": 2
-        }
+        assert results[1].output["infra_retry"]["discarded_rounds"] == [
+            {"ConnectionError[infra]": 2}
+        ]
 
     @pytest.mark.asyncio
     async def test_multi_round_backoff_and_partial_recovery(self, tmp_path, monkeypatch):
@@ -1256,8 +1271,18 @@ class TestInfraResilience:
             workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
         )
         results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
-        assert results[0].score == 1.0 and results[0].output["infra_retry"]["round"] == 1
-        assert results[1].score == 0.5 and results[1].output["infra_retry"]["round"] == 2
+        assert results[0].score == 1.0
+        assert results[0].output["infra_retry"] == {
+            "recovered_round": 1,
+            "discarded_rounds": [{"ConnectionError[infra]": 1}],
+        }
+        # t1 burned TWO rounds before recovering; the audit marker must list
+        # both, not just the round immediately before recovery.
+        assert results[1].score == 0.5
+        assert results[1].output["infra_retry"] == {
+            "recovered_round": 2,
+            "discarded_rounds": [{"TimeoutError[infra]": 1}, {"TimeoutError[infra]": 1}],
+        }
         assert [c[0] for c in calls] == [["t0", "t1"], ["t0", "t1"], ["t1"]]
         assert [c[1].name for c in calls[1:]] == ["jobs-infra-retry-1", "jobs-infra-retry-2"]
         assert sleeps == [30.0, 60.0]

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -54,6 +54,7 @@ def _write_trial(
     trajectory: str | None = None,
     finished_at: str | None = None,
     exception_type: str | None = None,
+    exception_message: str = "",
 ):
     # Real harbor layout: <jobs>/<timestamp>/<trial>/result.json, plus a job-level
     # <jobs>/<timestamp>/result.json summary (no task_name) that collation must skip.
@@ -73,7 +74,7 @@ def _write_trial(
     if exception_type is not None:
         data["exception_info"] = {
             "exception_type": exception_type,
-            "exception_message": "",
+            "exception_message": exception_message,
             "exception_traceback": "",
         }
     (d / "result.json").write_text(json.dumps(data))
@@ -949,3 +950,314 @@ class TestMeanRewardKeyMismatch:
         assert r.score == 0.5
         assert r.metrics["n_dead"] == 1.0
         assert r.metrics["n_scored"] == 1.0
+
+
+class TestInfraResilience:
+    """Dead-attempt classification + bounded within-eval infra retry.
+
+    Classification is diagnostic and retry-gating only: every dead attempt
+    still scores 0.0 regardless of class (excusing infra-labeled deaths from
+    the score would let a candidate raise fake ConnectionErrors on hard tasks).
+    The retry is OFF BY DEFAULT and exists for trusted-candidate evaluations:
+    against an adversarial optimizer it is a re-roll lever, since the
+    qualifying predicate derives from exceptions raised in candidate code. It
+    re-measures only samples whose EVERY attempt died of a transient infra
+    cause, in a fresh sibling jobs dir, and stamps an audit marker on
+    recovered samples so the discarded round stays visible.
+    """
+
+    def _flow_runner(self, monkeypatch, tmp_path, rounds_by_call, **cfg):
+        """A runner whose _run_harbor writes fixture trials per call:
+        rounds_by_call[i] is a list of (trial, task, rewards, exc_type, exc_msg)
+        written into whatever jobs dir call i receives."""
+        monkeypatch.setenv("VERO_HOME_DIR", str(tmp_path / "vh"))
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds@1", agent_import_path="pkg.mod:Agent",
+            **cfg,
+        ))
+        calls = []
+
+        async def _fake_run(project_path, params, task_names, jobs_dir):
+            i = len(calls)
+            calls.append((list(task_names), Path(jobs_dir)))
+            for trial, task, rewards, exc_type, exc_msg in rounds_by_call[i]:
+                _write_trial(Path(jobs_dir), trial, task, rewards,
+                             exception_type=exc_type, exception_message=exc_msg)
+
+        monkeypatch.setattr(runner, "_run_harbor", _fake_run)
+        monkeypatch.setattr(runner, "_task_names_for", lambda p: [(0, "t0"), (1, "t1")])
+        sleeps = []
+        import asyncio as _asyncio
+        real_sleep = _asyncio.sleep
+
+        async def _fast_sleep(d, *a, **k):
+            sleeps.append(d)
+            await real_sleep(0)
+
+        monkeypatch.setattr("asyncio.sleep", _fast_sleep)
+        return runner, calls, sleeps
+
+    def test_infra_deaths_labeled_and_counted_but_still_zero_filled(self, tmp_path):
+        # One scored attempt, one infra death, one candidate crash: the mean
+        # zero-fills BOTH deaths (classification must never move the score),
+        # and the labels + n_dead_infra let an analyst see which zeros
+        # measured the plumbing.
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds@1", agent_import_path="pkg.mod:Agent",
+            n_attempts=3, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"
+        _write_trial(jobs, "a", "t0", {"reward": 1.0})
+        _write_trial(jobs, "b", "t0", None, exception_type="ConnectionError")
+        _write_trial(jobs, "c", "t0", None, exception_type="UnsupportedParamsError")
+        groups = runner._trial_groups(jobs)
+        r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.score == pytest.approx(1.0 / 3)
+        assert r.output["dead_exception_types"] == {
+            "ConnectionError[infra]": 1,
+            "UnsupportedParamsError": 1,
+        }
+        assert r.metrics["n_dead"] == 2.0
+        assert r.metrics["n_dead_infra"] == 1.0
+
+    def test_forged_infra_suffix_is_neutralized(self, tmp_path):
+        # The suffix contract is load-bearing and the exception type name is
+        # candidate-authored: a class literally named "XError[infra]" must not
+        # classify as infra. Brackets are neutralized before labeling.
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds@1", agent_import_path="pkg.mod:Agent",
+            n_attempts=2, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"
+        _write_trial(jobs, "a", "t0", {"reward": 1.0})
+        _write_trial(jobs, "b", "t0", None, exception_type="MadeUpError[infra]")
+        groups = runner._trial_groups(jobs)
+        r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.output["dead_exception_types"] == {"MadeUpError(infra)": 1}
+        assert r.metrics["n_dead_infra"] == 0.0
+
+    def test_key_budget_exhaustion_labeled_and_alarmed(self, tmp_path, caplog):
+        # litellm reports a spent key budget as a BadRequestError; only the
+        # message identifies it. It must be labeled infra (those zeros likely
+        # measure an outage) and alarmed at ERROR (every later call fails
+        # identically). The alarm text hedges: the signature is read from
+        # candidate-process exceptions and needs corroboration.
+        import logging as _logging
+
+        runner = HarborRunner(HarborConfig(
+            task_source="org/ds@1", agent_import_path="pkg.mod:Agent",
+            n_attempts=2, aggregate_attempts="mean",
+        ))
+        jobs = tmp_path / "jobs"
+        msg = "litellm.BadRequestError: Budget has been exceeded! Current cost: 102.47, Max budget: 99.0"
+        _write_trial(jobs, "a", "t0", None, exception_type="BadRequestError", exception_message=msg)
+        _write_trial(jobs, "b", "t0", None, exception_type="BadRequestError", exception_message=msg)
+        groups = runner._trial_groups(jobs)
+        with caplog.at_level(_logging.ERROR, logger="vero.harbor.runner"):
+            r = runner._sample_result(groups["t0"][0], 0, "t0", _params(), attempts=groups["t0"])
+        assert r.error is not None
+        assert "BadRequestError[infra:llm-key-budget] x2" in r.error
+        assert r.output["dead_exception_types"] == {"BadRequestError[infra:llm-key-budget]": 2}
+        assert any("spend budget as exhausted" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_retry_is_off_by_default(self, tmp_path, monkeypatch):
+        # The re-roll lever must be opt-in: with a default config, an
+        # infra-outaged sample books its cause-rich error and nothing re-runs.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", {"reward": 1.0}, None, ""),
+                 ("b", "t1", None, "ConnectionError", "")],
+            ],
+        )
+        assert runner.config.infra_retry_rounds == 0
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        assert len(calls) == 1
+        assert sleeps == []
+
+    @pytest.mark.asyncio
+    async def test_retry_reruns_only_the_outaged_sample(self, tmp_path, monkeypatch):
+        # t0 scores; t1 loses every attempt to ConnectionError. The retry round
+        # re-runs t1 ALONE in a fresh SIBLING jobs dir after a backoff, the
+        # fresh measurement replaces the recorded outage, and the booked output
+        # carries the audit marker naming the discarded dead attempts.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", {"reward": 1.0}, None, ""),
+                 ("b", "t1", None, "ConnectionError", ""),
+                 ("c", "t1", None, "ConnectionError", "")],
+                [("r1", "t1", {"reward": 0.5}, None, "")],
+            ],
+            infra_retry_rounds=1,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[0].score == 1.0
+        assert results[1].error is None and results[1].score == 0.5
+        assert results[1].output["infra_retry"] == {
+            "round": 1,
+            "discarded_dead_attempts": {"ConnectionError[infra]": 2},
+        }
+        assert "infra_retry" not in (results[0].output or {})
+        assert len(calls) == 2
+        assert calls[1][0] == ["t1"]
+        # sibling of jobs/, never nested inside it (resume collations rglob
+        # the whole jobs dir and would pool this round's dead attempts)
+        assert calls[1][1].name == "jobs-infra-retry-1"
+        assert calls[1][1].parent == calls[0][1].parent
+        assert sleeps == [30.0]
+
+    @pytest.mark.asyncio
+    async def test_candidate_crash_and_spent_key_never_retry(self, tmp_path, monkeypatch):
+        # A crash is a result; a spent key cannot recover by waiting. Neither
+        # triggers a retry round even with retries enabled.
+        budget_msg = "Budget has been exceeded! Current cost: 102.47, Max budget: 99.0"
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", None, "UnsupportedParamsError", ""),
+                 ("b", "t1", None, "BadRequestError", budget_msg)],
+            ],
+            infra_retry_rounds=1,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[0].error is not None and results[1].error is not None
+        assert len(calls) == 1
+        assert sleeps == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_cause_fully_dead_sample_never_retries(self, tmp_path, monkeypatch):
+        # EVERY dead cause must be transient-infra (all, not any): a
+        # deterministically-crashing candidate must not qualify for a re-roll
+        # by mixing one fake ConnectionError into its crashes.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", {"reward": 1.0}, None, ""),
+                 ("b", "t1", None, "ConnectionError", ""),
+                 ("c", "t1", None, "UnsupportedParamsError", "")],
+            ],
+            n_attempts=2, aggregate_attempts="mean", infra_retry_rounds=1,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[1].error is not None
+        assert len(calls) == 1
+        assert sleeps == []
+
+    @pytest.mark.asyncio
+    async def test_persistent_outage_keeps_the_cause_rich_error(self, tmp_path, monkeypatch):
+        # The retry round produces nothing (outage persists): the durable
+        # record must keep the original infra-labeled error, not degrade to
+        # "no Harbor trial result" or raise out of the eval.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", {"reward": 1.0}, None, ""),
+                 ("b", "t1", None, "ConnectionError", "")],
+                [],
+            ],
+            infra_retry_rounds=1,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[1].error is not None
+        assert "ConnectionError[infra]" in results[1].error
+        assert results[1].output["dead_exception_types"] == {"ConnectionError[infra]": 1}
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_partially_scored_sample_is_a_measurement_not_an_outage(self, tmp_path, monkeypatch):
+        # One attempt scored, one died of infra: the sample is a (noisy)
+        # measurement. Its infra death stays zero-filled in the mean and it is
+        # NOT retried; anything else would let infra flakiness re-roll scores.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", {"reward": 1.0}, None, ""),
+                 ("b", "t0", None, "ConnectionError", ""),
+                 ("c", "t1", {"reward": 1.0}, None, "")],
+            ],
+            n_attempts=2, aggregate_attempts="mean", infra_retry_rounds=1,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[0].score == 0.5
+        assert results[0].metrics["n_dead_infra"] == 1.0
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_round_mean_is_not_diluted_by_dead_rounds(self, tmp_path, monkeypatch):
+        # The fresh round is collated from its own sibling dir alone: the two
+        # dead attempts of round 0 must not zero-dilute the fresh mean
+        # (1.0, not 0.5), and the audit marker records what was discarded.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", {"reward": 1.0}, None, ""),
+                 ("b", "t1", None, "ConnectionError", ""),
+                 ("c", "t1", None, "ConnectionError", "")],
+                [("r1", "t1", {"reward": 1.0}, None, ""),
+                 ("r2", "t1", {"reward": 1.0}, None, "")],
+            ],
+            n_attempts=2, aggregate_attempts="mean", infra_retry_rounds=1,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[1].score == 1.0
+        assert results[1].metrics["n_scored"] == 2.0
+        assert results[1].metrics["n_dead"] == 0.0
+        assert results[1].output["infra_retry"]["discarded_dead_attempts"] == {
+            "ConnectionError[infra]": 2
+        }
+
+    @pytest.mark.asyncio
+    async def test_multi_round_backoff_and_partial_recovery(self, tmp_path, monkeypatch):
+        # Two rounds: round 1 recovers t0 and leaves t1 outaged; round 2
+        # retries ONLY the survivor, after a LONGER (linear) backoff, in its
+        # own fresh sibling dir.
+        runner, calls, sleeps = self._flow_runner(
+            monkeypatch, tmp_path,
+            rounds_by_call=[
+                [("a", "t0", None, "ConnectionError", ""),
+                 ("b", "t1", None, "TimeoutError", "")],
+                [("r1a", "t0", {"reward": 1.0}, None, ""),
+                 ("r1b", "t1", None, "TimeoutError", "")],
+                [("r2b", "t1", {"reward": 0.5}, None, "")],
+            ],
+            infra_retry_rounds=2,
+        )
+        params = _params()
+        await runner.produce_sample_results(
+            workspace=MagicMock(project_path="/wt"), params=params, result_dir=tmp_path / "res"
+        )
+        results = load_all_sample_results(get_vero_home_dir() / "sessions", "s", params.result_id)
+        assert results[0].score == 1.0 and results[0].output["infra_retry"]["round"] == 1
+        assert results[1].score == 0.5 and results[1].output["infra_retry"]["round"] == 2
+        assert [c[0] for c in calls] == [["t0", "t1"], ["t0", "t1"], ["t1"]]
+        assert [c[1].name for c in calls[1:]] == ["jobs-infra-retry-1", "jobs-infra-retry-2"]
+        assert sleeps == [30.0, 60.0]

--- a/vero/tests/test_harbor_runner.py
+++ b/vero/tests/test_harbor_runner.py
@@ -117,6 +117,19 @@ class TestBuildCommand:
         cmd = _runner()._build_command("/wt", _params(), ["t0"], Path("/jobs"))
         assert "--with" not in cmd
 
+    def test_model_override_beats_configured_model(self):
+        # Transfer targets: a per-eval executor override (via task_params)
+        # wins over the task's configured model.
+        params = _params()
+        params.task_params = {"harbor_model_override": "openai/gpt-4o"}
+        cmd = _runner()._build_command("/wt", params, ["t0"], Path("/jobs"))
+        m = cmd[cmd.index("-m") + 1]
+        assert m == "openai/gpt-4o"
+
+    def test_no_override_uses_configured_model(self):
+        cmd = _runner()._build_command("/wt", _params(), ["t0"], Path("/jobs"))
+        assert cmd[cmd.index("-m") + 1] == "anthropic/x"
+
 
 class TestExtractReward:
     def test_priority_pass_then_reward_then_sole_key(self):

--- a/vero/tests/test_harbor_verifier.py
+++ b/vero/tests/test_harbor_verifier.py
@@ -89,7 +89,7 @@ class TestAutoBestSelection:
         )
         admin_scores = {"hi": 0.1, "lo": 0.95}
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(
                 result=MagicMock(score=MagicMock(return_value=admin_scores.get(commit, 0.99)))
             )
@@ -125,7 +125,7 @@ class TestAutoBestSelection:
             }
         )
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.7)))
 
         engine.evaluate_admin = AsyncMock(side_effect=_admin)
@@ -172,7 +172,7 @@ class TestSubsetEvalShortlistFilter:
             }
         )
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             # admin re-score agrees the full-split ranking is right
             score = {"solid": 0.7, "lucky": 0.3}.get(commit, 0.5)
             return MagicMock(result=MagicMock(score=MagicMock(return_value=score)))
@@ -212,7 +212,7 @@ class TestSubsetEvalShortlistFilter:
             }
         )
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.5)))
 
         engine.evaluate_admin = AsyncMock(side_effect=_admin)
@@ -260,7 +260,7 @@ class TestAutoBestBaselineFloor:
         # agent admin-scores 0.2 on the selection split; base admin-scores 0.3;
         # the reverted base scores 0.35 on the target split (distinct values so the
         # assertions can tell the target eval apart from the floor comparison).
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             if commit == "base":
                 score = 0.35 if split == "validation" else 0.3
             else:
@@ -296,7 +296,7 @@ class TestAutoBestBaselineFloor:
         engine = MagicMock()
         engine.db.get_experiments_df.return_value = self._df()
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.3)))  # all equal
 
         engine.evaluate_admin = AsyncMock(side_effect=_admin)
@@ -327,7 +327,7 @@ class TestAutoBestBaselineFloor:
             }
         )
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.5)))
 
         engine.evaluate_admin = AsyncMock(side_effect=_admin)
@@ -349,7 +349,7 @@ class TestAutoBestBaselineFloor:
         engine = MagicMock()
         engine.db.get_experiments_df.return_value = self._df()
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             score = 0.3 if commit == "base" else 0.6  # agent genuinely improves
             return MagicMock(result=MagicMock(score=MagicMock(return_value=score)))
 
@@ -374,7 +374,7 @@ class TestAutoBestBaselineFloor:
         engine = MagicMock()
         engine.db.get_experiments_df.return_value = self._df()
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.2)))
 
         engine.evaluate_admin = AsyncMock(side_effect=_admin)
@@ -476,7 +476,7 @@ class TestNoCandidateFallback:
             }
         )
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.5)))
 
         engine.evaluate_admin = AsyncMock(side_effect=_admin)
@@ -733,7 +733,7 @@ class TestSelectionIntegrity:
             }
         )
 
-        async def _admin(*, task, dataset_id, split, commit, sample_ids=None):
+        async def _admin(*, task, dataset_id, split, commit, sample_ids=None, model=None):
             if commit == "base" and split == "validation":
                 raise RuntimeError("nested run crashed")
             return MagicMock(result=MagicMock(score=MagicMock(return_value=0.9)))
@@ -754,6 +754,32 @@ class TestSelectionIntegrity:
         # the final (target) eval ran on the SEED, not the unverified candidate
         assert engine.evaluate_admin.await_args.kwargs["commit"] == "base"
         assert engine.evaluate_admin.await_args.kwargs["split"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_transfer_target_model_reaches_champion_and_baseline_evals(self, tmp_path):
+        # A target's executor-model override must apply to BOTH the champion
+        # eval and the baseline eval, or the comparison is not like-for-like.
+        self._submit(tmp_path)
+        engine = MagicMock()
+        engine.evaluate_admin = AsyncMock(
+            return_value=MagicMock(result=MagicMock(score=MagicMock(return_value=0.5)))
+        )
+        v = Verifier(
+            engine=engine,
+            admin_volume=tmp_path,
+            reward_mode="submit",
+            score_baseline=True,
+            base_commit="base",
+            targets=[VerificationTarget(
+                task="t", dataset_id="ds", split="test",
+                reward_key="reward_4o", model="openai/gpt-4o",
+            )],
+        )
+        await v.finalize()
+        models = [c.kwargs["model"] for c in engine.evaluate_admin.await_args_list]
+        commits = [c.kwargs["commit"] for c in engine.evaluate_admin.await_args_list]
+        assert models == ["openai/gpt-4o", "openai/gpt-4o"]
+        assert set(commits) == {"cand", "base"}
 
     @pytest.mark.asyncio
     async def test_floored_target_records_dominant_crash_cause(self, tmp_path):


### PR DESCRIPTION
Stacked on #37. Together they are the response to the wave-1 transfer-matrix finding: three of five champions independently hardcoded `temperature=0` (a variance-reduction trick on their home model) and scored **0/72** on claude-opus-4-8, which rejects that parameter, while looking healthy on every eval the optimization loop ever ran. #37 makes such a crash legible after the fact; this PR makes it measurable DURING every run.

## What it does

`VerificationTarget` gains an optional `model`: a finalize target with an executor override scores the selected commit under a model it was **not** optimized on, alongside its home-model reward in the same reward.json:

```yaml
targets:
  - split: test
    reward_key: reward            # home executor
  - split: test
    reward_key: reward_opus       # transfer probe
    model: anthropic/claude-opus-4-8
```

A champion with a baked-in model coupling then ships `reward_opus: 0.0` with the crash cause in `target_errors` (#37), instead of the coupling surfacing one substrate away, weeks later, in a manual probe.

## Design notes

- The baseline is scored under the same override, so `score_baseline` comparisons stay like-for-like per target.
- Plumbing rides `task_params["harbor_model_override"]` (an existing per-eval passthrough): `TargetSpec` (build.yaml) → compiler → `_TargetCfg` (serve.json) → `VerificationTarget` → `engine.evaluate_admin(model=...)` → `HarborRunner` `-m`. Mode A ignores the key; the shared `run_constraints` are copied, never mutated.
- Selection is untouched: the override applies to finalize targets only, so the optimizer's incentives during the run are unchanged; portability is measured, not optimized against (that would be its own experiment).

## Tests

- Engine: override rides `task_params` without mutating shared constraints; no-override passes constraints through unchanged.
- Runner: `-m` honors the override over the configured model.
- Verifier: the override reaches BOTH the champion and baseline evals.
- Build: `TargetSpec.model` round-trips through the compiler into serve.json and validates.
- Full affected suites green (153 passed after widening 11 strict-signature test fakes of `evaluate_admin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `model` override to `VerificationTarget` (and the full `TargetSpec → compiler → serve.json → verifier` pipeline) so finalize can score a champion under a model it was **not** optimized on — a direct response to finding that three champions independently baked in `temperature=0` and scored 0/72 on an executor that rejects that parameter. It also adds bounded within-eval infra retry (`infra_retry_rounds`, off by default), dead-attempt classification with infra labeling, a key-budget exhaustion alarm, and an `n_dead_infra` metric.

- **Transfer probe plumbing**: `evaluate_admin(model=...)` creates a shallow copy of `run_constraints` (never mutates shared state) and injects the override into `task_params["harbor_model_override"]`; the baseline is scored under the same override so comparisons remain like-for-like.
- **Infra retry (opt-in)**: samples whose *every* attempt died of a transient infrastructure exception can be retried in a fresh sibling jobs dir with a linear backoff; the qualifying predicate is restricted to transient causes only, and each recovered sample receives an `infra_retry` audit marker listing the discarded rounds.
- **Dead-attempt classification**: a conservative allowlist of infra exception names labels deaths as `[infra]` or `[infra:llm-key-budget]`; bracket-injection in candidate-authored exception names is neutralized before classification; `n_dead_infra` surfaces the count without affecting the score.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The transfer-probe plumbing is minimal and non-invasive; infra retry is opt-in and off by default; no shared state is mutated.

The model override creates a copy of run_constraints rather than mutating the shared object; the infra retry is gated behind infra_retry_rounds > 0 (default 0); the adversarial re-roll vector is correctly neutralized by requiring ALL attempts to carry a transient-infra label. All new paths are covered by tests. No logic errors or data-integrity issues were found.

No files require special attention. runner.py is the largest change but is thoroughly tested by test_harbor_runner.py.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/evaluation/engine.py | Adds `model` parameter to `evaluate_admin`; correctly uses `model_copy` to create a shallow copy of `run_constraints` rather than mutating shared state. |
| vero/src/vero/harbor/build/compiler.py | One-line addition to propagate `t.model` into the serialized target dict for serve.json. |
| vero/src/vero/harbor/build/config.py | Adds `model: str | None = None` to `TargetSpec` with a clear doc comment. |
| vero/src/vero/harbor/config.py | Adds `infra_retry_rounds` and `infra_retry_delay_s` fields to `HarborConfig` with validation: rejects negative rounds and rejects zero/negative delay when retries are enabled. |
| vero/src/vero/harbor/runner.py | Largest change: adds dead-attempt classification, key-budget alarm, bounded infra retry with sibling-dir isolation and audit stamping, model override in `_build_command`, and `n_dead_infra` metric. Well-documented and tested; no shared-state mutation; adversarial-candidate guard is correctly opt-in. |
| vero/src/vero/harbor/serve.py | Adds `model: str | None = None` to `_TargetCfg` to round-trip the field through serve.json deserialization. |
| vero/src/vero/harbor/verifier.py | Adds `model` to `VerificationTarget`, threads it through `_admin_eval_score`, and correctly applies the same override to both champion and baseline evals to keep comparisons like-for-like. |
| vero/tests/test_harbor_runner.py | Adds `TestInfraResilience` with 9 tests covering classification, key-budget alarm, retry eligibility, multi-round backoff, audit-marker content, and adversarial no-retry invariants. |
| vero/tests/test_harbor_verifier.py | Updates 11 `_admin` fakes to accept the new `model` keyword arg; adds test verifying the override reaches both champion and baseline calls. |
| vero/tests/test_engine.py | Adds two tests confirming the model override injects into `task_params` without mutating `run_constraints`, and that a no-override call passes constraints through as the same object. |
| vero/tests/test_harbor_build.py | Adds a round-trip test verifying `TargetSpec.model` survives compilation into serve.json and is correctly deserialized. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge pull request #39 from scaleapi/har..."](https://github.com/scaleapi/vero/commit/c333cba7743950721116d84bfb480a8a508461b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42952058)</sub>

<!-- /greptile_comment -->