### PR TITLE
fix: cap requires-python <3.14 so uv can't pick a Python that fails to build litellm/pyo3

### DIFF
--- a/vero/pyproject.toml
+++ b/vero/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Varun Ursekar", email = "oss@scale.com" }
 ]
 license = { text = "MIT" }
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "async-lru>=2.0.5",
     "click>=8.0.0",


### PR DESCRIPTION
## Bug

`scale-vero`'s package `pyproject.toml` (in the repo's `vero/` subdir) declares `requires-python = ">=3.11"`, which is too permissive. `uv run` picks the newest installed interpreter (e.g. Python 3.14). The transitive dependency `litellm==1.92.0` (pulled via `scale-vero[optimize]` → `openai-agents[litellm]`) has a Rust/PyO3 core that fails to build on Python 3.14.

## Exact PyO3 error

```
error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
```

## Repro

On a machine whose default `uv`-managed Python is 3.14:

```bash
git clone git@github.com:scaleapi/vero.git
cd vero/vero
uv run vero harbor run ...
```

`uv` resolves to Python 3.14 (satisfies `>=3.11`), then the `litellm` build fails with the PyO3 error above. Pinning to 3.12 locally fixes it, confirming the interpreter version is the cause.

## Fix

Cap the upper bound so `uv` cannot select an interpreter that breaks the `litellm`/PyO3 build:

```diff
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
```

The repo has no `.github/workflows` CI matrix to reconcile against; the cap simply matches PyO3's max supported version (3.13). Change is limited to `vero/pyproject.toml`; nothing else is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an upper-bound Python version cap (`<3.14`) to `vero/pyproject.toml` to prevent `uv` from selecting Python 3.14, which breaks the `litellm`/PyO3 transitive dependency that only supports up to Python 3.13.

- The one-line change to `requires-python` in `vero/pyproject.toml` corrects a too-permissive lower-bound-only constraint, preventing `uv` from resolving to Python 3.14 where the `openai-agents[litellm]` extra would fail to build.
- When PyO3 officially adds Python 3.14 support and `litellm` ships a compatible release, this upper bound will need to be bumped accordingly.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single targeted constraint tightening that prevents a known build failure with no functional regressions.

The change is a one-line requires-python cap that matches the documented upper bound of the PyO3 library driving the breakage. The fix is minimal, the root cause is well-understood, and no other files are touched. The only future maintenance item is bumping this cap once litellm/PyO3 ships Python 3.14 support.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/pyproject.toml | Single-line fix capping requires-python to <3.14; change is correct and precisely scoped to the broken interpreter version. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[uv run / uv sync] --> B{Resolve Python interpreter}
    B -->|Before fix: >=3.11| C[uv picks newest installed\ne.g. Python 3.14]
    B -->|After fix: >=3.11,<3.14| D[uv picks Python 3.11–3.13]
    C --> E[Install openai-agents litellm extra]
    D --> F[Install openai-agents litellm extra]
    E --> G[Build litellm with PyO3]
    F --> H[Build litellm with PyO3]
    G --> I["❌ PyO3 error: Python 3.14 > max supported 3.13"]
    H --> J["✅ Build succeeds"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cap requires-python &lt;3.14 so uv can..."](https://github.com/scaleapi/vero/commit/e2faa36c61aaf4cc7aa1dda48f9ae8eddc6ffb72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47032179)</sub>

<!-- /greptile_comment -->