### PR TITLE
fix: forward per-run agent env (--ae) to the optimizer's harbor run

### DIFF
--- a/vero/src/vero/harbor/build/config.py
+++ b/vero/src/vero/harbor/build/config.py
@@ -237,6 +237,13 @@ class HarborBuildConfig(EvaluationModel):
     feedback_max_bytes: int = Field(default=3000, ge=0)
     expose_attempt_detail: bool = False
     extra_harbor_args: list[str] = Field(default_factory=list)
+    # Environment variables injected into the optimizer agent's shell (setup/
+    # install and run), rendered as harbor `--ae KEY=VALUE` on the optimizer's
+    # `harbor run`. Distinct from `extra_harbor_args` (which only flows into the
+    # eval sub-run) and `task_environment` (the eval sub-run's env): this reaches
+    # the optimizer agent's own install/setup exec, e.g. UV_TOOL_BIN_DIR so
+    # `uv tool install` targets a writable dir on a non-root sandbox.
+    agent_env: dict[str, str] = Field(default_factory=dict)
 
     timeout_seconds: float = Field(default=1800.0, gt=0)
     case_timeout_seconds: float = Field(default=180.0, gt=0)

--- a/vero/src/vero/harbor/cli.py
+++ b/vero/src/vero/harbor/cli.py
@@ -430,6 +430,12 @@ def run_command(config_path, agent, model, environment, params, env_file, extra)
         ]
         if model is not None:
             command.extend(["-m", model])
+        # Forward the build's declared agent env to the optimizer agent's shell.
+        # Harbor's `--ae KEY=VALUE` populates the agent's extra_env, which harbor
+        # injects into the agent's setup/install exec (scoped_exec_env). Sorted
+        # for a deterministic command line.
+        for key in sorted(config.agent_env):
+            command.extend(["--ae", f"{key}={config.agent_env[key]}"])
         command.extend(extra)
         click.echo(shlex.join(command))
         completed = subprocess.run(

--- a/vero/tests/test_v05_harbor_build.py
+++ b/vero/tests/test_v05_harbor_build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 import tomllib
 from pathlib import Path
@@ -771,3 +772,63 @@ def test_compiler_uses_published_version_outside_a_source_checkout(
 def test_agent_access_defaults_to_safe_k_anonymity_floor():
     # Omitting min_aggregate_cases must yield a real floor (5), not a no-op (1).
     assert AgentAccessSpec(partition="validation").min_aggregate_cases == 5
+
+
+def test_run_command_forwards_agent_env_as_harbor_ae(tmp_path, monkeypatch):
+    # `config.agent_env` must be rendered as repeated `--ae KEY=VALUE` on the
+    # optimizer's `harbor run` so it reaches the agent's setup/install exec
+    # (harbor injects --ae into the agent's extra_env / scoped_exec_env). This is
+    # the only supported channel for e.g. UV_TOOL_BIN_DIR on a non-root sandbox;
+    # extra_harbor_args only flows into the eval sub-run, not this command.
+    from click.testing import CliRunner
+
+    from vero.harbor import build as harbor_build
+    from vero.harbor import cli as harbor_cli
+
+    config = _config(
+        tmp_path,
+        agent_env={"UV_TOOL_BIN_DIR": "/home/agent/.local/bin", "FOO": "bar"},
+    )
+    config_path = tmp_path / "build.yaml"
+    config_path.write_text("name: placeholder\n", encoding="utf-8")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(command, *args, **kwargs):
+        captured["command"] = list(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(harbor_cli.shutil, "which", lambda _name: "/usr/bin/uvx")
+    monkeypatch.setattr(harbor_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        harbor_build, "load_harbor_build_config", lambda *a, **k: config
+    )
+    monkeypatch.setattr(
+        harbor_build, "compile_harbor_task", lambda cfg, out: out
+    )
+
+    result = CliRunner().invoke(
+        harbor_cli.harbor,
+        [
+            "run",
+            "--config",
+            str(config_path),
+            "--agent",
+            "codex",
+            "--model",
+            "gpt-5.4",
+            "--environment",
+            "modal",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    command = captured["command"]
+    assert "--ae" in command
+    assert "--ae UV_TOOL_BIN_DIR=/home/agent/.local/bin" in shlex.join(command)
+    assert "--ae FOO=bar" in shlex.join(command)
+    # Deterministic (sorted-by-key) ordering: FOO before UV_TOOL_BIN_DIR.
+    joined = shlex.join(command)
+    assert joined.index("--ae FOO=bar") < joined.index(
+        "--ae UV_TOOL_BIN_DIR="
+    )


### PR DESCRIPTION
## Root cause

When vero runs the optimizer it shells out to `uvx ... harbor run` to launch the coding agent (codex / mini-swe-agent). There was **no supported way to pass environment variables into that optimizer agent's setup/install shell** from the build config.

- `run_command` in `vero/src/vero/harbor/cli.py` builds the optimizer's harbor command from a fixed list + `-m model` + the click `extra` passthrough (`@click.argument("extra", nargs=-1)`). It **never reads any per-run agent env**.
- `config.extra_harbor_args` (the only env-adjacent knob) is compiled **solely into the evaluation sub-run** the sidecar fires: the compiler writes it into `serve.json` (`vero/src/vero/harbor/build/compiler.py`), consumed by the sidecar backend (`vero/src/vero/harbor/backend.py`). That is a **different** `harbor run` with a **different** agent, so args there never reach the optimizer agent's install shell.
- Downstream harbor is already correct: harbor's `--ae/--agent-env` flag (`cli/trials.py`) populates the agent's `extra_env`, and harbor injects that env into the agent's setup/install exec by wrapping `install()` in `scoped_exec_env(agent.extra_env)` (`trial/trial.py`). So if vero rendered `--ae KEY=VALUE` onto the optimizer command, it would work; it just never did.

## Concrete motivation

There was no way to set e.g. `UV_TOOL_BIN_DIR` for the optimizer agent's install (needed on non-root sandboxes so `uv tool install` doesn't try to symlink into root-owned `/usr/local/bin`). Passing it via `extra_harbor_args` silently did nothing (wrong sub-run).

## Fix

- Add a dedicated build-config field `agent_env: dict[str, str] = {}` on `HarborBuildConfig` (alongside `extra_harbor_args`), documented as "environment variables injected into the optimizer agent's shell (setup/install and run), rendered as harbor `--ae KEY=VALUE`".
- In `run_command`, after appending `-m model` and before the `extra` passthrough, render `config.agent_env` as repeated `--ae KEY=VALUE` args, sorted by key for a deterministic command line. `config` is already in scope in `run_command`, so no threading was needed.
- Added a focused unit test in `tests/test_v05_harbor_build.py` asserting `run_command` with `agent_env={"UV_TOOL_BIN_DIR": "/home/agent/.local/bin"}` produces `--ae UV_TOOL_BIN_DIR=/home/agent/.local/bin` on the harbor command.

**`extra_harbor_args` is intentionally left unchanged** to avoid overloading its meaning (it means "eval sub-run args"). This keeps the two concerns cleanly separate.

## Base branch note

This targets `pr2-add-vero` rather than `main`: the redesigned VeRO harbor code (`src/vero/harbor/cli.py`, `build/config.py`, `build/compiler.py`, `backend.py`) is introduced by PR #45 (`pr2-add-vero`) and does not exist on `main` yet. The bug lives entirely in that code.

## Testing

- New test passes: `tests/test_v05_harbor_build.py::test_run_command_forwards_agent_env_as_harbor_ae`.
- Full `tests/test_v05_harbor_build.py` is green (21 passed, 4 skipped for the `harness-engineering-bench` gate). Two secret-check tests only fail when `OPENAI_API_KEY`/`OPENAI_BASE_URL` are unset; that is pre-existing on the base branch and unrelated to this change.
- `ruff check` passes on all three changed files. Env pinned to Python 3.12 (3.14 fails to build litellm/pyo3, see PR #47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a dedicated `agent_env: dict[str, str]` field to `HarborBuildConfig` and renders it as repeated `--ae KEY=VALUE` args on the optimizer's `harbor run` command, fixing a gap where there was no supported channel to inject environment variables (e.g. `UV_TOOL_BIN_DIR`) into the optimizer agent's setup/install shell.

- **`build/config.py`**: Adds the `agent_env` field, clearly documented as distinct from `extra_harbor_args` (eval sub-run) and `task_environment`, with a `default_factory=dict` default so existing configs are unaffected.
- **`cli.py`**: In `run_command`, iterates `config.agent_env` sorted by key and extends the harbor command with `--ae KEY=VALUE` pairs, placed before the `extra` passthrough so CLI-provided args can override them.
- **`test_v05_harbor_build.py`**: Adds a focused integration-style test monkeypatching `subprocess.run` and `compile_harbor_task` to verify the correct `--ae` args appear in sorted order.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, backward-compatible (default empty dict), and correctly threaded through an already-available config reference in run_command.

The addition is minimal: a new optional field on the config dataclass and a sorted loop in run_command that produces no output when agent_env is empty. Subprocess invocation uses a list (not a shell string), so values with spaces or special characters are passed safely. The test covers both the presence and the sort order of the generated args. No existing behavior is changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/config.py | Adds `agent_env: dict[str, str]` field with clear doc comment and `default_factory=dict`; backward-compatible and well-scoped. |
| vero/src/vero/harbor/cli.py | Renders `config.agent_env` as `--ae KEY=VALUE` args in sorted key order before the `extra` passthrough; placement and logic are correct. |
| vero/tests/test_v05_harbor_build.py | New test uses monkeypatching to verify `--ae` args appear in the harbor command in sorted key order; assertions are correct for the chosen test values. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as vero harbor run (cli.py)
    participant Config as HarborBuildConfig (config.py)
    participant Harbor as harbor run (optimizer agent)
    participant Sidecar as eval sub-run (harbor sidecar)

    User->>CLI: vero harbor run --config build.yaml
    CLI->>Config: load_harbor_build_config()
    Config-->>CLI: config (incl. agent_env, extra_harbor_args)
    CLI->>CLI: build command list
    note over CLI: append -m model
    note over CLI: append --ae KEY=VALUE (from agent_env, sorted)
    note over CLI: append extra passthrough args
    CLI->>Harbor: "subprocess.run([uvx, harbor, run, ..., --ae KEY=VALUE])"
    Harbor->>Harbor: scoped_exec_env(agent.extra_env) on install/setup
    note over Harbor: agent_env vars available here
    Harbor->>Sidecar: launch eval sub-run (from serve.json)
    note over Sidecar: extra_harbor_args flow here (separate channel)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: forward per-run agent env (--ae) to..."](https://github.com/scaleapi/vero/commit/32698b427de490eb16b145e6abffccd7b06e80d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47038287)</sub>

<!-- /greptile_comment -->