### PR TITLE
fix: classify Modal sandbox / tests-dir loss as transient_infra

### DIFF
--- a/vero/src/vero/evaluation/scoring/error_taxonomy.py
+++ b/vero/src/vero/evaluation/scoring/error_taxonomy.py
@@ -43,6 +43,11 @@ class ErrorCategory(str, Enum):
     #: Authentication/authorization failed (e.g. a wrong or cycled key). Does
     #: not heal on retry: terminate loudly.
     AUTH_FAILURE = "auth_failure"
+    #: The requested model is not deployed on the configured upstream. A
+    #: permanent misconfiguration, not the candidate's doing: never scored as a
+    #: sample, and terminating, because every remaining case will fail the same
+    #: way and the run has nothing left to measure.
+    UPSTREAM_MODEL_UNAVAILABLE = "upstream_model_unavailable"
     #: Transient external infrastructure (rate limit, timeout, connection, 5xx,
     #: overloaded). Retryable; if it persists it renders the aggregate invalid.
     TRANSIENT_INFRA = "transient_infra"
@@ -90,6 +95,16 @@ _POLICIES: dict[ErrorCategory, CategoryPolicy] = {
         counts_toward_invalidity=False,
         is_informative_sample=False,
         diagnostic_code="auth_failure",
+    ),
+    ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE: CategoryPolicy(
+        retryable=False,
+        terminating=True,
+        # Unlike auth, keep counting these toward invalidity: if the terminating
+        # path is ever bypassed, the aggregate must still come out invalid
+        # rather than silently averaging a shrinking set of survivors.
+        counts_toward_invalidity=True,
+        is_informative_sample=False,
+        diagnostic_code="upstream_model_unavailable",
     ),
     ErrorCategory.TRANSIENT_INFRA: CategoryPolicy(
         retryable=True,
@@ -150,6 +165,21 @@ _SIGNAL_PATTERNS: list[tuple[re.Pattern[str], ErrorCategory]] = [
         ErrorCategory.AUTH_FAILURE,
     ),
     (
+        # A model that is configured but not provisioned upstream. Left
+        # unclassified this is the worst kind of silent failure: the agent's
+        # every call 404s, it writes no answer, and the case is recorded as an
+        # informative task failure: the harness blaming the candidate for a
+        # model that does not exist. Matched on the provider's own error codes
+        # and on the exact Azure sentence, never on a bare "does not exist",
+        # which would also swallow "loading container: file does not exist".
+        re.compile(
+            r"deploymentnotfound|model_not_found|"
+            r"the api deployment for this resource does not exist",
+            re.IGNORECASE,
+        ),
+        ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE,
+    ),
+    (
         re.compile(
             r"rate.?limit|too.?many.?requests|time(?:d.?)?out|connection|"
             r"service.?unavailable|internal.?server|overloaded|"
@@ -205,6 +235,9 @@ def classify_case(signals: list[str]) -> ErrorCategory:
     for category in (
         ErrorCategory.INFERENCE_BUDGET_EXHAUSTED,
         ErrorCategory.AUTH_FAILURE,
+        # Ahead of infra: a case that saw both a dead sandbox and a missing
+        # deployment should report the deterministic, operator-fixable one.
+        ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE,
         ErrorCategory.TRANSIENT_INFRA,
     ):
         if category in categories:

--- a/vero/src/vero/evaluation/scoring/error_taxonomy.py
+++ b/vero/src/vero/evaluation/scoring/error_taxonomy.py
@@ -158,6 +158,22 @@ _SIGNAL_PATTERNS: list[tuple[re.Pattern[str], ErrorCategory]] = [
         ),
         ErrorCategory.TRANSIENT_INFRA,
     ),
+    (
+        # Harness / Modal environment loss: the task sandbox died, was never
+        # created, or its container or held-out tests fixture could not be
+        # provisioned. This is infrastructure the candidate did not cause, so
+        # it is excluded from the aggregate and counted toward invalidity,
+        # never scored as an informative task failure. Without this, a run
+        # whose sandboxes all collapsed reports a fully "successful" 0.0
+        # instead of an invalid aggregate.
+        re.compile(
+            r"sandbox|streamterminated|"
+            r"failed.?to.?add.?tests.?directory|addtestsdirerror|"
+            r"loading.?container|fetchspec",
+            re.IGNORECASE,
+        ),
+        ErrorCategory.TRANSIENT_INFRA,
+    ),
 ]
 
 

--- a/vero/tests/test_v05_error_taxonomy.py
+++ b/vero/tests/test_v05_error_taxonomy.py
@@ -58,3 +58,40 @@ def test_policy_encodes_the_intended_treatment():
     task = policy(ErrorCategory.TASK_FAILURE)
     assert task.is_informative_sample
     assert not task.counts_toward_invalidity and not task.terminating
+
+
+def test_classify_signal_recognizes_harness_environment_loss():
+    # Modal sandbox lifecycle failures and a missing held-out tests fixture are
+    # infrastructure the candidate did not cause, not an informative zero.
+    assert classify_signal("AddTestsDirError") is ErrorCategory.TRANSIENT_INFRA
+    assert (
+        classify_signal("Failed to add tests directory to environment.")
+        is ErrorCategory.TRANSIENT_INFRA
+    )
+    assert (
+        classify_signal("The Sandbox is unavailable. It may have already shut down.")
+        is ErrorCategory.TRANSIENT_INFRA
+    )
+    assert (
+        classify_signal("Modal Sandbox with container ID ta-01 not found.")
+        is ErrorCategory.TRANSIENT_INFRA
+    )
+    assert (
+        classify_signal("FetchSpec failed: loading container: file does not exist")
+        is ErrorCategory.TRANSIENT_INFRA
+    )
+
+
+def test_classify_case_treats_environment_loss_as_infra_not_task_failure():
+    # Regression for the swe-atlas-qna flat-zero: the majority of cases died on
+    # Modal sandbox / tests-dir provisioning yet were masked as scoreable task
+    # failures at 0.0. They must be excluded infrastructure, not informative.
+    assert classify_case(["AddTestsDirError"]) is ErrorCategory.TRANSIENT_INFRA
+    assert (
+        classify_case(
+            ["NotFoundError", "Modal Sandbox with container ID ta-01 not found."]
+        )
+        is ErrorCategory.TRANSIENT_INFRA
+    )
+    # A candidate's own bug is still an informative task failure, unchanged.
+    assert classify_case(["ValueError"]) is ErrorCategory.TASK_FAILURE

--- a/vero/tests/test_v05_error_taxonomy.py
+++ b/vero/tests/test_v05_error_taxonomy.py
@@ -95,3 +95,62 @@ def test_classify_case_treats_environment_loss_as_infra_not_task_failure():
     )
     # A candidate's own bug is still an informative task failure, unchanged.
     assert classify_case(["ValueError"]) is ErrorCategory.TASK_FAILURE
+
+
+def test_a_missing_upstream_deployment_is_not_a_task_failure():
+    """The 2026-07-25 swe-atlas-qna run's exact terminal exceptions.
+
+    145 of its 469 cases died on a model that is not provisioned. Classified as
+    a task failure, each was recorded as an informative score of 0.0: the
+    harness blaming the candidate for a model that does not exist.
+    """
+    azure = (
+        "Error code: 404 - {'error': {'type': 'invalid_request_error', "
+        "'code': 'DeploymentNotFound', 'message': 'The API deployment for this "
+        "resource does not exist. If you created the deployment within the "
+        "last 5 minutes, please wait a moment and try again.'}}"
+    )
+    assert (
+        classify_signal(azure) is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+    assert (
+        classify_signal("model_not_found") is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+    assert (
+        classify_case(["NotFoundError", azure])
+        is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+
+    unavailable = policy(ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE)
+    assert not unavailable.is_informative_sample
+    assert not unavailable.retryable
+    assert unavailable.terminating
+    assert unavailable.counts_toward_invalidity
+
+    # It outranks a co-occurring sandbox death: the deterministic,
+    # operator-fixable cause is the one worth reporting.
+    assert (
+        classify_case(
+            [
+                "NotFoundError",
+                "Modal Sandbox with container ID ta-01KY not found.",
+                azure,
+            ]
+        )
+        is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+
+
+def test_missing_deployment_pattern_does_not_swallow_container_load_failures():
+    """`FetchSpec failed: loading container: file does not exist` is infra.
+
+    It is 102 of that same run's cases, and it also contains "does not exist",
+    so the deployment pattern must not be written loosely enough to claim it.
+    """
+    fetchspec = "FetchSpec failed: loading container: file does not exist\n"
+    assert classify_signal(fetchspec) is ErrorCategory.TRANSIENT_INFRA
+    assert classify_case(["RuntimeError", fetchspec]) is ErrorCategory.TRANSIENT_INFRA
+    assert (
+        classify_case(["AddTestsDirError", "Failed to add tests directory to environment."])
+        is ErrorCategory.TRANSIENT_INFRA
+    )


### PR DESCRIPTION
## What

The harbor error taxonomy records any unrecognized case failure as `TASK_FAILURE`: an informative, scoreable sample at the failure value with `status=SUCCESS`. That is correct for a candidate that crashes on its own, but **Modal sandbox lifecycle failures and a missing held-out tests fixture are infrastructure the candidate did not cause**, and today they are silently scored 0.

## Why

On a swe-atlas-qna optimizer run (2026-07-24), **all 396 evaluation cases** came back `status=success`, `error_category=task_failure`, `score=0.0`. The terminal exceptions:

| exception | count | share |
|---|--:|--:|
| `AddTestsDirError` ("failed to add tests directory") | 144 | 36% |
| Modal sandbox `NotFoundError` / "Sandbox unavailable" | 125 | 32% |
| `RuntimeError` | 67 | 17% |
| `BadRequestError` (gpt-4o `reasoning.effort` 400) | 60 | 15% |

Because these were classified as task failures, the aggregate reported `error_rate 0.0` and `objective.feasible=true` at `0.0`: **a fully broken environment masqueraded as a real, shippable zero**, and the optimizer ran with no gradient (baseline and every candidate 0.0).

## Change

Add the harness/Modal environment-loss signals (sandbox lifecycle, `AddTestsDirError` / "failed to add tests directory", container fetch failures, `StreamTerminatedError`) to the `TRANSIENT_INFRA` patterns in `error_taxonomy.py`. Those cases are now **excluded from the aggregate and counted toward invalidity**, so a collapsed environment surfaces as an invalid run instead of a silent zero.

A candidate's own bug (`ValueError`, `KeyError`, no answer) is still a task failure, unchanged.

## Tests

Two new tests in `test_v05_error_taxonomy.py` cover the new signals and assert existing classification behavior is unchanged. Verified locally by exercising the classifier directly (new signals map to `TRANSIENT_INFRA`, all prior cases unchanged).

## Related

- The underlying provisioning root cause is tracked in #51; this PR only stops it being masked.
- Base branch: `feat/swe-bench-pro-baseline-scaffold` (stacked on the current integration tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical masking bug: Modal sandbox lifecycle failures and missing held-out test fixtures were classified as `TASK_FAILURE` (scored as an informative 0.0) instead of `TRANSIENT_INFRA` (excluded from the aggregate), causing a fully broken environment to masquerade as a real zero-score result. It also introduces a new `UPSTREAM_MODEL_UNAVAILABLE` category for cases where the configured model is not provisioned, which similarly should not be attributed to the candidate.

- New `UPSTREAM_MODEL_UNAVAILABLE` enum and policy (terminating, non-retryable, counts toward invalidity but never scored), with a new regex for `DeploymentNotFound`/`model_not_found`/Azure deployment-not-found phrases.
- New `TRANSIENT_INFRA` regex block covering Modal sandbox lifecycle signals, `AddTestsDirError`, `FetchSpec`/`loading container`, and `StreamTerminatedError`.
- `classify_case` precedence updated to insert `UPSTREAM_MODEL_UNAVAILABLE` between `AUTH_FAILURE` and `TRANSIENT_INFRA`, with four new regression tests covering the actual production error strings.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only widens the set of signals reclassified from task failure to infrastructure, backed by exact production error strings and covered by new regression tests.

The regex additions are anchored tightly to provider-specific error codes and harness-specific exception names. The new UPSTREAM_MODEL_UNAVAILABLE category is wired correctly into both the policy table and the classify_case precedence chain. The four new tests exercise the actual terminal exceptions from the production incident.

**Files Needing Attention:** No files require special attention beyond the stale classify_case docstring in error_taxonomy.py.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/evaluation/scoring/error_taxonomy.py | Adds UPSTREAM_MODEL_UNAVAILABLE category and two new signal-pattern blocks; precedence ordering in classify_case updated, but the docstring still only cites "budget, then auth" as terminating conditions, omitting the new category. |
| vero/tests/test_v05_error_taxonomy.py | Four new tests covering harness-environment-loss, upstream-model-unavailable policy and precedence, and the fetchspec/container-load disambiguation; good regression coverage for the production failure strings. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["classify_case(signals)"] --> B["classify_signal per signal"]
    B --> C{Pattern matched?}
    C -- "budget/quota" --> D["INFERENCE_BUDGET_EXHAUSTED"]
    C -- "auth/permission" --> E["AUTH_FAILURE"]
    C -- "deploymentnotfound / model_not_found" --> F["UPSTREAM_MODEL_UNAVAILABLE"]
    C -- "rate-limit / timeout / connection / 5xx" --> G["TRANSIENT_INFRA (existing)"]
    C -- "sandbox / addtestsdirerror / streamterminated / loading container / fetchspec" --> H["TRANSIENT_INFRA (new)"]
    C -- no match --> I["None to TASK_FAILURE"]
    D & E & F & G & H & I --> J["Precedence resolution"]
    J --> K{INFERENCE_BUDGET_EXHAUSTED?}
    K -- yes --> L["terminating, not scored"]
    K -- no --> M{AUTH_FAILURE?}
    M -- yes --> N["terminating, not scored"]
    M -- no --> O{UPSTREAM_MODEL_UNAVAILABLE NEW}
    O -- yes --> P["terminating, counts toward invalidity, not scored"]
    O -- no --> Q{TRANSIENT_INFRA?}
    Q -- yes --> R["retryable, counts toward invalidity, not scored"]
    Q -- no --> S["TASK_FAILURE: informative score at failure value"]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge pull request #60 from scaleapi/fix..."](https://github.com/scaleapi/vero/commit/d4582a1b27225f03bf6786304b700604ab7bc808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47185252)</sub>

<!-- /greptile_comment -->