### PR TITLE
fix: repair a scheme-less WANDB_BASE_URL and stop losing W&B sink failures

### DIFF
--- a/vero/src/vero/harbor/deployment.py
+++ b/vero/src/vero/harbor/deployment.py
@@ -25,6 +25,7 @@ from vero.evaluation.backends.command import CommandBackend, CommandBackendConfi
 from vero.evaluation.engine import EvaluationEngine
 from vero.harbor.backend import HarborBackend, HarborBackendConfig
 from vero.models import StrictModel
+from vero.runtime.artifacts import ArtifactStore
 from vero.sandbox import LocalSandbox
 from vero.sidecar.serve import SidecarComponents
 from vero.sidecar.session import initialize_harbor_session_manifest
@@ -323,13 +324,28 @@ async def build_harbor_components(config: dict) -> SidecarComponents:
                 log_traces=parsed.wandb.log_traces,
             )
             engine.listeners.append(wandb_sink)
-        except Exception:
+        except Exception as error:
             logger.warning(
                 "W&B reporting disabled: the sidecar sink could not be "
                 "initialized; the evaluation sidecar continues without it",
                 exc_info=True,
             )
             wandb_sink = None
+            # The warning above goes to the sidecar container's stderr, which no
+            # run artifact captures, so a silently disabled sink looks exactly
+            # like a healthy run that logged nothing. Record why in the session
+            # artifacts, which are archived into the exported run record.
+            try:
+                ArtifactStore(session_dir / "artifacts").write_json(
+                    "wandb/init-error.json",
+                    {
+                        "project": parsed.wandb.project,
+                        "error_type": type(error).__name__,
+                        "error": str(error),
+                    },
+                )
+            except OSError:
+                logger.warning("could not record the W&B init failure", exc_info=True)
 
     usage_path = (
         Path(parsed.inference_usage_path)

--- a/vero/src/vero/runtime/wandb.py
+++ b/vero/src/vero/runtime/wandb.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,31 @@ from vero.runtime.artifacts import ArtifactStore
 from vero.runtime.events import RuntimeEvent
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_wandb_base_url(environment: dict[str, str] | None = None) -> str | None:
+    """Give a scheme-less ``WANDB_BASE_URL`` the ``https://`` it needs.
+
+    A self-hosted host is naturally written ``scaleai.wandb.io``, but W&B's
+    settings model parses ``base_url`` as a URL and rejects that with
+    ``Input should be a valid URL, relative URL without a base``. The error
+    surfaces out of ``wandb.init()``, which callers treat as "W&B unavailable",
+    so one missing scheme silently costs a run all of its reporting.
+
+    Returns the value in effect, or None when the variable is unset.
+    """
+    environ = os.environ if environment is None else environment
+    value = (environ.get("WANDB_BASE_URL") or "").strip()
+    if not value or "://" in value:
+        return value or None
+    corrected = f"https://{value}"
+    environ["WANDB_BASE_URL"] = corrected
+    logger.warning(
+        "WANDB_BASE_URL %r has no scheme and would be rejected by W&B; using %r",
+        value,
+        corrected,
+    )
+    return corrected
 
 
 def _open_wandb_run(
@@ -43,6 +69,7 @@ def _open_wandb_run(
             raise RuntimeError(
                 "W&B reporting requires `pip install scale-vero[wandb]`"
             ) from error
+    normalize_wandb_base_url()
     wandb_dir.mkdir(parents=True, exist_ok=True)
     stable_id = run_id or ("vero-" + hashlib.sha256(session_id.encode()).hexdigest()[:16])
     init_kwargs: dict[str, Any] = {
@@ -96,6 +123,7 @@ class WandbEventSink:
                     "W&B reporting requires `pip install scale-vero[wandb]`"
                 ) from error
 
+        normalize_wandb_base_url()
         wandb_dir = session_dir / "artifacts" / "wandb"
         wandb_dir.mkdir(parents=True, exist_ok=True)
         self.artifacts = ArtifactStore(session_dir / "artifacts")

--- a/vero/tests/test_v05_harbor_deployment.py
+++ b/vero/tests/test_v05_harbor_deployment.py
@@ -270,3 +270,76 @@ async def test_deployment_finalize_hook_archives_gateway_state(tmp_path):
     assert (
         exported / "requests/requests-00001.jsonl"
     ).read_text() == '{"scope":"producer"}\n'
+
+
+@pytest.mark.asyncio
+async def test_wandb_init_failure_is_recorded_in_the_session_artifacts(tmp_path):
+    # A sink that cannot start only logs to the sidecar container's stderr, which
+    # no run artifact captures, so a disabled sink is indistinguishable from a
+    # healthy run that logged nothing. Leave the reason behind in the session.
+    trusted = tmp_path / "trusted"
+    agent = tmp_path / "agent"
+    _repo(trusted, "VALUE = 1\n")
+    _repo(agent, "VALUE = 1\n")
+    cases = tmp_path / "cases.json"
+    cases.write_text('[{"id":"task","task_name":"org/task"}]')
+    evaluation_set = EvaluationSet(name="benchmark")
+    objective = ObjectiveSpec(
+        selector=MetricSelector(metric="score"),
+        direction="maximize",
+    )
+    session_dir = tmp_path / "state/session"
+    config = {
+        "repo_path": str(trusted),
+        "agent_repo_path": str(agent),
+        "session_dir": str(session_dir),
+        "backends": {
+            "backend": {
+                "task_source": "org/benchmark@1.0",
+                "agent_import_path": "program:Agent",
+                "cases_path": str(cases),
+                "harbor_requirement": "harbor==0.1.17",
+                "uv_executable": sys.executable,
+            }
+        },
+        "access_policies": [],
+        "budgets": [],
+        "selection": {
+            "mode": "auto_best",
+            "backend_id": "backend",
+            "evaluation_set": evaluation_set.model_dump(mode="json"),
+            "objective": objective.model_dump(mode="json"),
+            "baseline_version": "HEAD",
+        },
+        "targets": [
+            {
+                "reward_key": "reward",
+                "backend_id": "backend",
+                "evaluation_set": evaluation_set.model_dump(mode="json"),
+                "objective": objective.model_dump(mode="json"),
+            }
+        ],
+        "admin_volume": str(tmp_path / "state/admin"),
+        "wandb": {"project": "vero-tests"},
+    }
+
+    import vero.runtime.wandb as wandb_module
+
+    def _explode(**kwargs):
+        raise ValueError("Input should be a valid URL, relative URL without a base")
+
+    original = wandb_module.SidecarWandbSink
+    wandb_module.SidecarWandbSink = _explode
+    try:
+        components = await build_harbor_components(config)
+    finally:
+        wandb_module.SidecarWandbSink = original
+
+    # The eval path survives: observability never takes the sidecar down.
+    assert components.telemetry is None
+    recorded = json.loads(
+        (session_dir / "artifacts/wandb/init-error.json").read_text()
+    )
+    assert recorded["project"] == "vero-tests"
+    assert recorded["error_type"] == "ValueError"
+    assert "valid URL" in recorded["error"]

--- a/vero/tests/test_v05_wandb.py
+++ b/vero/tests/test_v05_wandb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -402,3 +403,31 @@ def test_sidecar_wandb_telemetry_is_best_effort(tmp_path: Path):
     poller.poll_once()  # must not raise
     assert client.run.logged == []
     assert client.run.artifacts == []
+
+
+def test_scheme_less_wandb_base_url_is_repaired_before_init(tmp_path: Path, monkeypatch):
+    """A self-hosted host written without a scheme must not silently kill reporting.
+
+    W&B parses `base_url` as a URL, so `WANDB_BASE_URL=scaleai.wandb.io` raises
+    out of `wandb.init()` and the sidecar disables W&B for the whole run.
+    """
+    from vero.runtime.wandb import normalize_wandb_base_url
+
+    monkeypatch.setenv("WANDB_BASE_URL", "scaleai.wandb.io")
+    assert normalize_wandb_base_url() == "https://scaleai.wandb.io"
+    assert os.environ["WANDB_BASE_URL"] == "https://scaleai.wandb.io"
+
+    # Already-qualified values, including plain http, are left exactly as given.
+    monkeypatch.setenv("WANDB_BASE_URL", "http://localhost:8080")
+    assert normalize_wandb_base_url() == "http://localhost:8080"
+    assert os.environ["WANDB_BASE_URL"] == "http://localhost:8080"
+
+    monkeypatch.delenv("WANDB_BASE_URL", raising=False)
+    assert normalize_wandb_base_url() is None
+
+    # And the repair happens before a sink opens its run.
+    monkeypatch.setenv("WANDB_BASE_URL", "scaleai.wandb.io")
+    SidecarWandbSink(
+        project="v", session_id="s", session_dir=tmp_path / "session", client=FakeWandb()
+    )
+    assert os.environ["WANDB_BASE_URL"] == "https://scaleai.wandb.io"


### PR DESCRIPTION
Closes #52 (pending the live confirmation noted at the bottom).

## The symptom

No harbor benchmark run has ever reported anything to the self-hosted W&B. Entity `shehab-yasser` listed **zero projects**. Every run's exported `session/artifacts/wandb/state.json` looked like this:

```json
{"evaluation_ids": [], "next_step": 0, "run_id": "vero-a25e1cd8b7064d7e", "request_log_files": {}}
```

…from the 2026-07-25 swe-atlas-qna run whose session contains **11 completed evaluations**. So "nothing was logged" was never "nothing happened".

## The mechanism

That exact fingerprint is what `SidecarWandbSink.__init__` leaves behind when `wandb.init()` throws. `_save_state()` runs at `runtime/wandb.py:225`, `_open_wandb_run()` at `:230`. `harbor/deployment.py:265-287` catches anything out of the constructor and continues with `wandb_sink = None`, by design — observability must not take the eval path down.

## The cause, reproduced locally at \$0

```
$ WANDB_BASE_URL=scaleai.wandb.io python -c "import wandb; wandb.init(project='vero-egress-probe', ...)"
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
base_url
  Input should be a valid URL, relative URL without a base
    [type=url_parsing, input_value='scaleai.wandb.io', input_type=str]
```

W&B parses `base_url` as a URL. The natural way to write a self-hosted host is rejected, and the rejection is indistinguishable from "W&B is unavailable".

Same script with `https://` prepended:

```
INIT OK -> https://scaleai.wandb.io/shehab-yasser/vero-egress-probe/runs/vero-probe-0001
wandb: Synced 5 W&B file(s), 0 media file(s), 2 artifact file(s)
FINISH OK
```

The project auto-created server-side; `query_wandb_entity_projects(entity="shehab-yasser")` went from `[]` to `[vero-egress-probe]`. Metrics logged, `wandb.Artifact` uploaded. **Egress was never blocked, credentials were never missing, and the code was never unplumbed.**

Note the repo's own `swe-bench-pro/baseline/secrets.env.example:23` already gets it right (`WANDB_BASE_URL=https://scaleai.wandb.io`); the live gitignored `secrets.env` had drifted to the scheme-less form. Since the deployed secrets file is not in the repo, fixing only the file would leave the trap armed for the next operator.

## Also worth correcting

Issue #52 is titled "Weave traces". There is no Weave in this codebase — `weave` is not a dependency and is not importable in the built env. `wandb.log_traces` drives `SidecarWandbSink._log_trace`, which uploads a `wandb.Artifact` of type `evaluation_trace`. So `count_weave_traces` would return nothing even on a perfectly healthy run; the right server-side check is whether the **project** exists and carries runs and artifacts.

## Changes

- `normalize_wandb_base_url()` prepends `https://` to a scheme-less `WANDB_BASE_URL` and warns; called before both `wandb.init()` sites. Values that already carry a scheme (including `http://localhost:8080`) pass through untouched; unset stays unset.
- The swallowed init failure now also lands in `session/artifacts/wandb/init-error.json` with the exception type and message. The existing `logger.warning` only reaches the sidecar container's stderr, which **no run artifact captures** — grepping every artifact of the failing run for "wandb" returns nothing. That invisibility is what made a one-line config bug survive multiple runs.

Tests: `test_scheme_less_wandb_base_url_is_repaired_before_init` (repair, passthrough, unset, and that a sink repairs before opening its run) and `test_wandb_init_failure_is_recorded_in_the_session_artifacts` (eval path survives, reason is durable).

## Still to confirm

The local probe proves the URL fix and that scaleai.wandb.io is reachable **from this laptop**. Modal-sandbox egress to it is not yet proven. A live benchmark run on this branch is queued; I will post the resulting project URL and artifact count here before this merges.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent failure modes that caused every harbor benchmark run to report nothing to the self-hosted W&B instance: a scheme-less `WANDB_BASE_URL` that W&B's pydantic model rejected, and a swallowed init failure that left no durable evidence in run artifacts.

- `normalize_wandb_base_url()` prepends `https://` to any scheme-less value and mutates `os.environ` in-place so W&B's settings model receives the corrected URL; it is called before both independent `wandb.init()` sites (`_open_wandb_run` for `SidecarWandbSink`, and directly in `WandbEventSink.__init__`).
- On construction failure, `deployment.py` now writes `wandb/init-error.json` into the session artifact directory (in addition to the existing stderr warning), making the failure discoverable via the exported run record rather than only through transient container logs.
- Two new tests cover scheme repair (including passthrough and unset), repair-before-run-open for `SidecarWandbSink`, eval-path survival on init failure, and durability of the recorded error.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge once the live benchmark run confirms Modal-sandbox egress to scaleai.wandb.io (as noted in the PR description).

Both changes are narrow and defensive: URL normalization is idempotent and only fires on misconfigured input, and the error-recording path is wrapped in its own OSError guard so it can never affect the eval path. The existing sink-failure handling is preserved exactly; only the durability of the diagnosis is improved. Tests cover the new code paths directly.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/runtime/wandb.py | Adds normalize_wandb_base_url() helper and calls it before both wandb.init() sites; the function is idempotent and correctly mutates os.environ so W&B's pydantic settings model picks up the corrected value. |
| vero/src/vero/harbor/deployment.py | On W&B sink construction failure, now writes wandb/init-error.json into the session artifacts in addition to the existing stderr warning; uses except OSError as a safe fallback so artifact-write errors cannot interrupt the eval path. |
| vero/tests/test_v05_wandb.py | Adds test_scheme_less_wandb_base_url_is_repaired_before_init covering scheme-less repair, already-qualified passthrough, unset, and repair-before-run-open for SidecarWandbSink. |
| vero/tests/test_v05_harbor_deployment.py | Adds test_wandb_init_failure_is_recorded_in_the_session_artifacts; monkey-patches SidecarWandbSink with an exploding callable, verifies the eval path survives and that wandb/init-error.json carries the project name, exception type, and message. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["WANDB_BASE_URL set in env"] --> B{normalize_wandb_base_url}
    B -->|"has '://' or empty"| C["pass through unchanged"]
    B -->|"scheme-less e.g. scaleai.wandb.io"| D["prepend https://\nlog warning\nmutate os.environ"]
    C --> E[wandb.init]
    D --> E

    subgraph SidecarWandbSink path
        F["SidecarWandbSink.__init__"] --> G["_save_state (run_id persisted)"]
        G --> H["_open_wandb_run()"]
        H --> B
    end

    subgraph WandbEventSink path
        I["WandbEventSink.__init__"] --> B
    end

    E -->|"success"| J["sink attached to engine.listeners"]
    E -->|"exception"| K["except Exception as error"]
    K --> L["logger.warning (stderr only)"]
    L --> M["ArtifactStore.write_json\nwandb/init-error.json"]
    M -->|"OSError"| N["logger.warning, continue"]
    M -->|"success"| O["wandb_sink = None\neval path continues"]
    N --> O
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: repair a scheme-less WANDB\_BASE\_URL..."](https://github.com/scaleapi/vero/commit/934cc4f50714ae3ac870053d553466967959f0eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47194440)</sub>

<!-- /greptile_comment -->