### PR TITLE
fix: a missing upstream deployment is not a task failure

### DIFF
--- a/vero/src/vero/evaluation/scoring/error_taxonomy.py
+++ b/vero/src/vero/evaluation/scoring/error_taxonomy.py
@@ -43,6 +43,11 @@ class ErrorCategory(str, Enum):
     #: Authentication/authorization failed (e.g. a wrong or cycled key). Does
     #: not heal on retry: terminate loudly.
     AUTH_FAILURE = "auth_failure"
+    #: The requested model is not deployed on the configured upstream. A
+    #: permanent misconfiguration, not the candidate's doing: never scored as a
+    #: sample, and terminating, because every remaining case will fail the same
+    #: way and the run has nothing left to measure.
+    UPSTREAM_MODEL_UNAVAILABLE = "upstream_model_unavailable"
     #: Transient external infrastructure (rate limit, timeout, connection, 5xx,
     #: overloaded). Retryable; if it persists it renders the aggregate invalid.
     TRANSIENT_INFRA = "transient_infra"
@@ -90,6 +95,16 @@ _POLICIES: dict[ErrorCategory, CategoryPolicy] = {
         counts_toward_invalidity=False,
         is_informative_sample=False,
         diagnostic_code="auth_failure",
+    ),
+    ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE: CategoryPolicy(
+        retryable=False,
+        terminating=True,
+        # Unlike auth, keep counting these toward invalidity: if the terminating
+        # path is ever bypassed, the aggregate must still come out invalid
+        # rather than silently averaging a shrinking set of survivors.
+        counts_toward_invalidity=True,
+        is_informative_sample=False,
+        diagnostic_code="upstream_model_unavailable",
     ),
     ErrorCategory.TRANSIENT_INFRA: CategoryPolicy(
         retryable=True,
@@ -150,6 +165,21 @@ _SIGNAL_PATTERNS: list[tuple[re.Pattern[str], ErrorCategory]] = [
         ErrorCategory.AUTH_FAILURE,
     ),
     (
+        # A model that is configured but not provisioned upstream. Left
+        # unclassified this is the worst kind of silent failure: the agent's
+        # every call 404s, it writes no answer, and the case is recorded as an
+        # informative task failure: the harness blaming the candidate for a
+        # model that does not exist. Matched on the provider's own error codes
+        # and on the exact Azure sentence, never on a bare "does not exist",
+        # which would also swallow "loading container: file does not exist".
+        re.compile(
+            r"deploymentnotfound|model_not_found|"
+            r"the api deployment for this resource does not exist",
+            re.IGNORECASE,
+        ),
+        ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE,
+    ),
+    (
         re.compile(
             r"rate.?limit|too.?many.?requests|time(?:d.?)?out|connection|"
             r"service.?unavailable|internal.?server|overloaded|"
@@ -205,6 +235,9 @@ def classify_case(signals: list[str]) -> ErrorCategory:
     for category in (
         ErrorCategory.INFERENCE_BUDGET_EXHAUSTED,
         ErrorCategory.AUTH_FAILURE,
+        # Ahead of infra: a case that saw both a dead sandbox and a missing
+        # deployment should report the deterministic, operator-fixable one.
+        ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE,
         ErrorCategory.TRANSIENT_INFRA,
     ):
         if category in categories:

--- a/vero/tests/test_v05_error_taxonomy.py
+++ b/vero/tests/test_v05_error_taxonomy.py
@@ -95,3 +95,62 @@ def test_classify_case_treats_environment_loss_as_infra_not_task_failure():
     )
     # A candidate's own bug is still an informative task failure, unchanged.
     assert classify_case(["ValueError"]) is ErrorCategory.TASK_FAILURE
+
+
+def test_a_missing_upstream_deployment_is_not_a_task_failure():
+    """The 2026-07-25 swe-atlas-qna run's exact terminal exceptions.
+
+    145 of its 469 cases died on a model that is not provisioned. Classified as
+    a task failure, each was recorded as an informative score of 0.0: the
+    harness blaming the candidate for a model that does not exist.
+    """
+    azure = (
+        "Error code: 404 - {'error': {'type': 'invalid_request_error', "
+        "'code': 'DeploymentNotFound', 'message': 'The API deployment for this "
+        "resource does not exist. If you created the deployment within the "
+        "last 5 minutes, please wait a moment and try again.'}}"
+    )
+    assert (
+        classify_signal(azure) is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+    assert (
+        classify_signal("model_not_found") is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+    assert (
+        classify_case(["NotFoundError", azure])
+        is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+
+    unavailable = policy(ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE)
+    assert not unavailable.is_informative_sample
+    assert not unavailable.retryable
+    assert unavailable.terminating
+    assert unavailable.counts_toward_invalidity
+
+    # It outranks a co-occurring sandbox death: the deterministic,
+    # operator-fixable cause is the one worth reporting.
+    assert (
+        classify_case(
+            [
+                "NotFoundError",
+                "Modal Sandbox with container ID ta-01KY not found.",
+                azure,
+            ]
+        )
+        is ErrorCategory.UPSTREAM_MODEL_UNAVAILABLE
+    )
+
+
+def test_missing_deployment_pattern_does_not_swallow_container_load_failures():
+    """`FetchSpec failed: loading container: file does not exist` is infra.
+
+    It is 102 of that same run's cases, and it also contains "does not exist",
+    so the deployment pattern must not be written loosely enough to claim it.
+    """
+    fetchspec = "FetchSpec failed: loading container: file does not exist\n"
+    assert classify_signal(fetchspec) is ErrorCategory.TRANSIENT_INFRA
+    assert classify_case(["RuntimeError", fetchspec]) is ErrorCategory.TRANSIENT_INFRA
+    assert (
+        classify_case(["AddTestsDirError", "Failed to add tests directory to environment."])
+        is ErrorCategory.TRANSIENT_INFRA
+    )


### PR DESCRIPTION
Stacked on #53. Refs #51.

## The gap #53 left

#53 stopped a dead sandbox being scored as an informative zero. The same masking survives one layer up, for a cause that is both more common and easier to fix.

Full per-case terminal-exception census of the 2026-07-25 swe-atlas-qna run (469 cases, every one scored 0.0):

| n | exception | classified as | correct? |
|---:|---|---|---|
| 165 | `NotFoundError: Modal Sandbox with container ID ta-… not found` | `transient_infra` | ✅ (thanks to #53) |
| **145** | `NotFoundError: 404 … 'code': 'DeploymentNotFound'` | **`task_failure`** | ❌ |
| 102 | `RuntimeError: FetchSpec failed: loading container: file does not exist` | `transient_infra` | ✅ |
| 53 | `AddTestsDirError: Failed to add tests directory` | `transient_infra` | ✅ |
| 4 | `NotFoundError: Task has already finished with status failure` | `task_failure` | ❌ (see below) |

Those 145 are the configured eval model not being provisioned on the Azure resource. The agent's every call 404s, it writes no answer, `classify_case` finds nothing it recognises in the signal and falls through to `TASK_FAILURE`, whose policy is `is_informative_sample=True`. Each case therefore became a genuine score of 0.0, and the harness reported that **the candidate failed the task** — for a model that does not exist.

This is exactly the failure mode the module's own docstring says it exists to prevent: *"recorded 'nothing shipped' as a real score of zero"*.

## The change

`UPSTREAM_MODEL_UNAVAILABLE`:

- `is_informative_sample=False` — the point of the fix; these stop polluting the aggregate.
- `retryable=False` — it will not heal.
- `terminating=True` — every remaining case fails identically, so there is nothing left to measure. Matches `AUTH_FAILURE`'s shape; both are permanent operator-fixable misconfigurations.
- `counts_toward_invalidity=True` — unlike `AUTH_FAILURE`. If the terminating path is ever bypassed, the aggregate must still come out invalid rather than quietly averaging a shrinking set of survivors.

Ranked **above** `TRANSIENT_INFRA` in `classify_case`, so a case that saw both a dead sandbox and a missing deployment reports the deterministic, operator-fixable cause.

## The precision that matters

The obvious pattern for this is "does not exist". That would be a bug: 102 cases in the same run fail with `FetchSpec failed: loading container: file does not exist`, which is genuine infrastructure and must stay `transient_infra`. The pattern therefore matches only the provider's own error codes (`DeploymentNotFound`, `model_not_found`) and the exact Azure sentence. `test_missing_deployment_pattern_does_not_swallow_container_load_failures` pins that boundary using the run's literal strings.

## Not fixed here

The 4 `NotFoundError: Task has already finished with status failure` cases are Modal sandbox deaths that still land in `task_failure`, because neither the type name nor the message contains any word the infra pattern recognises. Small enough to leave rather than widen a regex on 4 samples, but worth knowing the taxonomy is still keyed off message text and will keep missing variants like this. A structural signal (the exception's module, e.g. `modal.exception.*`) would be a better long-term key.

Tests: `test_a_missing_upstream_deployment_is_not_a_task_failure` and `test_missing_deployment_pattern_does_not_swallow_container_load_failures`, both using the exact strings from the run. Full suite 386 passed / 1 environmental failure (Docker daemon down) / 5 skipped.

Complements #59, which stops the run from ever starting when a configured model is not deployed. This one handles the case where a deployment disappears mid-run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces `UPSTREAM_MODEL_UNAVAILABLE` as a new `ErrorCategory` to fix 145 of 469 swe-atlas-qna cases being wrongly treated as informative task failures when the Azure deployment for the evaluation model was simply not provisioned. The policy is `is_informative_sample=False`, `terminating=True`, `retryable=False`, and `counts_toward_invalidity=True`.

- Adds a precise signal pattern (`deploymentnotfound`, `model_not_found`, the exact Azure sentence) ordered before the TRANSIENT_INFRA block in both `_SIGNAL_PATTERNS` and the `classify_case` priority chain, so a case that saw both a dead sandbox and a missing deployment reports the deterministic, operator-fixable cause.
- Ships two tests using the run's literal exception strings: one verifying the full policy contract, and one pinning the boundary so `FetchSpec failed: loading container: file does not exist` cannot be misclassified by the new pattern.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped, backed by production data, and cannot misclassify existing categories

The signal pattern is deliberately narrow (provider-specific error codes and the exact Azure sentence) to prevent false positives, and the boundary test pins that distinction. Policy choices are coherent with the existing taxonomy. The only gap is a stale two-word docstring phrase with no runtime effect.

**Files Needing Attention:** No files require special attention
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/evaluation/scoring/error_taxonomy.py | Adds UPSTREAM_MODEL_UNAVAILABLE category with policy (non-informative, terminating, counts toward invalidity), a precise signal-matching pattern, and correct precedence in classify_case; docstring for classify_case is slightly stale |
| vero/tests/test_v05_error_taxonomy.py | Adds two focused tests using the run's exact production strings: one proving UPSTREAM_MODEL_UNAVAILABLE is classified and policy-checked correctly, one pinning the boundary so container-load failures are not swallowed by the new pattern |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[signals: list of str] --> B[classify_signal each signal]
    B --> C{Pattern match}
    C -->|budget/quota| D[INFERENCE_BUDGET_EXHAUSTED]
    C -->|auth/permission| E[AUTH_FAILURE]
    C -->|DeploymentNotFound / model_not_found / Azure sentence| F[UPSTREAM_MODEL_UNAVAILABLE]
    C -->|rate-limit / timeout / connection / 5xx| G[TRANSIENT_INFRA]
    C -->|sandbox / container / fetchspec| G
    C -->|no match / empty| H[None]
    D & E & F & G & H --> I[categories set]
    I --> J{Priority check}
    J -->|INFERENCE_BUDGET_EXHAUSTED in set| K[return INFERENCE_BUDGET_EXHAUSTED]
    J -->|AUTH_FAILURE in set| L[return AUTH_FAILURE]
    J -->|UPSTREAM_MODEL_UNAVAILABLE in set| M[return UPSTREAM_MODEL_UNAVAILABLE]
    J -->|TRANSIENT_INFRA in set| N[return TRANSIENT_INFRA]
    J -->|none matched| O[return TASK_FAILURE]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: a missing upstream deployment is no..."](https://github.com/scaleapi/vero/commit/10515d12ad0e8c489752f035fb13c94c6ea82917) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47197152)</sub>

<!-- /greptile_comment -->