### PR TITLE
fix: keep the swe-bench-pro seed agent's task context across tool turns

### DIFF
--- a/harness-engineering-bench/swe-bench-pro/baseline/target/src/swebench_pro_agent/agent.py
+++ b/harness-engineering-bench/swe-bench-pro/baseline/target/src/swebench_pro_agent/agent.py
@@ -47,6 +47,12 @@ MAX_TURNS = 50
 MAX_TOOL_OUTPUT_CHARS = 20_000
 MAX_FILE_READ_CHARS = 60_000
 
+# ``run`` resends the whole conversation every turn instead of relying on the
+# provider to remember it, so the transcript has to be bounded: 50 turns of
+# 20k-character tool output would overflow any context window. Oldest whole
+# turns are dropped first and the task statement is never dropped.
+MAX_HISTORY_CHARS = 300_000
+
 # Repository checkout location inside the task environment. The pinned
 # swebenchpro task images set `WORKDIR /app` and reset the project's git
 # checkout in place there, and the task instruction says so verbatim ("I've
@@ -285,6 +291,26 @@ class SweBenchProAgent(BaseAgent):
         omitted = len(value) - (2 * half)
         return f"{value[:half]}\n...[{omitted} characters omitted]...\n{value[-half:]}"
 
+    @staticmethod
+    def _history_size(blocks: list[list[dict[str, Any]]]) -> int:
+        return sum(
+            len(json.dumps(item, ensure_ascii=False))
+            for block in blocks
+            for item in block
+        )
+
+    def _trim_history(self, blocks: list[list[dict[str, Any]]]) -> int:
+        """Drop whole oldest turns until the transcript fits the budget.
+
+        Whole turns, never individual items: a ``function_call`` sent without its
+        matching ``function_call_output`` is a hard 400 from the Responses API.
+        """
+        dropped = 0
+        while len(blocks) > 1 and self._history_size(blocks) > MAX_HISTORY_CHARS:
+            blocks.pop(0)
+            dropped += 1
+        return dropped
+
     def _trace(self, event: dict[str, Any]) -> None:
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         trace_path = self.logs_dir / "swe-bench-pro-trace.jsonl"
@@ -447,17 +473,30 @@ class SweBenchProAgent(BaseAgent):
         context: AgentContext,
     ) -> None:
         self._patch_index = 0
-        next_input: Any = instruction
-        previous_response_id: str | None = None
         input_tokens = 0
         output_tokens = 0
         cached_tokens = 0
+        # The conversation is held HERE, not on the provider. An earlier version
+        # sent only the newest tool result and passed ``previous_response_id`` to
+        # let the server reconstruct the rest. That silently loses everything on
+        # any OpenAI-compatible gateway that accepts the field without backing it
+        # with a response store: from turn 2 the model saw a bare tool result with
+        # no task attached, so it re-explored the repository until the turn budget
+        # ran out. Measured on the 66-case sample with deepseek-v4-flash: 66/66
+        # exhausted all 50 turns, 3163 of 3300 tool calls were ls/find/git/cat, and
+        # write_file, apply_patch and submit were called zero times, for a reward
+        # of 0.0000 on every case.
+        task_item: dict[str, Any] = {"role": "user", "content": instruction}
+        blocks: list[list[dict[str, Any]]] = []
 
         for turn in range(1, MAX_TURNS + 1):
+            conversation: list[Any] = [task_item]
+            for block in blocks:
+                conversation.extend(block)
             request: dict[str, Any] = {
                 "model": self._api_model,
                 "instructions": INSTRUCTIONS,
-                "input": next_input,
+                "input": conversation,
                 "tools": TOOLS,
                 "max_output_tokens": 12_000,
                 "parallel_tool_calls": False,
@@ -466,8 +505,6 @@ class SweBenchProAgent(BaseAgent):
             # gpt-4.1 is a hard 400 on the very first turn.
             if _is_reasoning_model(self._api_model):
                 request["reasoning"] = {"effort": "high"}
-            if previous_response_id is not None:
-                request["previous_response_id"] = previous_response_id
             response = await self._responses_create(**request)
             usage = response.usage
             input_tokens += self._usage_value(usage, "input_tokens")
@@ -494,9 +531,23 @@ class SweBenchProAgent(BaseAgent):
                 context.metadata = {"turns": turn, "trace": "swe-bench-pro-trace.jsonl"}
                 break
 
-            next_input = []
+            turn_items: list[dict[str, Any]] = []
+            if response.output_text:
+                turn_items.append(
+                    {"role": "assistant", "content": response.output_text}
+                )
             submitted = False
             for call in calls:
+                # Echo the call itself before its output: the API matches the two
+                # by call_id, and an orphaned output is rejected.
+                turn_items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call.call_id,
+                        "name": call.name,
+                        "arguments": call.arguments,
+                    }
+                )
                 try:
                     arguments = json.loads(call.arguments or "{}")
                 except json.JSONDecodeError as error:
@@ -531,7 +582,7 @@ class SweBenchProAgent(BaseAgent):
                     else:
                         result = {"error": f"unknown tool: {call.name}"}
                 self._trace({"turn": turn, "tool": call.name, "result": result})
-                next_input.append(
+                turn_items.append(
                     {
                         "type": "function_call_output",
                         "call_id": call.call_id,
@@ -540,10 +591,13 @@ class SweBenchProAgent(BaseAgent):
                 )
                 if submitted:
                     break
+            blocks.append(turn_items)
+            dropped = self._trim_history(blocks)
+            if dropped:
+                self._trace({"turn": turn, "event": "history_trimmed", "turns_dropped": dropped})
             if submitted:
                 context.metadata = {"turns": turn, "trace": "swe-bench-pro-trace.jsonl"}
                 break
-            previous_response_id = response.id
         else:
             # Exhausting the turn budget is NOT a trial failure. The reward comes
             # from the task's hidden suite run against whatever the agent left in

--- a/harness-engineering-bench/swe-bench-pro/baseline/target/tests/test_agent.py
+++ b/harness-engineering-bench/swe-bench-pro/baseline/target/tests/test_agent.py
@@ -129,6 +129,96 @@ async def test_responses_create_retries_transient_errors(tmp_path, monkeypatch):
     }
 
 
+class TwoTurnResponses:
+    """Runs one shell command, then submits. Records every request it received."""
+
+    def __init__(self):
+        self.calls = 0
+        self.requests: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.calls += 1
+        self.requests.append(kwargs)
+        name = "run_shell" if self.calls == 1 else "submit"
+        arguments = '{"command": "git status --short"}' if self.calls == 1 else "{}"
+        return SimpleNamespace(
+            id=f"response-{self.calls}",
+            output=[
+                SimpleNamespace(
+                    type="function_call",
+                    name=name,
+                    arguments=arguments,
+                    call_id=f"call-{self.calls}",
+                )
+            ],
+            output_text="",
+            usage=SimpleNamespace(
+                input_tokens=10,
+                output_tokens=1,
+                input_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_conversation_is_resent_and_never_relies_on_the_provider(
+    tmp_path, monkeypatch
+):
+    """The task and prior turns must be in the request, not on the server.
+
+    Regression test for the bug that scored 0.0000 on all 66 sampled cases:
+    the agent sent only the newest tool result plus ``previous_response_id``,
+    so a gateway without a response store dropped the task entirely.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    agent = SweBenchProAgent(logs_dir=tmp_path / "logs", model_name="openai/gpt-4o")
+    responses = TwoTurnResponses()
+    agent._client = SimpleNamespace(responses=responses)
+    context = SimpleNamespace(
+        metadata=None,
+        n_input_tokens=None,
+        n_output_tokens=None,
+        n_cache_tokens=None,
+    )
+
+    task = "Preserve this exact objective after every tool call."
+    await agent.run(task, FakeEnvironment(), context)
+
+    assert len(responses.requests) == 2
+    # Never delegate memory to the provider.
+    assert all("previous_response_id" not in r for r in responses.requests)
+    # The task survives into the second turn, carried by us.
+    second = responses.requests[1]["input"]
+    assert second[0] == {"role": "user", "content": task}
+    # ... and so does the first turn's call together with its output.
+    kinds = [item.get("type") for item in second[1:]]
+    assert "function_call" in kinds and "function_call_output" in kinds
+    call = next(i for i in second[1:] if i.get("type") == "function_call")
+    output = next(i for i in second[1:] if i.get("type") == "function_call_output")
+    assert call["call_id"] == output["call_id"], "orphaned output is a 400"
+    assert "git status --short" in call["arguments"]
+
+
+def test_trim_history_drops_whole_turns_and_keeps_pairs_matched(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    agent = SweBenchProAgent(logs_dir=tmp_path / "logs", model_name="openai/gpt-4o")
+    blocks = [
+        [
+            {"type": "function_call", "call_id": f"c{i}", "name": "run_shell",
+             "arguments": "{}"},
+            {"type": "function_call_output", "call_id": f"c{i}", "output": "x" * 80_000},
+        ]
+        for i in range(10)
+    ]
+    dropped = agent._trim_history(blocks)
+
+    assert dropped > 0, "an oversized transcript must be trimmed"
+    assert agent._history_size(blocks) <= 300_000
+    for block in blocks:
+        ids = [i["call_id"] for i in block]
+        assert len(set(ids)) == 1, "a turn must keep its call and output together"
+
+
 def test_agent_requires_model(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     with pytest.raises(ValueError, match="requires a Harbor model"):


### PR DESCRIPTION
## What was broken

The swe-bench-pro seed agent delegated its conversation state to the Responses API
field `previous_response_id`. The LiteLLM gateway accepts that field without
backing it with a response store, so from turn two onward the model received a
bare tool result with no task attached. It had no idea what it was supposed to be
doing.

## Evidence

Measured over the 66-case sampled test split, before the fix:

- `write_file`, `apply_patch` and `submit` were called **zero** times
- 3163 of 3300 tool calls were `ls` / `find` / `git` / `cat`, so the agent spent
  every turn re-orienting
- all 66 cases exhausted the 50-turn budget in under seven minutes each
- the split scored **0.0000**

With the transcript held locally and resent on every turn, the same 66 cases
score **0.2000**, and 10 development cases score **0.3000**.

## The fix

Keep the transcript in the agent and resend it, instead of trusting the gateway
to remember it.

The history is bounded at `MAX_HISTORY_CHARS` and trimmed by whole turns, never
by individual items: a `function_call` sent without its matching
`function_call_output` is a hard 400 from the Responses API, so a naive
item-level trim would turn a context problem into a crash.

## Tests

`tests/test_agent.py` gains coverage for the resend path and for the
whole-turn trimming invariant, including the case where trimming would
otherwise orphan a `function_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical regression where the SWE-bench-pro agent scored 0.0000 across all sampled cases because it relied on `previous_response_id` to maintain conversation state — a field the LiteLLM gateway silently accepts but doesn't back with a response store. The fix moves conversation ownership into the agent itself, resending the full transcript every turn with a `MAX_HISTORY_CHARS` budget enforced by whole-turn trimming.

- **Core change (`agent.py`):** Removes `previous_response_id` and introduces a `blocks` list that accumulates each turn's `function_call`/`function_call_output` pairs; the full conversation (`task_item + blocks`) is reconstructed and sent on every call to the Responses API.
- **History bounding (`_trim_history`):** Drops the oldest whole turns (never individual items) to stay under `MAX_HISTORY_CHARS = 300_000`; the task statement is never trimmed, and the whole-turn invariant prevents orphaned `function_call` items that would cause a hard API 400.
- **Tests (`test_agent.py`):** Two new tests cover the resend path (asserting `previous_response_id` is absent and the task survives to the second request) and the trimming invariant (asserting dropped turns always keep their call/output pairs matched).

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The conversation-replay logic is straightforward and well-tested; the only loose end is a hardcoded size literal in the new test.

The agent fix is correct and well-documented. The one notable issue is that `test_trim_history_drops_whole_turns_and_keeps_pairs_matched` asserts the post-trim size against the literal `300_000` rather than importing `MAX_HISTORY_CHARS`, so if the budget constant is ever adjusted the test will silently validate against the wrong threshold. Nothing in the production path is broken by this.

**Files Needing Attention:** The test assertion on line 216 of `tests/test_agent.py` should reference `MAX_HISTORY_CHARS` instead of the hardcoded literal.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| harness-engineering-bench/swe-bench-pro/baseline/target/src/swebench_pro_agent/agent.py | Replaces `previous_response_id` delegation with a locally-maintained `blocks` list resent every turn; adds `MAX_HISTORY_CHARS` constant and `_trim_history`/`_history_size` helpers with whole-turn granularity to prevent orphaned `function_call` items. |
| harness-engineering-bench/swe-bench-pro/baseline/target/tests/test_agent.py | Adds `TwoTurnResponses` stub and two new tests — one verifying the full conversation is resent and `previous_response_id` is never sent, and one verifying whole-turn trimming and call/output pair integrity; one assertion hard-codes `300_000` instead of importing `MAX_HISTORY_CHARS`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant blocks as blocks[]
    participant API as Responses API

    Note over Agent: task_item = {role:user, content:instruction}
    Note over Agent: blocks = []

    loop each turn (up to MAX_TURNS)
        Agent->>Agent: "conversation = [task_item] + flatten(blocks)"
        Agent->>API: "responses.create(input=conversation)"
        API-->>Agent: response (output, function_calls)

        alt no tool calls
            Agent->>Agent: break (done)
        else has tool calls
            Agent->>Agent: "build turn_items = [function_call, function_call_output, ...]"
            Agent->>blocks: blocks.append(turn_items)
            Agent->>Agent: "_trim_history(blocks) — drop oldest whole turns if > MAX_HISTORY_CHARS"
            alt submitted
                Agent->>Agent: break
            end
        end
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aharness-engineering-bench%2Fswe-bench-pro%2Fbaseline%2Ftarget%2Ftests%2Ftest_agent.py%3A216%0AThe%20size%20assertion%20uses%20the%20literal%20%60300_000%60%20rather%20than%20the%20%60MAX_HISTORY_CHARS%60%20constant%20defined%20in%20%60agent.py%60.%20If%20the%20budget%20is%20ever%20tuned%2C%20this%20assertion%20will%20silently%20pass%20against%20the%20wrong%20threshold%20and%20stop%20catching%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20from%20swebench_pro_agent.agent%20import%20MAX_HISTORY_CHARS%0A%20%20%20%20assert%20agent._history_size%28blocks%29%20%3C%3D%20MAX_HISTORY_CHARS%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=64&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aharness-engineering-bench%2Fswe-bench-pro%2Fbaseline%2Ftarget%2Ftests%2Ftest_agent.py%3A216%0AThe%20size%20assertion%20uses%20the%20literal%20%60300_000%60%20rather%20than%20the%20%60MAX_HISTORY_CHARS%60%20constant%20defined%20in%20%60agent.py%60.%20If%20the%20budget%20is%20ever%20tuned%2C%20this%20assertion%20will%20silently%20pass%20against%20the%20wrong%20threshold%20and%20stop%20catching%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20from%20swebench_pro_agent.agent%20import%20MAX_HISTORY_CHARS%0A%20%20%20%20assert%20agent._history_size%28blocks%29%20%3C%3D%20MAX_HISTORY_CHARS%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fvero&pr=64&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fvero%22%20on%20the%20existing%20branch%20%22fix%2Fswebp-agent-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fswebp-agent-context%22.%0A%0A%23%23%23%20Issue%201%0Aharness-engineering-bench%2Fswe-bench-pro%2Fbaseline%2Ftarget%2Ftests%2Ftest_agent.py%3A216%0AThe%20size%20assertion%20uses%20the%20literal%20%60300_000%60%20rather%20than%20the%20%60MAX_HISTORY_CHARS%60%20constant%20defined%20in%20%60agent.py%60.%20If%20the%20budget%20is%20ever%20tuned%2C%20this%20assertion%20will%20silently%20pass%20against%20the%20wrong%20threshold%20and%20stop%20catching%20regressions.%0A%0A%60%60%60suggestion%0A%20%20%20%20from%20swebench_pro_agent.agent%20import%20MAX_HISTORY_CHARS%0A%20%20%20%20assert%20agent._history_size%28blocks%29%20%3C%3D%20MAX_HISTORY_CHARS%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fvero&pr=64&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
harness-engineering-bench/swe-bench-pro/baseline/target/tests/test_agent.py:216
The size assertion uses the literal `300_000` rather than the `MAX_HISTORY_CHARS` constant defined in `agent.py`. If the budget is ever tuned, this assertion will silently pass against the wrong threshold and stop catching regressions.

```suggestion
    from swebench_pro_agent.agent import MAX_HISTORY_CHARS
    assert agent._history_size(blocks) <= MAX_HISTORY_CHARS
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep the swe-bench-pro seed agent&#39;s..."](https://github.com/scaleapi/vero/commit/69f031af1b008d6b0c271a2f3e86e4d77eccd4da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48368181)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->