### PR TITLE
fix: stop a provider-refused parameter from making a whole model unusable

### DIFF
--- a/vero/src/vero/gateway/inference.py
+++ b/vero/src/vero/gateway/inference.py
@@ -693,8 +693,33 @@ def _unsupported_params(body: bytes) -> list[str]:
     accept the parameter are untouched and keep their exact semantics. That
     matters more than elegance here -- an unconditional strip would silently
     change behaviour for every harness that relies on ``tool_choice``.
+
+    Matched against the decoded ``error.message`` rather than the raw response
+    bytes, so JSON string escaping cannot corrupt the names. Reading the raw body
+    happens to work for the error shape we see today only because Python's list
+    repr quotes with ``'``, which JSON does not escape. Were the upstream to quote
+    with ``"``, the encoded body would carry ``[\\"tool_choice\\"]`` and the names
+    would come back with a trailing backslash -- which then fails the caller's
+    "is this parameter actually in the request" check, so the retry would silently
+    never fire and the model would stay unusable for a now-invisible reason.
     """
-    match = _UNSUPPORTED_PARAMS.search(body.decode("utf-8", "replace"))
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = None
+    text = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            candidate = error.get("message")
+            text = candidate if isinstance(candidate, str) else None
+        elif isinstance(error, str):
+            text = error
+    if text is None:
+        # Not the shape we expect: fall back to the raw body rather than give up,
+        # since a missed match costs a usable model.
+        text = body.decode("utf-8", "replace")
+    match = _UNSUPPORTED_PARAMS.search(text)
     if not match:
         return []
     return re.findall(r"['\"]([^'\"]+)['\"]", match.group(1))

--- a/vero/src/vero/gateway/inference.py
+++ b/vero/src/vero/gateway/inference.py
@@ -598,9 +598,7 @@ class _RequestAttributor:
             self.errors += 1
             return {}
 
-    def register_response(
-        self, fields: dict[str, str] | None, head: bytes
-    ) -> None:
+    def register_response(self, fields: dict[str, str] | None, head: bytes) -> None:
         try:
             thread = (fields or {}).get("thread_id")
             if not thread or not head:
@@ -666,6 +664,42 @@ def _cost_fields(headers: Any) -> dict[str, float]:
         except (TypeError, ValueError):
             continue
     return fields
+
+
+#: The upstream proxy's refusal to forward a parameter to a provider, naming the
+#: parameters at fault: ``does not support parameters: ['tool_choice']``. It
+#: rejects the whole request rather than dropping the parameter.
+_UNSUPPORTED_PARAMS = re.compile(
+    r"does not support parameters:\s*\[([^\]]*)\]", re.IGNORECASE
+)
+
+
+def _unsupported_params(body: bytes) -> list[str]:
+    """Parameter names an upstream 400 blamed, or [] if it blamed none.
+
+    Some providers reject parameters that every agentic harness sends. Fireworks
+    rejects ``tool_choice``, so a tool-driving harness cannot use those models at
+    all -- the run dies on its first real request -- even though the model emits
+    tool calls perfectly well without the parameter.
+
+    The error suggests three fixes. Two configure the upstream proxy, which we do
+    not own. The third, ``allowed_openai_params``, works on ``/chat/completions``
+    but is silently ignored on ``/responses`` (measured against the live
+    upstream), and ``/responses`` is exactly what an openai-prefixed harness
+    uses. So neither is a general fix.
+
+    Retrying without the blamed parameters is, and it is the conservative option:
+    it engages only on a request that has *already* failed, so providers that
+    accept the parameter are untouched and keep their exact semantics. That
+    matters more than elegance here -- an unconditional strip would silently
+    change behaviour for every harness that relies on ``tool_choice``.
+    """
+    match = _UNSUPPORTED_PARAMS.search(body.decode("utf-8", "replace"))
+    if not match:
+        return []
+    return re.findall(r"['\"]([^'\"]+)['\"]", match.group(1))
+
+
 def _provider_error(status_code: int, message: str, code: str) -> JSONResponse:
     return JSONResponse(
         status_code=status_code,
@@ -792,6 +826,9 @@ def create_inference_gateway_app(
         # exit path -- streamed, non-streamed, and error -- records the cost
         # without each one having to remember to pass it.
         cost_fields: dict[str, float] = {}
+        # Parameters the upstream refused and we retried without. Recorded so a
+        # degraded request is auditable rather than a silent behaviour change.
+        dropped_params: list[str] = []
 
         async def log_request(
             *,
@@ -810,6 +847,7 @@ def create_inference_gateway_app(
                 attribution=attribution,
                 endpoint=endpoint,
                 model=value.get("model") if isinstance(value, dict) else None,
+                dropped_params=dropped_params or None,
                 stream=stream,
                 status=status,
                 error=error,
@@ -823,6 +861,7 @@ def create_inference_gateway_app(
                 response=response,
                 **thread_fields,
             )
+
         # Per-scope allow-list: producer (optimizer) and evaluation (target) have
         # separate tokens + allowed_models, so the target is normally confined to
         # its fixed eval model. NOTE (known, deferred): this is not a *hard*
@@ -866,17 +905,40 @@ def create_inference_gateway_app(
         }
         headers["authorization"] = f"Bearer {upstream_api_key}"
         url = f"{base_url}/{endpoint}"
-        try:
-            upstream = await app.state.upstream.send(
+
+        async def send(payload: bytes) -> httpx.Response:
+            return await app.state.upstream.send(
                 app.state.upstream.build_request(
                     "POST",
                     url,
                     params=request.query_params,
-                    content=body,
+                    content=payload,
                     headers=headers,
                 ),
                 stream=True,
             )
+
+        try:
+            upstream = await send(body)
+            # A provider that refuses a parameter fails the whole request before
+            # reaching the model, so nothing has been billed and nothing has been
+            # streamed downstream yet: dropping the blamed parameters and sending
+            # once more is safe here and nowhere later. Only a request that has
+            # already failed is touched, so providers that accept the parameter
+            # keep their exact semantics.
+            if upstream.status_code == 400 and isinstance(value, dict):
+                failed_body = await upstream.aread()
+                blamed = [
+                    name for name in _unsupported_params(failed_body) if name in value
+                ]
+                if blamed:
+                    await upstream.aclose()
+                    for name in blamed:
+                        value.pop(name)
+                    # Re-serialize so the request log records what we really sent.
+                    body = json.dumps(value).encode()
+                    dropped_params.extend(blamed)
+                    upstream = await send(body)
         except httpx.HTTPError:
             await asyncio.shield(
                 store.complete(scope_name, attribution, upstream_error=True)

--- a/vero/src/vero/gateway/inference.py
+++ b/vero/src/vero/gateway/inference.py
@@ -780,6 +780,10 @@ def create_inference_gateway_app(
     app.state.usage_store = store
     app.state.request_log = request_log
     app.state.request_attributor = attributor
+    # model -> parameters that model's provider has refused. Learned from the
+    # upstream's own 400 so there is no list to maintain or let go stale, and
+    # reset on restart, which costs one re-discovery per model.
+    app.state.refused_params: dict[str, frozenset[str]] = {}
 
     @app.get("/health")
     async def health():
@@ -943,14 +947,32 @@ def create_inference_gateway_app(
                 stream=True,
             )
 
+        # Apply what this model has already told us it refuses, so the discovery
+        # below costs one extra round-trip per (model, parameter) for the lifetime
+        # of the gateway rather than one per request. A tool-driving harness sends
+        # the parameter on nearly every call -- 52 of 66 in a conformance run --
+        # so retrying each one would double that traffic against the RPM limit for
+        # no new information.
+        refused = app.state.refused_params.get(model, frozenset())
+        if refused and isinstance(value, dict):
+            known = [name for name in refused if name in value]
+            if known:
+                for name in known:
+                    value.pop(name)
+                body = json.dumps(value).encode()
+                dropped_params.extend(known)
+
         try:
             upstream = await send(body)
-            # A provider that refuses a parameter fails the whole request before
-            # reaching the model, so nothing has been billed and nothing has been
+            # A provider that refuses a parameter fails the request before it
+            # reaches the model, so nothing has been billed and nothing has been
             # streamed downstream yet: dropping the blamed parameters and sending
             # once more is safe here and nowhere later. Only a request that has
             # already failed is touched, so providers that accept the parameter
-            # keep their exact semantics.
+            # keep their exact semantics -- and because the refusal is learned
+            # from the provider rather than configured, a model that later gains
+            # support simply stops being asked to give it up, with no stale list
+            # to notice and prune.
             if upstream.status_code == 400 and isinstance(value, dict):
                 failed_body = await upstream.aread()
                 blamed = [
@@ -963,6 +985,10 @@ def create_inference_gateway_app(
                     # Re-serialize so the request log records what we really sent.
                     body = json.dumps(value).encode()
                     dropped_params.extend(blamed)
+                    # Bounded by allowed_models across scopes, so this cannot grow
+                    # with traffic: an unlisted model is rejected before reaching
+                    # here.
+                    app.state.refused_params[model] = refused.union(blamed)
                     upstream = await send(body)
         except httpx.HTTPError:
             await asyncio.shield(

--- a/vero/tests/test_v05_harbor_inference.py
+++ b/vero/tests/test_v05_harbor_inference.py
@@ -1064,3 +1064,50 @@ def test_gateway_records_dropped_params_in_the_request_log(tmp_path):
     assert records[0]["dropped_params"] == ["tool_choice"]
     # A request nothing was dropped from must not carry a misleading empty list.
     assert records[1].get("dropped_params") is None
+
+
+def test_gateway_learns_a_refusal_once_instead_of_retrying_every_request(tmp_path):
+    """The discovery must cost one extra round-trip, not one per request.
+
+    A tool-driving harness sends `tool_choice` on nearly every call (52 of 66 in a
+    conformance run), so retrying each one would double that traffic against the
+    RPM limit to re-learn something the gateway already knows.
+    """
+    attempts = []
+
+    def upstream(request: httpx.Request):
+        payload = json.loads(request.content)
+        attempts.append("tool_choice" in payload)
+        if "tool_choice" in payload:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": (
+                            "fireworks_ai does not support parameters: ['tool_choice'],"
+                        )
+                    }
+                },
+            )
+        return httpx.Response(200, json={"id": "response", "usage": {}})
+
+    app = create_inference_gateway_app(
+        config=_config(tmp_path, max_requests=20, max_tokens=10_000),
+        upstream_api_key="upstream-secret",
+        upstream_base_url="https://provider.example/v1",
+        transport=httpx.MockTransport(upstream),
+    )
+    with TestClient(app) as client:
+        for _ in range(5):
+            response = client.post(
+                "/scopes/producer/optimizer/v1/responses",
+                headers={"Authorization": "Bearer scoped-token"},
+                json={"model": "gpt-test", "tool_choice": "auto", "input": []},
+            )
+            assert response.status_code == 200
+
+    # Five client requests cost six upstream calls: the first pays a rejected
+    # attempt plus its retry, the remaining four are stripped up front and go
+    # straight through. Retrying per request would have cost ten.
+    assert attempts == [True, False, False, False, False, False], attempts
+    assert attempts.count(True) == 1, "the refusal must be discovered only once"

--- a/vero/tests/test_v05_harbor_inference.py
+++ b/vero/tests/test_v05_harbor_inference.py
@@ -583,9 +583,7 @@ def test_gateway_request_log_rotation_boundary(tmp_path):
     asyncio.run(fill())
     files = sorted((tmp_path / "requests").glob("requests-*.jsonl"))
     assert len(files) > 1
-    total = sum(
-        len(path.read_text().splitlines()) for path in files
-    )
+    total = sum(len(path.read_text().splitlines()) for path in files)
     assert total == 6
 
 
@@ -646,7 +644,11 @@ def test_gateway_attribution_threads_stateful_and_stateless_requests(tmp_path):
         client.post(
             "/scopes/producer/optimizer/v1/responses",
             headers=headers,
-            json={"model": "gpt-test", "input": "Another task entirely", "stream": True},
+            json={
+                "model": "gpt-test",
+                "input": "Another task entirely",
+                "stream": True,
+            },
         )
         client.post(
             "/scopes/producer/optimizer/v1/responses",
@@ -862,3 +864,108 @@ def test_gateway_request_log_omits_cost_when_the_upstream_sends_none(tmp_path):
 
     record = _log_records(tmp_path)[0]
     assert not any(key.startswith("upstream_cost") for key in record)
+
+
+_UNSUPPORTED = (
+    "litellm.UnsupportedParamsError: fireworks_ai does not support parameters: "
+    "['tool_choice'], for model=accounts/fireworks/models/kimi-k3."
+)
+
+
+def test_gateway_retries_without_parameters_the_provider_refuses(tmp_path):
+    """A provider that refuses tool_choice must not kill the whole request.
+
+    Fireworks answers 400 for `tool_choice`, which every tool-driving harness
+    sends, so the model is unusable through the gateway -- the run dies on its
+    first real request. Neither documented workaround is general: two configure
+    the upstream proxy we do not own, and `allowed_openai_params` is honoured on
+    /chat/completions but ignored on /responses, which is the endpoint an
+    openai-prefixed harness actually uses.
+
+    Retrying without the blamed parameter is endpoint-agnostic and engages only
+    on an already-failed request.
+    """
+    seen = []
+
+    def upstream(request: httpx.Request):
+        payload = json.loads(request.content)
+        seen.append(payload)
+        if "tool_choice" in payload:
+            return httpx.Response(400, json={"error": {"message": _UNSUPPORTED}})
+        return httpx.Response(200, json={"id": "response", "usage": {}})
+
+    app = create_inference_gateway_app(
+        config=_config(tmp_path, max_requests=4),
+        upstream_api_key="upstream-secret",
+        upstream_base_url="https://provider.example/v1",
+        transport=httpx.MockTransport(upstream),
+    )
+    with TestClient(app) as client:
+        # /responses is the endpoint that matters: this is where the documented
+        # allowed_openai_params escape hatch does not work.
+        ok = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "gpt-test", "tool_choice": "auto", "input": []},
+        )
+
+    assert ok.status_code == 200
+    assert len(seen) == 2, "expected one rejected attempt then one retry"
+    assert seen[0]["tool_choice"] == "auto"
+    assert "tool_choice" not in seen[1]
+    assert seen[1]["model"] == "gpt-test", "the rest of the request must survive"
+
+
+def test_gateway_does_not_retry_when_the_provider_accepts_the_parameter(tmp_path):
+    """Providers that accept tool_choice keep it, and their exact semantics.
+
+    This is the reason the fix is a retry rather than an unconditional strip: a
+    strip would silently change behaviour for every harness that relies on
+    tool_choice against a provider that supports it.
+    """
+    seen = []
+
+    def upstream(request: httpx.Request):
+        seen.append(json.loads(request.content))
+        return httpx.Response(200, json={"id": "response", "usage": {}})
+
+    app = create_inference_gateway_app(
+        config=_config(tmp_path, max_requests=4),
+        upstream_api_key="upstream-secret",
+        upstream_base_url="https://provider.example/v1",
+        transport=httpx.MockTransport(upstream),
+    )
+    with TestClient(app) as client:
+        client.post(
+            "/scopes/producer/optimizer/v1/chat/completions",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "gpt-test", "tool_choice": "required", "messages": []},
+        )
+
+    assert len(seen) == 1, "a successful request must not be retried"
+    assert seen[0]["tool_choice"] == "required"
+
+
+def test_gateway_does_not_retry_a_400_that_blames_nothing_droppable(tmp_path):
+    """An unrelated 400 is relayed once, not retried into a second charge."""
+    seen = []
+
+    def upstream(request: httpx.Request):
+        seen.append(json.loads(request.content))
+        return httpx.Response(400, json={"error": {"message": "bad request"}})
+
+    app = create_inference_gateway_app(
+        config=_config(tmp_path, max_requests=4),
+        upstream_api_key="upstream-secret",
+        upstream_base_url="https://provider.example/v1",
+        transport=httpx.MockTransport(upstream),
+    )
+    with TestClient(app) as client:
+        failed = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "gpt-test", "tool_choice": "auto", "input": []},
+        )
+
+    assert failed.status_code == 400
+    assert len(seen) == 1

--- a/vero/tests/test_v05_harbor_inference.py
+++ b/vero/tests/test_v05_harbor_inference.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 
 from vero.gateway.inference import (
     InferenceGatewayConfig,
+    InferenceRequestLogConfig,
     InferenceScopeConfig,
+    _unsupported_params,
     create_inference_gateway_app,
     token_digest,
 )
@@ -969,3 +971,96 @@ def test_gateway_does_not_retry_a_400_that_blames_nothing_droppable(tmp_path):
 
     assert failed.status_code == 400
     assert len(seen) == 1
+
+
+def test_unsupported_params_survives_json_escaped_quoting():
+    """The blamed names must parse whatever quoting the upstream uses.
+
+    Today's upstream builds the list with Python's repr, so it arrives
+    single-quoted and JSON leaves it alone. Were it ever double-quoted, JSON
+    would escape it to ``[\\"tool_choice\\"]``; matching the raw body then yields
+    ``tool_choice\\`` with a trailing backslash, which fails the caller's
+    "is this parameter in the request" check. The retry would silently never fire
+    -- a worse failure than the 400, because nothing says why.
+    """
+    message = (
+        "litellm.UnsupportedParamsError: fireworks_ai does not support parameters: "
+    )
+    single = json.dumps({"error": {"message": message + "['tool_choice']"}}).encode()
+    double = json.dumps({"error": {"message": message + '["tool_choice"]'}}).encode()
+
+    assert _unsupported_params(single) == ["tool_choice"]
+    assert _unsupported_params(double) == ["tool_choice"]
+    # Several parameters, and an unrelated error, both behave.
+    many = json.dumps(
+        {"error": {"message": "does not support parameters: ['tool_choice', 'top_k']"}}
+    ).encode()
+    assert _unsupported_params(many) == ["tool_choice", "top_k"]
+    assert _unsupported_params(b'{"error": {"message": "rate limited"}}') == []
+    # A non-JSON body still gets a best-effort read rather than giving up.
+    assert _unsupported_params(b"does not support parameters: ['tool_choice']") == [
+        "tool_choice"
+    ]
+
+
+def test_gateway_records_dropped_params_in_the_request_log(tmp_path):
+    """A degraded request must be auditable, not merely successful.
+
+    The retry silently changes what was asked of the provider. If the audit field
+    regresses, every future degraded request becomes invisible and the only signal
+    left is a behaviour difference nobody is looking for.
+    """
+
+    def upstream(request: httpx.Request):
+        payload = json.loads(request.content)
+        if "tool_choice" in payload:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": (
+                            "litellm.UnsupportedParamsError: fireworks_ai does not "
+                            "support parameters: ['tool_choice'],"
+                        )
+                    }
+                },
+            )
+        return httpx.Response(200, json={"id": "response", "usage": {}})
+
+    config = _config(tmp_path, max_requests=4).model_copy(
+        update={
+            "request_log": InferenceRequestLogConfig(
+                directory=str(tmp_path / "requests")
+            )
+        }
+    )
+    app = create_inference_gateway_app(
+        config=config,
+        upstream_api_key="upstream-secret",
+        upstream_base_url="https://provider.example/v1",
+        transport=httpx.MockTransport(upstream),
+    )
+    with TestClient(app) as client:
+        retried = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "gpt-test", "tool_choice": "auto", "input": []},
+        )
+        untouched = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "gpt-test", "input": []},
+        )
+    assert retried.status_code == 200
+    assert untouched.status_code == 200
+
+    records = [
+        json.loads(line)
+        for path in sorted((tmp_path / "requests").glob("*.jsonl"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 2, records
+    assert records[0]["dropped_params"] == ["tool_choice"]
+    # A request nothing was dropped from must not carry a misleading empty list.
+    assert records[1].get("dropped_params") is None


### PR DESCRIPTION
Fixes the `opencode x kimi-k3` grid cell, which could not run at all.

## The failure

`opencode`s first tool-bearing request came back 400:

```
litellm.UnsupportedParamsError: fireworks_ai does not support parameters:
[tool_choice], for model=accounts/fireworks/models/kimi-k3
```

The agent exited non-zero and the trial died 2m 04s in with no candidate. The
model is not the problem: with the parameter absent it emits tool calls normally.
One parameter the provider declines to accept was blocking an entire contestant.

## Why the documented workarounds do not cover it

The upstream error suggests three fixes. Two configure the upstream proxy, which
we do not own. The third is `allowed_openai_params`, and it turns out to be
endpoint dependent. Measured against the live upstream:

| request | `/chat/completions` | `/responses` |
|---|---|---|
| tools only | 200 | 200 |
| `tool_choice` | 400 | 400 |
| `tool_choice` + `allowed_openai_params` | **200** | **400** |

An openai-prefixed harness talks to `/responses`, which is exactly where the
escape hatch is silently ignored. I shipped the `allowed_openai_params` version
first and it passed a hand-rolled end-to-end check on `/chat/completions` while
the real conformance run still failed on `/responses` — the request log showed the
parameter being added and refused anyway.

## The fix

The gateway reads the offending parameter names out of the 400 and sends once
more without them. A refused parameter fails the request before it reaches the
model, so nothing has been billed and nothing has been streamed downstream; the
retry is safe at that point and nowhere later.

**Retrying rather than stripping is deliberate.** Only a request that has *already*
failed is touched, so providers that accept `tool_choice` keep their exact
semantics. An unconditional strip would have silently changed behaviour for every
harness that relies on it, which is not a trade worth making mid-experiment.
Dropped parameters are recorded in the request log, so a degraded request is
auditable rather than invisible.

## Verification

A full `harness-conformance` run with `opencode x fireworks_ai/kimi-k3`:

- **reward 1.0**, level with `codex` and `claude-code` on the same target
- `error_rate` 0.0, `shipped: true`, 9m 40s (the failing run died at 1m 38s)
- zero `UnsupportedParamsError` in the agent log
- retry fired on **52 of 66** gateway requests, every one 200

Tests cover the retry on `/responses`, no retry when the provider accepts the
parameter, and no retry on a 400 that blames nothing droppable. Full suite: 483
passed, 15 skipped.

## Follow-up, not in scope here

`opencode` runs a separate small model for session-title generation that is
absent from the gateway scope allow-list, so every run logs an avoidable 403
(1 of the 66 requests above). Non-fatal — the r1 opencode cells scored normally
with it — but worth cleaning up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a provider-refused parameter (`tool_choice`) that was making the entire `kimi-k3` model unusable through the gateway. On a 400 response naming unsupported parameters, the gateway now strips only those parameters and retries once; it also caches the refusal per-model so subsequent requests are pre-stripped without an extra round-trip.

- **Retry logic** (`inference.py`): A new `_unsupported_params` helper parses the error body (preferring `error.message` over raw bytes to avoid JSON-escaping issues) and extracts blamed parameter names. On a 400, the gateway strips matching parameters, re-serializes the body, records `dropped_params` in the request log for auditability, persists the refusal in `app.state.refused_params`, and sends once more. The retry is gated on a request that has already failed, so providers that accept the parameter keep their exact semantics.
- **Tests** (`test_v05_harbor_inference.py`): Five new tests cover the retry on `/responses`, no retry on success, no retry for unrelated 400s, JSON-escaped quoting edge cases in the error parser, the `dropped_params` audit field, and the one-discovery-per-model efficiency property.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the retry is narrowly scoped to requests that have already returned 400, leaves all successful paths untouched, and is fully covered by new tests including the audit-trail regression pin.

The retry logic engages only after a confirmed upstream refusal, so it cannot affect providers that accept the parameter. The refused_params cache is bounded by the gateway's allowed_models set and is never written without a provider-confirmed 400. Tests cover the retry path, the no-retry path, the audit field, and the efficiency property.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/gateway/inference.py | Adds _unsupported_params helper, per-model refused_params cache, and a single-retry loop that strips provider-blamed parameters; the retry only fires on an already-failed 400, leaving successful providers untouched. |
| vero/tests/test_v05_harbor_inference.py | Five new test cases cover the retry on /responses, no-retry on success, no-retry for unrelated 400s, JSON-escaped quoting in the error parser, the dropped_params audit field, and the one-discovery-per-model efficiency guarantee. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Learn a provider&#39;s refusal once, not on ..."](https://github.com/scaleapi/vero/commit/aa3ba2993a6efe1d7f9c92050c1a07c121f75106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48573060)</sub>

<!-- /greptile_comment -->