### PR TITLE
fix: pin W&B reporting to the shared team org instead of the launcher's default

### DIFF
--- a/harness-engineering-bench/browsecomp-plus/baseline/build.yaml
+++ b/harness-engineering-bench/browsecomp-plus/baseline/build.yaml
@@ -104,6 +104,7 @@ secrets:
 
 wandb:
   project: harness-engineering-bench  # one project for the whole suite
+  entity: egp  # the shared team org, NOT the launching user's default
   group: browsecomp-plus  # keeps the benchmark distinguishable in the shared project
   name: ${wandb_run:-browsecomp-plus}  # per-launch label, e.g. --param wandb_run=browsecomp-plus__claude-sonnet-5
   tags: [browsecomp-plus]

--- a/harness-engineering-bench/gaia/baseline/build.yaml
+++ b/harness-engineering-bench/gaia/baseline/build.yaml
@@ -136,6 +136,7 @@ agent_env:
 
 wandb:
   project: harness-engineering-bench  # one project for the whole suite
+  entity: egp  # the shared team org, NOT the launching user's default
   group: gaia  # keeps the benchmark distinguishable in the shared project
   name: ${wandb_run:-gaia}  # per-launch label, e.g. --param wandb_run=gaia__opencode
   tags: [gaia]

--- a/harness-engineering-bench/officeqa/baseline/build.yaml
+++ b/harness-engineering-bench/officeqa/baseline/build.yaml
@@ -141,6 +141,7 @@ agent_env:
 
 wandb:
   project: harness-engineering-bench
+  entity: egp  # the shared team org, NOT the launching user's default
   group: officeqa  # keeps the benchmark distinguishable in the shared project
   name: ${wandb_run:-officeqa}  # per-launch label, e.g. --param wandb_run=officeqa__claude-sonnet-5
   tags: [officeqa]

--- a/harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml
@@ -134,6 +134,7 @@ secrets:
 
 wandb:
   project: harness-engineering-bench  # one project for the whole suite
+  entity: egp  # the shared team org, NOT the launching user's default
   group: swe-atlas-qna  # keeps the benchmark distinguishable in the shared project
   name: ${wandb_run:-swe-atlas-qna}  # per-launch label, e.g. --param wandb_run=swe-atlas-qna__claude-sonnet-5
   tags: [swe-atlas-qna]

--- a/harness-engineering-bench/swe-atlas-qna/baseline/build.yaml
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/build.yaml
@@ -122,6 +122,7 @@ secrets:
 
 wandb:
   project: harness-engineering-bench  # one project for the whole suite
+  entity: egp  # the shared team org, NOT the launching user's default
   group: swe-atlas-qna  # keeps the benchmark distinguishable in the shared project
   name: ${wandb_run:-swe-atlas-qna}  # per-launch label, e.g. --param wandb_run=swe-atlas-qna__claude-sonnet-5
   tags: [swe-atlas-qna]

--- a/harness-engineering-bench/swe-bench-pro/baseline/build.sample.yaml
+++ b/harness-engineering-bench/swe-bench-pro/baseline/build.sample.yaml
@@ -131,6 +131,7 @@ harness_user: harness
 
 wandb:
   project: vero-swe-bench-pro
+  entity: egp  # the shared team org, NOT the launching user's default
   group: swe-bench-pro-sample  # distinct from the full-split group
   log_traces: true
 

--- a/harness-engineering-bench/swe-bench-pro/baseline/build.yaml
+++ b/harness-engineering-bench/swe-bench-pro/baseline/build.yaml
@@ -89,6 +89,7 @@ harness_user: harness
 
 wandb:
   project: vero-swe-bench-pro
+  entity: egp  # the shared team org, NOT the launching user's default
   group: swe-bench-pro
   log_traces: true
 

--- a/harness-engineering-bench/tau3/baseline/build.yaml
+++ b/harness-engineering-bench/tau3/baseline/build.yaml
@@ -95,6 +95,7 @@ secrets:
 
 wandb:
   project: harness-engineering-bench  # one project for the whole suite
+  entity: egp  # the shared team org, NOT the launching user's default
   group: tau3  # keeps the benchmark distinguishable in the shared project
   name: ${wandb_run:-tau3}  # per-launch label, e.g. --param wandb_run=tau3__claude-sonnet-5
   tags: [tau3]

--- a/harness-engineering-bench/terminal-bench/baseline/build.yaml
+++ b/harness-engineering-bench/terminal-bench/baseline/build.yaml
@@ -134,6 +134,7 @@ agent_env:
 
 wandb:
   project: harness-engineering-bench  # one project for the whole suite
+  entity: egp  # the shared team org, NOT the launching user's default
   group: terminal-bench
   name: ${wandb_run:-terminal-bench}
   tags: [terminal-bench]


### PR DESCRIPTION
## Problem

No benchmark config sets `wandb.entity`, so `wandb.init` falls back to the **launching user's account default**. The destination of a run therefore depends on *who ran it*, not on the config.

Accounts whose default is `egp` land in the shared org. Any other account silently lands in that person's private entity, with nothing in the run or the config to say so.

## How it actually failed

A `swe-atlas-qna` cell launched from an account with a personal default reported into `shehab-yasser/harness-engineering-bench` instead of `egp/harness-engineering-bench`:

https://scaleai.wandb.io/shehab-yasser/harness-engineering-bench/runs/vero-cc79186f3c3444bf

Same config, same command, different org. The failure mode is nasty because a cell that reported elsewhere is indistinguishable from a cell that never started, and cross-cell comparison has to be reassembled by hand across two orgs.

## Fix

One line per config. `WandbSpec` already exposes the field and documents it:

> `entity`: Owning user or team; the account default when omitted.

It flows straight into `wandb.init(entity=...)` at `runtime/wandb.py:113`. It was simply never set.

```yaml
wandb:
  project: harness-engineering-bench
  entity: egp  # the shared team org, NOT the launching user's default
```

## Why the config and not `WANDB_ENTITY`

`scripts/wandb_progress.py` already reads `WANDB_ENTITY` from `heb.secrets.env`, with a good comment about why it does not trust the account default. But that env var is **not in any config's `secrets:` list**, so it never reaches the sidecar that creates the run. Exporting it fixes the *reader* while leaving the *writer* on the account default, which is the more confusing half of the bug. Setting it in the config fixes the writer for everyone, permanently, and stays under review.

## Scope

All nine configs that carry a `wandb:` block:

`browsecomp-plus`, `gaia`, `officeqa`, `swe-atlas-qna` (both `build.yaml` and `build.gpt54mini.yaml`), `swe-bench-pro` (both `build.yaml` and `build.sample.yaml`), `tau3`, `terminal-bench`.

## Test plan

- [x] All nine configs still parse, and each resolves `entity=egp` through `WandbSpec`.
- [x] Confirmed `egp/harness-engineering-bench` exists.
- [x] Confirmed `egp/vero-swe-bench-pro` does **not** exist yet, which is fine: W&B auto-creates a project on first write, so no manual setup is required. Flagging it so the first swe-bench-pro run creating a new project is not mistaken for a misconfiguration.

## Note for anyone with in-flight runs

W&B can move runs between projects but **not between entities**, so runs already reporting to a personal entity cannot be relocated after the fact. Their numbers remain valid; they just live in the wrong place. This only affects runs started after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins W&B reporting to the shared `egp` entity for every benchmark configuration that enables W&B.
- Adds `entity: egp` to all nine existing `wandb` blocks.
- Preserves each benchmark's existing project, group, tags, run name, and trace settings.
- Makes the reporting destination independent of the launching account's default entity.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with all affected benchmark configurations consistently targeting the shared W&B entity.

The added field is supported by the W&B configuration schema and is forwarded through the runtime initialization path without changing unrelated benchmark behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| harness-engineering-bench/browsecomp-plus/baseline/build.yaml | Pins BrowseComp Plus reporting to the shared `egp` W&B entity. |
| harness-engineering-bench/gaia/baseline/build.yaml | Pins GAIA reporting to the shared `egp` W&B entity. |
| harness-engineering-bench/officeqa/baseline/build.yaml | Pins OfficeQA reporting to the shared `egp` W&B entity. |
| harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml | Pins the GPT-5.4 Mini SWE Atlas Q&A variant to the shared `egp` W&B entity. |
| harness-engineering-bench/swe-atlas-qna/baseline/build.yaml | Pins the primary SWE Atlas Q&A configuration to the shared `egp` W&B entity. |
| harness-engineering-bench/swe-bench-pro/baseline/build.sample.yaml | Pins the sampled SWE-bench Pro configuration to the shared `egp` W&B entity. |
| harness-engineering-bench/swe-bench-pro/baseline/build.yaml | Pins the full SWE-bench Pro configuration to the shared `egp` W&B entity. |
| harness-engineering-bench/tau3/baseline/build.yaml | Pins Tau3 reporting to the shared `egp` W&B entity. |
| harness-engineering-bench/terminal-bench/baseline/build.yaml | Pins Terminal Bench reporting to the shared `egp` W&B entity. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pin W&amp;B reporting to the shared tea..."](https://github.com/scaleapi/vero/commit/1a04073cb828607454235ab9485498163a03f74b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49158768)</sub>

<!-- /greptile_comment -->