### PR TITLE
Pin the swe-atlas-qna gpt-5.4-mini baseline, and price seed-killed trials into every pin

### DIFF
--- a/harness-engineering-bench/CONFIGURATION.md
+++ b/harness-engineering-bench/CONFIGURATION.md
@@ -171,8 +171,8 @@ benchmark can be checked against the others at a glance.
 
 | | gaia | officeqa | swe-atlas-qna | tau3 | browsecomp-plus | terminal-bench | swe-bench-pro |
 |---|---|---|---|---|---|---| --- |
-| target model | gpt-5.4-mini ◇ | deepseek-v4-flash | gpt-oss-120b | deepseek-v4-flash | deepseek-v4-flash | grok-build-0.1 ✦ | gpt-4o ◈ |
-| held-out baseline (K=3) ◆ | 0.621 ±0.052 | 0.341 ±0.033 | 0.068 ±0.026 (agg 0.632) | 0.732 ±0.010 | 0.462 ±0.028 | 0.260 ±0.018 | 0.294 ±0.008 ◈ |
+| target model | gpt-5.4-mini ◇ | deepseek-v4-flash | gpt-oss-120b (alt: gpt-5.4-mini) | deepseek-v4-flash | deepseek-v4-flash | grok-build-0.1 ✦ | gpt-4o ◈ |
+| held-out baseline (K=3) ◆ | 0.621 ±0.052 | 0.341 ±0.033 | 0.068 ±0.026 (agg 0.632); alt 0.132 ±0.018 | 0.732 ±0.010 | 0.462 ±0.028 | 0.260 ±0.018 | 0.294 ±0.008 ◈ |
 | split dev/val/test | 33/66/66 | 49/98/99 | 25/49/50 | 75/150/150 | 33/66/66 | 17/36/36 | 146/292/293 ◈ |
 | dev budget (runs / cases) | 100 / 132 | 100 / 196 | 100 / 100 | 100 / 300 | 100 / 132 | 100 / 68 | 100 / 146 ◈ |
 | val budget (runs / cases) | 100 / 264 | 100 / 392 | 100 / 196 | 100 / 600 | 100 / 264 | 100 / 144 | 100 / 292 ◈ |
@@ -354,6 +354,15 @@ signal — a candidate `reward_key` switch, pending the verifier emitting
 deepseek benchmarks logged zero exceptions over 945 trials, swe-atlas lost
 5/150 to gpt-oss 128k context overflow, and gaia lost 4/198 (infra) after the
 agent's reason/search-only-turn crash was fixed.
+
+swe-atlas also carries a second pinned target build,
+`baseline/build.gpt54mini.yaml`: **gpt-5.4-mini at 0.132 ±0.018** (n=136, K=3:
+0.109 / 0.136 / 0.152, measured 2026-07-31 with the same `--seed` path). The
+two pins are per-build, not interchangeable — each build's delta is against its
+own target's floor, never the other's. 12 of its 150 trials raised the seed's
+"neither an answer nor a tool call" RuntimeError (~8%), which is seed headroom
+in the same sense as terminal-bench's timeouts; 2 more fell to one
+RateLimitError and one VerifierTimeoutError.
 
 **Re-pin these whenever a seed agent changes.** The first set went stale because the seed agents moved 4-10 commits afterwards -- one commit touched all five -- and nothing recorded the dependency. Re-measured 2026-07-28 with `scripts/rescore_candidate.py --seed`, which reuses the original path exactly. Only tau3 moved materially (+0.121 against an sd of 0.0099, so a genuine seed improvement); the other four shifted inside their own noise.
 

--- a/harness-engineering-bench/CONFIGURATION.md
+++ b/harness-engineering-bench/CONFIGURATION.md
@@ -172,7 +172,7 @@ benchmark can be checked against the others at a glance.
 | | gaia | officeqa | swe-atlas-qna | tau3 | browsecomp-plus | terminal-bench | swe-bench-pro |
 |---|---|---|---|---|---|---| --- |
 | target model | gpt-5.4-mini ◇ | deepseek-v4-flash | gpt-oss-120b (alt: gpt-5.4-mini) | deepseek-v4-flash | deepseek-v4-flash | grok-build-0.1 ✦ | gpt-4o ◈ |
-| held-out baseline (K=3) ◆ | 0.621 ±0.052 | 0.341 ±0.033 | 0.068 ±0.026 (agg 0.632); alt 0.132 ±0.018 | 0.732 ±0.010 | 0.462 ±0.028 | 0.260 ±0.018 | 0.294 ±0.008 ◈ |
+| held-out baseline (K=3) ◆ | 0.621 ±0.052 | 0.341 ±0.033 | 0.067 ±0.025 (agg 0.632); alt 0.122 ±0.018 | 0.732 ±0.010 | 0.462 ±0.028 | 0.241 ±0.013 | 0.294 ±0.008 ◈ |
 | split dev/val/test | 33/66/66 | 49/98/99 | 25/49/50 | 75/150/150 | 33/66/66 | 17/36/36 | 146/292/293 ◈ |
 | dev budget (runs / cases) | 100 / 132 | 100 / 196 | 100 / 100 | 100 / 300 | 100 / 132 | 100 / 68 | 100 / 146 ◈ |
 | val budget (runs / cases) | 100 / 264 | 100 / 392 | 100 / 196 | 100 / 600 | 100 / 264 | 100 / 144 | 100 / 292 ◈ |
@@ -341,7 +341,16 @@ capability. See `runs/BASELINES.md`.
 ◆ Held-out baseline of the seed harness on the **test** partition, mean over
 K=3 independent rounds; ± is the stdev across the three round means. Pinned
 into each target's `baseline_reward` with `score_baseline: false`, which avoids
-re-scoring the seed every finalization. The pin is reported in every run's
+re-scoring the seed every finalization. **Failed-trial convention** (adopted
+2026-07-31 after review of PR #75): a trial the *seed* killed scores 0 — an
+optimizer can fix the harness, and finalization zero-fills a candidate's dead
+attempts the same way, so the floor must pay the same tax; a trial the
+*platform* killed is dropped — retries cannot score a trial that never ran, and
+zero-filling infra bakes outage luck into the pin. The classification lives in
+`runs/recompute.py`; unclassified exception types are a hard error there. Under
+this convention only three floors moved (swe-atlas both builds, terminal-bench
+— the two seeds with material defect rates); the deepseek pins' rare failures
+were all platform-side. The pin is reported in every run's
 `finalize.json` under `baseline_rewards`, so the improvement delta is recorded
 alongside the reward rather than joined by hand against this table. (Runs before
 2026-07-28 carry an empty `baseline_rewards`: the verifier read the pin only
@@ -356,13 +365,14 @@ deepseek benchmarks logged zero exceptions over 945 trials, swe-atlas lost
 agent's reason/search-only-turn crash was fixed.
 
 swe-atlas also carries a second pinned target build,
-`baseline/build.gpt54mini.yaml`: **gpt-5.4-mini at 0.132 ±0.018** (n=136, K=3:
-0.109 / 0.136 / 0.152, measured 2026-07-31 with the same `--seed` path). The
+`baseline/build.gpt54mini.yaml`: **gpt-5.4-mini at 0.122 ±0.018** (n=148, K=3:
+0.100 / 0.122 / 0.143, measured 2026-07-31 with the same `--seed` path). The
 two pins are per-build, not interchangeable — each build's delta is against its
 own target's floor, never the other's. 12 of its 150 trials raised the seed's
-"neither an answer nor a tool call" RuntimeError (~8%), which is seed headroom
-in the same sense as terminal-bench's timeouts; 2 more fell to one
-RateLimitError and one VerifierTimeoutError.
+"neither an answer nor a tool call" RuntimeError (~8%) and score 0 in the pin
+per the failed-trial convention — seed headroom in the same sense as
+terminal-bench's timeouts; 2 more fell to platform-side failures (one
+RateLimitError, one VerifierTimeoutError) and are excluded.
 
 **Re-pin these whenever a seed agent changes.** The first set went stale because the seed agents moved 4-10 commits afterwards -- one commit touched all five -- and nothing recorded the dependency. Re-measured 2026-07-28 with `scripts/rescore_candidate.py --seed`, which reuses the original path exactly. Only tau3 moved materially (+0.121 against an sd of 0.0099, so a genuine seed improvement); the other four shifted inside their own noise.
 

--- a/harness-engineering-bench/swe-atlas-qna/baseline/README.md
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/README.md
@@ -12,11 +12,15 @@ comparison, not an optimization result:
 
 | build | target model | pinned `baseline_reward` |
 | --- | --- | --- |
-| `build.yaml` | `fireworks_ai/gpt-oss-120b` | 0.0676 (K=3, n=148) |
-| `build.gpt54mini.yaml` | `gpt-5.4-mini` | 0.1324 (K=3, n=136) |
+| `build.yaml` | `fireworks_ai/gpt-oss-120b` | 0.0667 (K=3, n=150) |
+| `build.gpt54mini.yaml` | `gpt-5.4-mini` | 0.1216 (K=3, n=148) |
 
 Both floors were measured with `scripts/rescore_candidate.py --seed`, the same
-path that produced every other pinned baseline in the suite.
+path that produced every other pinned baseline in the suite. Trials the seed
+itself killed score 0 (they are harness headroom, and finalization taxes a
+candidate's dead attempts the same way); trials the platform killed are
+excluded. For gpt-5.4-mini that prices in the seed's ~8% empty-completion
+fail-fast — the largest single piece of fixable headroom in this seed.
 
 The Harbor tasks retain their canonical rubric-based verifier. That verifier
 needs `OPENAI_API_BASE`; the target agent uses `OPENAI_BASE_URL`. They may

--- a/harness-engineering-bench/swe-atlas-qna/baseline/README.md
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/README.md
@@ -5,19 +5,30 @@ repository mounted at `/app` and writes its final answer to
 `/logs/agent/answer.txt`. The editable program controls its prompt, search
 strategy, shell tools, context management, and answer synthesis.
 
-The trusted build pins the target model to `gpt-5.4-mini-2026-03-17`, the
-dataset version, split, budgets, access policy, and final test partition. The
-Harbor tasks retain their canonical rubric-based verifier. That verifier needs
-`OPENAI_API_BASE`; the target agent uses `OPENAI_BASE_URL`. They may point to
-the same OpenAI-compatible endpoint.
+Two pinned target builds share this seed, split, budgets, and access policy;
+they differ only in target model, and each pins the seed floor measured on
+**its own** model — a delta against the other build's floor is a model
+comparison, not an optimization result:
+
+| build | target model | pinned `baseline_reward` |
+| --- | --- | --- |
+| `build.yaml` | `fireworks_ai/gpt-oss-120b` | 0.0676 (K=3, n=148) |
+| `build.gpt54mini.yaml` | `gpt-5.4-mini` | 0.1324 (K=3, n=136) |
+
+Both floors were measured with `scripts/rescore_candidate.py --seed`, the same
+path that produced every other pinned baseline in the suite.
+
+The Harbor tasks retain their canonical rubric-based verifier. That verifier
+needs `OPENAI_API_BASE`; the target agent uses `OPENAI_BASE_URL`. They may
+point to the same OpenAI-compatible endpoint.
 
 Compile from the repository root:
 
 ```bash
 cd vero
 VERO_SKIP_SECRET_CHECK=1 uv run vero harbor build \
-  --config ../harness-engineering-bench/candidates/swe-atlas-qna/baseline/build.yaml \
-  --output ../harness-engineering-bench/candidates/swe-atlas-qna/baseline/compiled
+  --config ../harness-engineering-bench/swe-atlas-qna/baseline/build.yaml \
+  --output ../harness-engineering-bench/swe-atlas-qna/baseline/compiled
 ```
 
 For a real run, provide `OPENAI_API_KEY`, `OPENAI_BASE_URL`,

--- a/harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml
@@ -31,15 +31,16 @@ selection_partition: validation
 targets:
   - partition: test
     reward_key: reward
-    # NO baseline_reward. The pinned 0.0676 was measured on
-    # fireworks_ai/gpt-oss-120b and says nothing about this target; a delta
-    # against it would be a model comparison dressed up as an optimization
-    # result.
-    # With `score_baseline: false` below, this run therefore reports an ABSOLUTE
-    # held-out score and no delta. That is deliberate: the seed floor for this
-    # target is measured out of band by holdout/validate-model.sh, which scores
-    # the unmodified seed on held-out cases for a fraction of a finalization
-    # pass. Pair the two numbers; do not compare this score to 0.0676.
+    # Measured on THIS target model, not inherited: build.yaml's 0.0676 was
+    # measured on fireworks_ai/gpt-oss-120b and says nothing about gpt-5.4-mini
+    # -- a delta against it would be a model comparison dressed up as an
+    # optimization result. Pinned via
+    #   rescore_candidate.py --seed --benchmark swe-atlas-qna --model gpt-5.4-mini
+    # (the same path that produced every other pinned baseline).
+    baseline_reward: 0.1324  # K=3: 0.109 / 0.136 / 0.152 (sd 0.0180, n=136). See runs/BASELINES.md
+    # 14 of 150 baseline trials raised: 12 RuntimeError ("model returned neither
+    # an answer nor a tool call"), 1 RateLimitError, 1 VerifierTimeoutError. The
+    # RuntimeError rate (~8%) is seed headroom, not task difficulty.
     failure_value: 0.0
     max_attempts: 1
     # The held-out eval is noisy: score the selected candidate 3x per case and
@@ -57,7 +58,7 @@ objective:
   direction: maximize
 reward_mode: submit  # agent picks; falls back to auto_best, then current version
 baseline_floor: false  # gates on validation while reward is on test; opt-in only
-score_baseline: false  # one held-out pass only; seed floor measured out of band
+score_baseline: false  # seed floor pinned above; don't re-score it every run
 rescore_top_k: 3
 rescore_attempts: 1
 

--- a/harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml
@@ -31,16 +31,20 @@ selection_partition: validation
 targets:
   - partition: test
     reward_key: reward
-    # Measured on THIS target model, not inherited: build.yaml's 0.0676 was
+    # Measured on THIS target model, not inherited: build.yaml's floor was
     # measured on fireworks_ai/gpt-oss-120b and says nothing about gpt-5.4-mini
     # -- a delta against it would be a model comparison dressed up as an
     # optimization result. Pinned via
     #   rescore_candidate.py --seed --benchmark swe-atlas-qna --model gpt-5.4-mini
     # (the same path that produced every other pinned baseline).
-    baseline_reward: 0.1324  # K=3: 0.109 / 0.136 / 0.152 (sd 0.0180, n=136). See runs/BASELINES.md
-    # 14 of 150 baseline trials raised: 12 RuntimeError ("model returned neither
-    # an answer nor a tool call"), 1 RateLimitError, 1 VerifierTimeoutError. The
-    # RuntimeError rate (~8%) is seed headroom, not task difficulty.
+    #
+    # Convention: trials the SEED killed score 0 (12 RuntimeError, the seed's
+    # empty-completion fail-fast at ~8% -- harness headroom an optimizer can
+    # fix, and finalization zero-fills a candidate's dead attempts the same
+    # way); trials the PLATFORM killed are dropped (1 RateLimitError,
+    # 1 VerifierTimeoutError -- zero-filling infra bakes outage luck into the
+    # floor). See runs/recompute.py for the classification.
+    baseline_reward: 0.1216  # K=3: 0.100 / 0.122 / 0.143 (sd 0.0175, n=148). See runs/BASELINES.md
     failure_value: 0.0
     max_attempts: 1
     # The held-out eval is noisy: score the selected candidate 3x per case and

--- a/harness-engineering-bench/swe-atlas-qna/baseline/build.yaml
+++ b/harness-engineering-bench/swe-atlas-qna/baseline/build.yaml
@@ -31,7 +31,10 @@ selection_partition: validation
 targets:
   - partition: test
     reward_key: reward
-    baseline_reward: 0.0676  # re-pinned 0.061 / 0.102 / 0.040 (sd 0.0257); was 0.0966. See runs/BASELINES.md
+    # Seed-killed trials score 0 (2 BadRequestError: the seed overflowing the
+    # 128k context, which context management -- a harness concern -- would fix);
+    # platform-killed trials are dropped. See runs/recompute.py.
+    baseline_reward: 0.0667  # K=3: 0.060 / 0.100 / 0.040 (sd 0.0249, n=150); was 0.0676 excluding seed-killed trials, 0.0966 pre-repin. See runs/BASELINES.md
     failure_value: 0.0
     max_attempts: 1
     # The held-out eval is noisy: score the selected candidate 3x per case and

--- a/harness-engineering-bench/terminal-bench/README.md
+++ b/harness-engineering-bench/terminal-bench/README.md
@@ -5,15 +5,20 @@ is long-horizon work in a command line, and each task's own tests decide pass or
 fail, so the reward is a pass rate.
 
 **Status: measured and pinned.** Target model `xai/grok-build-0.1`, held-out
-baseline **0.2600 ±0.0176** (K=3, n=100). Recorded in `runs/BASELINES.md` and
-`CONFIGURATION.md`, reproducible with `python3 runs/recompute.py`.
+baseline **0.2407 ±0.0131** (K=3, n=108). Recorded in `runs/BASELINES.md` and
+`CONFIGURATION.md`, reproducible with `python3 runs/recompute.py`. Trials the
+seed itself killed score 0 in the pin (4 `UnicodeDecodeError` from the seed's
+undecodable-output bug plus 4 timeouts the verifier could not score); trials
+the platform killed are excluded. The convention is documented at the ◆
+footnote in `CONFIGURATION.md`.
 
 One number to know before comparing a candidate against it: 18 of 108 baseline
 trials ended in `AgentTimeoutError`, a 20% exception rate against 0.3-3.5%
 elsewhere in the suite. The seed allows 40 steps at a 300s per-command cap while
 48 of 89 tasks declare a 900s budget, so three slow commands exhaust the clock.
 That is real headroom, but a sixth of the baseline's failures are wall-clock rather
-than capability.
+than capability. (14 of the 18 still scored — grading runs on the container's
+final state — and were always inside the pin.)
 
 ## The dataset
 
@@ -180,9 +185,9 @@ development tasks, one round each):
 crashed 5 of 17 trials returning bodies the SDK could not parse.
 
 It costs ~8.6x the cheapest candidate, which is the right trade: what a benchmark
-needs is a baseline with headroom, not reward per dollar. 0.26 sits near officeqa's
-0.3412, where the best cell moved +0.41; 0.12 is swe-atlas-qna territory (0.0676),
-the least informative cell in the suite.
+needs is a baseline with headroom, not reward per dollar. 0.24 sits near officeqa's
+0.3412, where the best cell moved +0.41; 0.12 is swe-atlas-qna territory (0.0667
+on gpt-oss-120b), the least informative cell in the suite.
 
 Deliberately **not** a Fireworks model. The shared per-minute generated-token quota
 is what limits how many cells run at once, so a target off that provider does not
@@ -191,18 +196,20 @@ contend with the officeqa or browsecomp-plus grids.
 ## Spread, and why n_attempts stays at 3
 
 36 held-out cases is the smallest test partition in the suite and was expected to
-be noisy. Measured sd is **0.0176** -- second tightest of the six, behind only
+be noisy. Measured sd is **0.0131** -- second tightest of the six, behind only
 tau3's 0.0099, and tighter than officeqa at 99 cases (0.0330) or gaia at 66
 (0.0524). Each task ships its own deterministic tests, so no LLM judge or user
 simulator rides on the score. Raising `n_attempts` to 5 was on the table before
-this was measured; it is not needed.
+this was measured; it is not needed. (Scoring seed-killed trials as zeros
+*tightened* the spread, from 0.0176: the seed's failure rate was itself part of
+the round-to-round variance, and pricing it consistently removes that noise.)
 
 ## Known seed bug
 
 `UnicodeDecodeError` killed 4 baseline trials: a command emitting undecodable bytes
-ends the trial instead of degrading to truncated output. Unlike the timeouts, this
-is a bug rather than headroom. Fixing it changes the seed and therefore requires
-re-pinning the baseline, so it is recorded rather than fixed.
+ends the trial instead of degrading to truncated output. Those trials score 0 in
+the pin -- the defect is priced, not hidden. Fixing it changes the seed and
+therefore requires re-pinning the baseline, so it is recorded rather than fixed.
 
 ## Sources
 

--- a/harness-engineering-bench/terminal-bench/baseline/build.yaml
+++ b/harness-engineering-bench/terminal-bench/baseline/build.yaml
@@ -36,7 +36,11 @@ selection_partition: validation
 targets:
   - partition: test
     reward_key: reward
-    baseline_reward: 0.2600  # K=3: 0.273 / 0.235 / 0.273 (sd 0.0176, n=100). See runs/BASELINES.md
+    # Seed-killed trials score 0 (4 UnicodeDecodeError from the seed's
+    # undecodable-output bug, 4 AgentTimeoutError the verifier could not score;
+    # the other 14 timeouts scored on final container state and were always in
+    # the pin); platform-killed trials are dropped. See runs/recompute.py.
+    baseline_reward: 0.2407  # K=3: 0.250 / 0.222 / 0.250 (sd 0.0131, n=108); was 0.2600 excluding seed-killed trials. See runs/BASELINES.md
     # 36 held-out cases was expected to be noisy -- it is the smallest test set in
     # the suite -- but the measured sd is the second tightest of the six, behind
     # only tau3. Deterministic per-task tests instead of an LLM judge is the


### PR DESCRIPTION
## What

Two commits, one measurement and one convention it surfaced:

**1. Measures and pins the seed floor for `build.gpt54mini.yaml`** (swe-atlas-qna targeting `gpt-5.4-mini`), via `rescore_candidate.py --seed` — the same plain-`harbor run` path behind every other pin. 50 held-out test cases × 3 independent rounds.

**2. Adopts a failed-trial convention suite-wide** (from Greptile's review of commit 1): a trial the **seed** killed scores **0** — harness defects are optimizable headroom, and finalization zero-fills a candidate's dead attempts the same way (`harbor/backend.py`, `aggregate_attempts: mean`), so the floor must pay the same tax. A trial the **platform** killed is **dropped** — zero-filling infra bakes outage luck into the pin.

```
swe-atlas gpt-5.4-mini   baseline_reward: 0.1216 ± 0.0175  (n=148, rounds 0.100 / 0.122 / 0.143)
terminal-bench           0.2600 → 0.2407 ± 0.0131          (n=108)
swe-atlas gpt-oss-120b   0.0676 → 0.0667 ± 0.0249          (n=150)
gaia / officeqa / tau3 / browsecomp-plus: unchanged — their only failures were platform-side
```

## The numbers worth knowing

- **~2× the gpt-oss-120b floor with a tighter spread.** This target turns swe-atlas-qna from the least informative cell in the suite into a usable one.
- **The gpt-5.4-mini seed's dominant defect is priced, not hidden:** 12 of 150 trials died to the seed's empty-completion fail-fast (`RuntimeError: model returned neither an answer nor a tool call`, ~8%, usually right after a shell command returned empty output). Those score 0 in the pin. Fixing that fail-fast is exactly the kind of harness repair the benchmark should reward — and now the floor charges the seed for it.
- **Both material re-pins tightened sd** (terminal-bench 0.0176→0.0131): the seed's failure rate was itself round-to-round variance; pricing it consistently removes that noise.
- **Terminal-bench nuance:** 14 of its 18 timeout trials were always in the pin (grading runs on final container state); the re-pin only prices the 4 the verifier couldn't score plus the 4 `UnicodeDecodeError` trials from the known seed bug.

## Also in this diff

- The gpt54mini config's provenance comment pointed at `holdout/validate-model.sh`, which never existed; it now names the real path.
- `baseline/README.md` documented a compile path from the removed `candidates/` layout; corrected, with both builds' floors tabled side by side and a don't-cross-compare warning.
- Convention stated at `CONFIGURATION.md`'s ◆ footnote; classification is a hard allow-list in the local recompute tooling (unclassified exception types refuse to compute).

## Testing

- All three re-pinned configs compile; each `serve.json` carries its new pin.
- Per-round artifacts under `runs/` (local, gitignored per repo policy); reproducible with `python3 runs/recompute.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins revised held-out baseline rewards using the documented failed-trial convention.
- Pins the gpt-5.4-mini SWE-Atlas-QnA baseline at 0.1216 and the gpt-oss-120b baseline at 0.0667.
- Updates Terminal-Bench’s baseline to 0.2407.
- Documents model-specific floors, failure handling, provenance, and corrected build paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| harness-engineering-bench/swe-atlas-qna/baseline/build.gpt54mini.yaml | Pins the model-specific baseline and now counts the 12 seed-caused failures as zero, resolving the prior unequal failure-accounting issue. |
| harness-engineering-bench/swe-atlas-qna/baseline/build.yaml | Revises the gpt-oss baseline under the same seed-versus-platform failure convention. |
| harness-engineering-bench/terminal-bench/baseline/build.yaml | Revises the Terminal-Bench baseline to incorporate seed-caused failed trials. |
| harness-engineering-bench/CONFIGURATION.md | Updates benchmark baseline tables and documents the failed-trial convention and alternate model floor. |
| harness-engineering-bench/swe-atlas-qna/baseline/README.md | Documents both model-specific builds, their pinned floors, and the corrected compilation path. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Score seed-killed trials as zeros in eve..."](https://github.com/scaleapi/vero/commit/bcb8733015477b23148a16a0ca483a765657ef99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49236912)</sub>

<!-- /greptile_comment -->