### PR TITLE
Let the Terminal-Bench target find the gateway on OPENAI_*

### DIFF
--- a/harness-engineering-bench/terminal-bench/baseline/target/src/terminal_bench_agent/agent.py
+++ b/harness-engineering-bench/terminal-bench/baseline/target/src/terminal_bench_agent/agent.py
@@ -97,15 +97,17 @@ class TerminalBenchAgent(BaseAgent):
         if self.model_name is None:
             raise ValueError("Terminal-Bench agent requires a Harbor model")
         self._api_model = self.model_name.removeprefix("openai/")
-        # Fail closed: OPENAI_* here can point at the unmetered upstream, so a
-        # fallback would bypass metering and the model allow-list silently.
-        gateway_key = os.environ.get("VERO_AGENT_INFERENCE_API_KEY")
-        gateway_url = os.environ.get("VERO_AGENT_INFERENCE_BASE_URL")
+        # Dedicated names first; they carry the gateway when OPENAI_* is upstream.
+        gateway_key = os.environ.get("VERO_AGENT_INFERENCE_API_KEY") or os.environ.get(
+            "OPENAI_API_KEY"
+        )
+        gateway_url = os.environ.get("VERO_AGENT_INFERENCE_BASE_URL") or os.environ.get(
+            "OPENAI_BASE_URL"
+        )
         if not gateway_key or not gateway_url:
             raise RuntimeError(
-                "Terminal-Bench target inference requires "
-                "VERO_AGENT_INFERENCE_API_KEY and VERO_AGENT_INFERENCE_BASE_URL; "
-                "refusing to fall back to OPENAI_*"
+                "Terminal-Bench target inference requires a scoped API key and "
+                "base URL on VERO_AGENT_INFERENCE_* or OPENAI_*"
             )
         # An unretried rate limit inside a trial scores the failure value.
         self._client = AsyncOpenAI(

--- a/harness-engineering-bench/terminal-bench/baseline/target/tests/test_agent.py
+++ b/harness-engineering-bench/terminal-bench/baseline/target/tests/test_agent.py
@@ -99,7 +99,7 @@ class TestOutputTruncation:
 
 
 class TestGatewayCredentials:
-    """The target must reach the metered gateway, never the upstream directly."""
+    """The target must find the gateway on either pair of variables."""
 
     @staticmethod
     def _construct(tmp_path: Any) -> TerminalBenchAgent:
@@ -108,20 +108,37 @@ class TestGatewayCredentials:
     def test_missing_credentials_raise(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        monkeypatch.delenv("VERO_AGENT_INFERENCE_API_KEY", raising=False)
-        monkeypatch.delenv("VERO_AGENT_INFERENCE_BASE_URL", raising=False)
-        monkeypatch.setenv("OPENAI_API_KEY", "upstream-key")
-        monkeypatch.setenv("OPENAI_BASE_URL", "https://upstream.example/v1")
-        with pytest.raises(RuntimeError, match="VERO_AGENT_INFERENCE"):
+        for name in (
+            "VERO_AGENT_INFERENCE_API_KEY",
+            "VERO_AGENT_INFERENCE_BASE_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        with pytest.raises(RuntimeError, match="scoped API key"):
             self._construct(tmp_path)
 
-    def test_credentials_are_used_when_present(
+    def test_openai_variables_are_used_when_vero_ones_are_absent(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
-        monkeypatch.setenv("VERO_AGENT_INFERENCE_API_KEY", "scoped-token")
-        monkeypatch.setenv("VERO_AGENT_INFERENCE_BASE_URL", "https://gw.example/v1")
+        monkeypatch.delenv("VERO_AGENT_INFERENCE_API_KEY", raising=False)
+        monkeypatch.delenv("VERO_AGENT_INFERENCE_BASE_URL", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "scoped-token")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gw.example/v1")
         agent = self._construct(tmp_path)
         assert "gw.example" in str(agent._client.base_url)
+
+    def test_dedicated_variables_win_over_openai_ones(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """OPENAI_* may be the unmetered upstream; precedence keeps us off it."""
+        monkeypatch.setenv("VERO_AGENT_INFERENCE_API_KEY", "scoped-token")
+        monkeypatch.setenv("VERO_AGENT_INFERENCE_BASE_URL", "https://gw.example/v1")
+        monkeypatch.setenv("OPENAI_API_KEY", "upstream-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://upstream.example/v1")
+        agent = self._construct(tmp_path)
+        assert "gw.example" in str(agent._client.base_url)
+        assert agent._client.api_key == "scoped-token"
 
 
 class TestRunLoop:


### PR DESCRIPTION
## The defect

The Terminal-Bench seed agent demanded `VERO_AGENT_INFERENCE_API_KEY` /
`VERO_AGENT_INFERENCE_BASE_URL` and explicitly refused to fall back to `OPENAI_*`.

But `terminal-bench/baseline/build.yaml` does not set `task_services_use_upstream`,
and every sibling does (`browsecomp-plus:143`, `swe-atlas-qna:184`, `tau3:135`).
With it false — the default — `harbor/backend.py:670-676` takes the other branch:

```python
if task_services_use_upstream:      # browsecomp-plus, tau3, swe-atlas-qna
    OPENAI_API_KEY = <real upstream>            # for task-owned graders
    VERO_AGENT_INFERENCE_API_KEY = <gateway>
else:                               # terminal-bench, officeqa, gaia, swe-bench-pro
    OPENAI_API_KEY = <gateway>
```

So `VERO_AGENT_INFERENCE_*` was never set, the agent raised in `__init__` on every
trial before any inference call, and harbor reported `no matching trials for N
requested tasks`.

**The seed could not run under its own config.** Cells only scored because their
optimizer diagnosed and patched this first — visible in the shipped candidates,
one of which is titled *"fix Harbor gateway credential discovery"*. The one cell
whose optimizer never made that fix scored nothing, three times, on two keys.

## The change

Prefer the dedicated names, fall back to `OPENAI_*`. Correct under both settings
of the flag: false, and `OPENAI_*` is the scoped gateway; true, and the dedicated
pair is set and wins, so the target never reaches the raw upstream. No config
change, and the upstream key stays out of the evaluation environment.

This is already the convention in `swe-bench-pro` and `tau3`, both of which read
both pairs with the same precedence.

## Tests

The replaced case asserted the guard *raises* when only `OPENAI_*` is set, i.e. it
pinned the broken behaviour. Now three cases:

- neither pair present → raises
- `OPENAI_*` only → used (the configuration this benchmark actually runs under)
- both present → dedicated pair wins (keeps the target off an unmetered endpoint)

16 tests pass.

## Scope and caveats

- **browsecomp-plus is untouched.** Same VERO-only pattern, but not broken because
  its config sets the flag. Its grid is mid-pass; changing the seed now would split
  the cohort.
- **This does not retroactively fix measured results.** The nine scored
  Terminal-Bench r1 cells came from optimizers that had to debug this themselves,
  so their deltas include that work. Sizing that confound needs a small control
  re-run against the fixed seed.
- **Metering was never bypassed.** With the flag false, `OPENAI_*` *is* the scoped,
  allow-listed gateway token, so the candidates that fell back stayed metered. The
  old comment claiming otherwise was wrong for this configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores Terminal-Bench startup under its existing Harbor configuration.
- Falls back to the scoped `OPENAI_*` credential pair when dedicated `VERO_AGENT_INFERENCE_*` variables are absent.
- Preserves dedicated-variable precedence when both credential pairs are available.
- Updates credential tests to cover missing credentials, fallback behavior, and precedence.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the fallback uses the scoped gateway credentials supplied by Terminal-Bench’s current Harbor configuration.

Harbor supplies the gateway key and URL through `OPENAI_*` for this target, while configurations exposing raw upstream credentials also supply the preferred dedicated pair, so the changed precedence preserves the gateway boundary.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| harness-engineering-bench/terminal-bench/baseline/target/src/terminal_bench_agent/agent.py | Adds credential fallback consistent with Terminal-Bench’s Harbor environment while retaining dedicated gateway precedence. |
| harness-engineering-bench/terminal-bench/baseline/target/tests/test_agent.py | Replaces the obsolete fail-closed assertion with coverage for absent credentials, OPENAI fallback, and dedicated-variable precedence. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Initialize TerminalBenchAgent] --> B{VERO_AGENT_INFERENCE pair available?}
    B -->|Yes| C[Use dedicated gateway credentials]
    B -->|No| D{OPENAI pair available?}
    D -->|Yes| E[Use Harbor-provided scoped gateway credentials]
    D -->|No| F[Raise RuntimeError]
    C --> G[Construct AsyncOpenAI client]
    E --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Let the Terminal-Bench target find the g..."](https://github.com/scaleapi/vero/commit/a99c9d98afba399435c73b427b03ce2c57affcbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49274631)</sub>

<!-- /greptile_comment -->