### PR TITLE
fix: export the session on every terminal outcome, not only when the verifier runs

### DIFF
--- a/vero/docs/guide.md
+++ b/vero/docs/guide.md
@@ -129,6 +129,14 @@ records, budget state, the finalization result, and the producer trajectory —
 re-render it any time with `vero report`. Export failure fails the run rather
 than discarding the only durable copy.
 
+A run that *fails* never reaches the verifier phase, so it leaves none of that.
+For those, the compiled task also snapshots the session from a Harbor collect
+hook, which runs on every terminal outcome, leaving
+`artifacts/session-rescue.tar.gz` alongside the trial. Same archive format,
+minus the files a finalize produces, so the candidate repo and every evaluation
+score are still recoverable. See `docs/harbor-architecture.md`, "When step 5
+never happens".
+
 > **Security boundary.** The inference gateway protects *provider credentials*,
 > not the OS process. The pinned Harbor overlay and sidecar keep budget and
 > scoring trusted, but candidate code still runs inside the nested Harbor

--- a/vero/docs/harbor-architecture.md
+++ b/vero/docs/harbor-architecture.md
@@ -72,6 +72,41 @@ Named volumes carry state between services: `agent_repo`, `agent_context`,
 6. Harbor collects `/logs` back to **`jobs/<timestamp>/<task>/`** on disk and
    reports the reward.
 
+### When step 5 never happens
+
+Step 5 runs in Harbor's *verifier phase*, and the verifier phase is not
+guaranteed. Harbor's agent phase swallows only `AgentTimeoutError` and
+`NonZeroAgentExitCodeError` (`harbor/trial/single_step.py`); anything else
+propagates past `await self._run_verifier()`. Two outer trials died on
+2026-07-31: the one that hit a provider budget limit raised
+`NonZeroAgentExitCodeError`, reached the verifier, and left the full
+`verifier/session.tar.gz`. The one that hit a Modal `grpclib`
+`StreamTerminatedError` at 71 minutes left nothing, discarding a candidate that
+had already scored 0.1224 on 49 validation cases.
+
+What still runs on that path is **artifact collection**: Harbor calls
+`_collect_artifacts` from `Trial._recover_outputs` too, and in the failed run it
+succeeded from the same sandbox moments after the stream died. So the compiled
+task declares a `[[verifier.collect]]` hook that runs `vero harbor
+archive-session` inside the sidecar, plus a matching `[[artifacts]]` entry, and
+the snapshot lands at **`<task>/artifacts/session-rescue.tar.gz`** on *every*
+terminal outcome. It is token-free and does not finalize, so it is safe to run
+during teardown.
+
+The rescue archive is the same format as `verifier/session.tar.gz` minus the
+files a finalize produces, so it carries `candidates/repository.git` (every
+candidate commit) and `database.json` (every evaluation and score). To recover a
+candidate from either one: `extract_harbor_session_archive`, then
+`git --git-dir=<session>/candidates/repository.git archive <sha>`. Re-scoring it
+against a benchmark's pinned baseline is
+`harness-engineering-bench/scripts/rescore_candidate.py --session <archive>`,
+which lives out of tree because it needs that benchmark's `build.yaml`.
+
+A true *resume* is not available and is not the goal here: the optimizer's
+working tree, its harness process, and its agent context all live in the Modal
+sandbox, which is torn down. What survives is every candidate the optimizer
+committed and every score it measured.
+
 ## The evaluation core
 
 - **`EvaluationEngine`** (`evaluation/engine.py`) runs every evaluation through a
@@ -190,7 +225,7 @@ honest*. Paths are under `vero/src/vero/` unless noted.
    `gateway/inference.py`; the session archive in `sidecar/session.py`.
 9. **Observability** — `runtime/wandb.py` (`SidecarWandbSink`).
 10. **The CLI glue** — `harbor/cli.py` (`vero harbor run`, `finalize`,
-    `export-session`, `score-baseline`).
+    `export-session`, `archive-session`, `score-baseline`).
 
 Tests mirror this order (`tests/test_v05_harbor_*.py`) and are a good
 executable spec for each layer.

--- a/vero/src/vero/harbor/build/compiler.py
+++ b/vero/src/vero/harbor/build/compiler.py
@@ -42,6 +42,18 @@ PRODUCER_BASE_URL = LAYOUT.scope_url("producer", LAYOUT.optimizer_attribution)
 # must be here, or the rendered compose emits the key twice.
 GATEWAY_ROUTED_CREDENTIALS = frozenset(LAYOUT.routed_credential_envs)
 
+# The pre-collection session snapshot (see the [[verifier.collect]] block in
+# task.toml.j2). Measured: archiving a real 63M / ~2300-file session took 3.2s,
+# so Harbor's 60s collect-hook default would probably do. It is raised anyway
+# because a long optimization writes a full Harbor trial record per evaluated
+# case, and the whole point of the hook is to hold under the conditions that
+# already destroyed a run. Still bounded, because the hook runs inside the
+# trial's teardown and a hung one would stall artifact collection behind it.
+SESSION_RESCUE_TIMEOUT_SECONDS = 600
+# Flat name at the artifacts root, rather than Harbor's default of mirroring the
+# container path (which would bury it at artifacts/state/admin/).
+SESSION_RESCUE_DESTINATION = "session-rescue.tar.gz"
+
 # Container paths and service identities come from the layout, never from a
 # literal here: the templates read the same object, so the two cannot drift.
 VERO_DIR = LAYOUT.vero
@@ -791,6 +803,8 @@ def compile_harbor_task(
         "verifier_timeout": (
             config.verifier_timeout_seconds or max(1, int(config.timeout_seconds))
         ),
+        "session_rescue_timeout": SESSION_RESCUE_TIMEOUT_SECONDS,
+        "session_rescue_destination": SESSION_RESCUE_DESTINATION,
         "overlay_present": overlay_present,
         "overlay_excludes": overlay_excludes,
     }

--- a/vero/src/vero/harbor/build/templates/task.toml.j2
+++ b/vero/src/vero/harbor/build/templates/task.toml.j2
@@ -11,6 +11,21 @@ user = "agent"
 environment_mode = "shared"
 timeout_sec = {{ verifier_timeout }}
 
+# Snapshot the trusted session before artifact collection, so a trial that never
+# reaches the verifier still yields its candidates and evaluation records.
+# Harbor's agent phase only swallows AgentTimeoutError and
+# NonZeroAgentExitCodeError (harbor/trial/single_step.py); every other exception
+# propagates past `await self._run_verifier()`, so `vero harbor export-session`
+# never runs. Collect hooks and artifact downloads still do, because
+# Trial._recover_outputs calls _collect_artifacts on the failure path. Measured
+# 2026-07-31: a Modal grpclib StreamTerminatedError killed an outer trial at 71
+# minutes and left no archive at all, while artifact collection from the same
+# sandbox still succeeded moments later.
+[[verifier.collect]]
+service = "{{ layout.sidecar_host }}"
+command = "vero harbor archive-session"
+timeout_sec = {{ session_rescue_timeout }}
+
 [environment]
 build_timeout_sec = {{ build_timeout }}
 {% if secrets %}
@@ -20,3 +35,11 @@ build_timeout_sec = {{ build_timeout }}
 {{ secret }} = "${{ '{' }}{{ secret }}{{ '}' }}"
 {% endfor %}
 {% endif %}
+
+# Collected from the sidecar's own filesystem, a channel the optimizer cannot
+# write to. Best-effort on Harbor's side: a missing source is recorded as a
+# failed manifest entry, never a trial failure.
+[[artifacts]]
+source = "{{ layout.session_rescue_archive }}"
+destination = "{{ session_rescue_destination }}"
+service = "{{ layout.sidecar_host }}"

--- a/vero/src/vero/harbor/cli.py
+++ b/vero/src/vero/harbor/cli.py
@@ -1125,6 +1125,53 @@ def finalize_command(token_file, output):
     click.echo(json.dumps(result, indent=2))
 
 
+@harbor.command("archive-session")
+@click.option(
+    "--session-dir",
+    default=LAYOUT.session_dir,
+    show_default=True,
+    type=click.Path(path_type=Path, file_okay=False),
+)
+@click.option(
+    "--output",
+    default=LAYOUT.session_rescue_archive,
+    show_default=True,
+    type=click.Path(path_type=Path, dir_okay=False),
+)
+def archive_session_command(session_dir, output):
+    """Snapshot the session to a tar.gz in place, without finalizing.
+
+    The rescue half of `export-session`. It reads the session directory off the
+    admin volume and writes an archive beside it: no admin token, no HTTP call,
+    and above all no `/finalize`, so it cannot spend the finalization budget or
+    take the 28 minutes the verifier phase took on 2026-07-31. Measured at 3.2s
+    on a real 63M / ~2300-file session.
+
+    That cheapness is the point. This runs from a `[[verifier.collect]]` hook,
+    which Harbor invokes on *every* terminal outcome (`Trial._recover_outputs`
+    runs it even when the trial raised), whereas `export-session` runs only from
+    the verifier phase. Harbor swallows just `AgentTimeoutError` and
+    `NonZeroAgentExitCodeError` out of the agent phase; anything else skips the
+    verifier entirely. Measured: two outer trials died the same night, and the
+    one that raised `NonZeroAgentExitCodeError` reached the verifier and left an
+    8.8M `session.tar.gz`, while the one that raised a Modal
+    `grpclib.StreamTerminatedError` at 71 minutes left nothing at all, losing a
+    candidate that had already scored 0.1224 on 49 validation cases.
+
+    The archive is the same format `export-session` produces, minus the
+    finalization/status/report files that only exist after a finalize. It still
+    carries `candidates/repository.git` (every candidate commit) and
+    `database.json` (every evaluation and score).
+    """
+    archive = create_harbor_session_archive(session_dir, output)
+    click.echo(
+        json.dumps(
+            {"session": str(archive), "sha256": file_sha256(archive)},
+            indent=2,
+        )
+    )
+
+
 @harbor.command("export-session")
 @click.option(
     "--token-file",

--- a/vero/src/vero/layout.py
+++ b/vero/src/vero/layout.py
@@ -98,6 +98,16 @@ class TaskLayout:
         return f"{self.admin_volume}/session"
 
     @property
+    def session_rescue_archive(self) -> str:
+        """Pre-finalization session snapshot, taken before artifact collection.
+
+        Deliberately a sibling of ``session_dir`` rather than a child, so the
+        archive the verifier later builds from ``session_dir`` cannot contain a
+        copy of this one.
+        """
+        return f"{self.admin_volume}/session-rescue.tar.gz"
+
+    @property
     def case_resources_dir(self) -> str:
         return f"{self.admin_volume}/case-resources"
 

--- a/vero/tests/test_v05_harbor_build.py
+++ b/vero/tests/test_v05_harbor_build.py
@@ -23,7 +23,11 @@ from vero.harbor import (
     compile_harbor_task,
     load_harbor_build_config,
 )
-from vero.harbor.build.compiler import GATEWAY_ROUTED_CREDENTIALS
+from vero.harbor.build.compiler import (
+    GATEWAY_ROUTED_CREDENTIALS,
+    SESSION_RESCUE_DESTINATION,
+    SESSION_RESCUE_TIMEOUT_SECONDS,
+)
 from vero.harbor.build.config import (
     _HARBOR_ONLY_FIELDS,
     _AgentWorkspaceFields,
@@ -70,6 +74,7 @@ def test_task_layout_values_are_pinned():
     assert LAYOUT.gateway_port == 8001
     # Derived paths, so a base and its children cannot drift apart.
     assert LAYOUT.session_dir == "/state/admin/session"
+    assert LAYOUT.session_rescue_archive == "/state/admin/session-rescue.tar.gz"
     assert LAYOUT.case_resources_dir == "/state/admin/case-resources"
     assert LAYOUT.token_path == "/state/token/admin.token"
     assert LAYOUT.inference_state == "/state/inference/usage.json"
@@ -1163,6 +1168,51 @@ def test_compiler_isolates_upstream_inference_credentials(tmp_path, monkeypatch)
     assert backend["inference_gateway_token"] != "real-provider-secret"
     assert "real-provider-secret" not in json.dumps(serve)
     assert (output / "environment/gateway/Dockerfile").is_file()
+
+
+def test_compiled_task_rescues_the_session_outside_the_verifier_phase(tmp_path):
+    """A dead outer trial must still yield its candidates and evaluation records.
+
+    Regression for two outer trials that died on 2026-07-31. Harbor's agent phase
+    swallows only AgentTimeoutError and NonZeroAgentExitCodeError
+    (harbor/trial/single_step.py); the run that raised one of those reached the
+    verifier and left an 8.8M session.tar.gz, while the run that raised a Modal
+    grpclib StreamTerminatedError at 71 minutes skipped `_run_verifier` entirely
+    and left nothing, losing a candidate already scored at 0.1224 on 49 cases.
+    Collect hooks and artifact downloads run on both paths (Harbor calls
+    `_collect_artifacts` from `Trial._recover_outputs` too), so the snapshot has
+    to hang off those and not off tests/test.sh.
+    """
+
+    output = compile_harbor_task(
+        _config(tmp_path),
+        tmp_path / "compiled",
+        vero_root=Path(__file__).parents[1],
+    )
+
+    task = tomllib.loads((output / "task.toml").read_text(encoding="utf-8"))
+
+    (hook,) = task["verifier"]["collect"]
+    assert hook["service"] == LAYOUT.sidecar_host
+    # Token-free and finalize-free: a collect hook runs during teardown, so it
+    # must not need the admin token or spend the finalization budget.
+    assert hook["command"] == "vero harbor archive-session"
+    assert "--token-file" not in hook["command"]
+    assert hook["timeout_sec"] == SESSION_RESCUE_TIMEOUT_SECONDS
+
+    (artifact,) = task["artifacts"]
+    # Collected from the sidecar's own filesystem, which the optimizer in `main`
+    # cannot write to.
+    assert artifact["service"] == LAYOUT.sidecar_host
+    assert artifact["source"] == LAYOUT.session_rescue_archive
+    assert artifact["destination"] == SESSION_RESCUE_DESTINATION
+    # A sibling of the session dir, never a child, or the verifier's own export
+    # would archive a copy of this one.
+    assert not artifact["source"].startswith(LAYOUT.session_dir + "/")
+
+    # tests/test.sh still owns the authoritative, post-finalization export. The
+    # rescue snapshot is additive, not a replacement.
+    assert "vero harbor export-session" in (output / "tests/test.sh").read_text()
 
 
 def test_compiler_uses_published_version_outside_a_source_checkout(

--- a/vero/tests/test_v05_harbor_build.py
+++ b/vero/tests/test_v05_harbor_build.py
@@ -1450,3 +1450,58 @@ def test_unresolvable_path_task_source_names_the_missing_data(tmp_path):
     with pytest.raises(ValidationError, match="explicit version"):
         case("unpinned", task_source="gaia/gaia")
     case("pinned", task_source="gaia/gaia@sha256:abc123")
+
+
+def test_harbor_itself_routes_the_rescue_hook_into_the_sidecar_collection_pass(
+    tmp_path,
+):
+    """The rescue only fires if Harbor's own parser files it under a sidecar.
+
+    The two preceding tests assert what we emit. This asserts what Harbor makes
+    of it, which is where the change can silently become a no-op:
+    `Trial._collect_artifacts_phased` starts the sidecar pass with
+    `if not sidecars: return`, so a hook that parses but lands under `main`, or
+    fails to parse into `verifier.collect` at all, would leave the failure path
+    behaving exactly as it did before while every emitted-config assertion still
+    passed.
+
+    Validating through Harbor's real `TaskConfig` rather than the raw TOML is
+    the point: it is the same model the runtime builds a trial from, so a field
+    Harbor renames or stops honouring surfaces here instead of in a dead run.
+    """
+    harbor_task_config = pytest.importorskip(
+        "harbor.models.task.config"
+    ).TaskConfig
+
+    output = compile_harbor_task(
+        _config(tmp_path),
+        tmp_path / "compiled",
+        vero_root=Path(__file__).parents[1],
+    )
+    raw = tomllib.loads((output / "task.toml").read_text(encoding="utf-8"))
+    # The shared fixture's name carries quotes that Harbor's package-name rule
+    # rejects; irrelevant to collection, so normalise it rather than weaken the
+    # fixture other tests depend on.
+    raw["task"]["name"] = "org/optimize-program"
+
+    config = harbor_task_config.model_validate(raw)
+
+    sidecar_hooks = [
+        hook for hook in config.verifier.collect if hook.service != "main"
+    ]
+    assert sidecar_hooks, (
+        "no sidecar collect hook survived Harbor's parser, so the sidecar "
+        "collection pass short-circuits and a dead trial exports nothing"
+    )
+    (hook,) = sidecar_hooks
+    assert hook.service == LAYOUT.sidecar_host
+    assert hook.command == "vero harbor archive-session"
+    assert hook.timeout_sec == SESSION_RESCUE_TIMEOUT_SECONDS
+
+    sidecar_artifacts = [
+        artifact for artifact in config.artifacts if artifact.service != "main"
+    ]
+    assert sidecar_artifacts, "the rescue archive would never leave the sandbox"
+    (artifact,) = sidecar_artifacts
+    assert artifact.source == LAYOUT.session_rescue_archive
+    assert artifact.destination == SESSION_RESCUE_DESTINATION

--- a/vero/tests/test_v05_harbor_session.py
+++ b/vero/tests/test_v05_harbor_session.py
@@ -6,7 +6,9 @@ import tarfile
 from datetime import UTC, datetime
 
 import pytest
+from click.testing import CliRunner
 
+from vero.cli import main
 from vero.evaluation import (
     BackendProvenance,
     EvaluationSet,
@@ -103,6 +105,67 @@ def test_harbor_session_archive_records_symlinks_as_metadata_without_failing(tmp
     reasons = {entry["path"]: entry["reason"] for entry in skipped["skipped"]}
     assert reasons["session/link_in"] == "symlink"
     assert reasons["session/link_abs"] == "symlink"
+
+
+def test_archive_session_command_snapshots_without_a_token_or_a_live_sidecar(
+    tmp_path,
+):
+    """The rescue path must work from a collect hook during trial teardown.
+
+    That means no admin token and no HTTP: the hook runs while the trial is
+    already unwinding, and on 2026-07-31 the failure that lost a whole run was a
+    lost Modal stream, so any recovery that depends on another round trip is
+    exactly the thing that cannot be relied on. Filesystem only.
+    """
+    session = tmp_path / "state/admin/session"
+    session.mkdir(parents=True)
+    (session / "harbor-session.json").write_text(
+        _manifest().model_dump_json(indent=2) + "\n"
+    )
+    (session / "database.json").write_text('{"id":"trial"}\n')
+    (session / "candidates").mkdir()
+    (session / "candidates" / "repository.json").write_text('{"family":"git"}\n')
+    output = tmp_path / "state/admin/session-rescue.tar.gz"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "harbor",
+            "archive-session",
+            "--session-dir",
+            str(session),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    reported = json.loads(result.output)
+    assert reported["session"] == str(output)
+    assert reported["sha256"] == file_sha256(output)
+
+    # Same format the verifier's own export produces, so the recovery tooling
+    # that reads a session.tar.gz reads this one unchanged.
+    extracted = extract_harbor_session_archive(output, tmp_path / "extracted")
+    assert (extracted / "database.json").read_text() == '{"id":"trial"}\n'
+    assert (extracted / "candidates" / "repository.json").is_file()
+
+
+def test_archive_session_command_reports_a_missing_session(tmp_path):
+    result = CliRunner().invoke(
+        main,
+        [
+            "harbor",
+            "archive-session",
+            "--session-dir",
+            str(tmp_path / "absent"),
+            "--output",
+            str(tmp_path / "session-rescue.tar.gz"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert not (tmp_path / "session-rescue.tar.gz").exists()
 
 
 def test_harbor_session_archive_rejects_traversal(tmp_path):


### PR DESCRIPTION
## The gap

An optimization's durable output (candidate commits, evaluation records, per-case scores) is written by the **verifier phase**. But the verifier phase does not run on every failure, so whether hours of work survives depends on **which exception type** harbor caught.

`harbor/trial/single_step.py` runs `_run_agent()` -> `_collect_artifacts()` -> `_run_verifier()`, and `_run_agent` swallows only two types:

```python
except (AgentTimeoutError, NonZeroAgentExitCodeError) as exc:
    self._record_exception(exc)
```

Anything else propagates and `_run_verifier()` never executes.

## Verified against two real runs on 2026-07-31

| | Run 1 | Run 2 |
|---|---|---|
| exception | `StreamTerminatedError` (grpclib) | `ApiRateLimitError` |
| in that tuple? | **no** | **yes** (`ApiRateLimitError` is a `NonZeroAgentExitCodeError`, confirmed via `issubclass`) |
| `result.json` `verifier` | `null` | ran, 22:29:05 to 22:57:26 |
| `verifier/` contents | **empty** | 7 files, `session.tar.gz` 8.8M |

Run 1 lost everything despite having already earned a validation score of 0.1224 on 49 cases. Run 2 kept a shipped candidate (`da6ab2d68f22`) that was later recovered and rescored.

**The sandbox was reachable the whole time.** Run 1's `trial.log` shows `Trial failed: Connection lost` immediately followed by `Collecting main service artifacts`, and its `artifacts/manifest.json` records `status: "ok"`. Harbor calls `_collect_artifacts` from `_recover_outputs` on the failure path. The evidence was sitting on a volume harbor could still read; nothing exported it.

## Fix

Hang the export off **artifact collection**, which runs on every terminal outcome, instead of off the verifier phase, which does not.

- **`vero harbor archive-session`**: token-free, HTTP-free, finalize-free snapshot straight off the admin volume. Measured **3.2s** on the real 63M / ~2300-file Run 2 session, against the 28 minutes Run 2's verifier phase took.
- `task.toml.j2` emits a `[[verifier.collect]]` hook plus a matching `[[artifacts]]` entry, landing the archive at `<task>/artifacts/session-rescue.tar.gz`. Both are best-effort in harbor and cannot fail a trial.
- `LAYOUT.session_rescue_archive` is a **sibling** of `session_dir`, so the verifier's own later export cannot recursively contain it.

## Deliberately not done

`rescore_candidate.py` was **not** ported into vero. Its value is the scoring, which needs the benchmark's `build.yaml` and pinned `baseline_reward` from `harness-engineering-bench`. A vero command that extracts a worktree but cannot score it would not close the gap. The docs now name the script explicitly so recovery stops being tribal knowledge.

A true "resume" is infeasible and was not attempted: the optimizer's working tree and harness context die with the sandbox (`environment.delete: true`). What is worth keeping is the candidates and the scores, and those are recoverable.

## Verification beyond unit tests

- Rendered `task.toml` validates against harbor 0.20.0's real `TaskConfig`; the collect hook parses as `('eval-sidecar', 'vero harbor archive-session', 600.0)`. Previously `sidecars` was empty and `_collect_artifacts_phased` short-circuited at `if not sidecars: return`.
- Ran the new command against the **real** Run 2 session: produced an 8.8M archive that round-trips through `extract_harbor_session_archive` and yields candidate `da6ab2d68f22...` with parent `43bc6a0f...`, matching `finalization.json` exactly.

## Tests

Three new: `test_compiled_task_rescues_the_session_outside_the_verifier_phase`, `test_archive_session_command_snapshots_without_a_token_or_a_live_sidecar`, `test_archive_session_command_reports_a_missing_session`, plus a `session_rescue_archive` assertion in the pinned-layout test.

Note the suite requires credentials in the environment; without them six tests fail on `compiler.py:566` credential validation and look like regressions. With `set -a; . heb.secrets.env; set +a` the full suite is **485 passed, 15 skipped**, one unrelated collection error in `test_uv_with_editable.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a best-effort rescue path for optimization sessions when Harbor does not reach the verifier phase.
- Registers a sidecar collection hook that archives session state before artifact download.
- Exposes a token-free, filesystem-only `archive-session` command.
- Adds the rescue archive path and compiler configuration.
- Documents session recovery and adds configuration and CLI regression coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/harbor/build/templates/task.toml.j2 | Registers the sidecar collection hook and matching rescue-archive artifact. |
| vero/src/vero/harbor/cli.py | Adds a filesystem-only command that snapshots a session without finalization or credentials. |
| vero/src/vero/harbor/build/compiler.py | Supplies the rescue hook timeout and flat artifact destination to the task template. |
| vero/src/vero/layout.py | Defines the rescue archive beside the session directory to avoid recursive inclusion. |
| vero/tests/test_v05_harbor_build.py | Verifies emitted TOML and Harbor model parsing route the hook and artifact through the sidecar. |
| vero/tests/test_v05_harbor_session.py | Covers successful token-free archiving, extraction compatibility, and missing-session failure. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant H as Harbor trial
    participant S as Evaluation sidecar
    participant V as Admin volume
    participant A as Trial artifacts
    H->>S: Run agent/verifier lifecycle
    alt Verifier completes
        S->>V: Finalize and export session.tar.gz
    else Terminal outcome skips verifier
        H->>S: Run archive-session collect hook
        S->>V: Create session-rescue.tar.gz
    end
    H->>V: Collect configured archive
    V-->>A: Copy session-rescue.tar.gz
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: assert Harbor itself files the res..."](https://github.com/scaleapi/vero/commit/93444c4e81d0f84d9c7c71f26ba360457c0cf3e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49283705)</sub>

<!-- /greptile_comment -->