### PR TITLE
Let the gateway pin a model to one upstream deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ wheels/
 secrets.env
 *.secrets.env
 !*.example
+
+# Codex CLI local state, including the worktrees it checks out for its own runs.
+.codex/

--- a/harness-engineering-bench/terminal-bench/baseline/build.azure.yaml
+++ b/harness-engineering-bench/terminal-bench/baseline/build.azure.yaml
@@ -149,6 +149,22 @@ inference_gateway:
   request_log_attribution: true
   producer:
     allowed_models: ["${optimizer_model:-openai/gpt-5.4}"]
+    # THE ONLY BLOCK THAT MAY DIFFER FROM build.yaml, and a test asserts exactly
+    # that. A 183-line duplicate is a drift hazard: if the two files diverge in a
+    # budget, timeout or partition, this cell silently stops being comparable to
+    # the nine that use build.yaml, and nothing would fail to tell us.
+    #
+    # Pin gpt-5.6-sol to one Azure deployment. codex reduces a model id to its
+    # last path component, so a codex cell cannot ask for `azure_ai/gpt-5.6-sol`
+    # itself -- the gateway has to supply it. Without this the request lands on
+    # the unqualified load-balanced group, and the Responses API's encrypted
+    # reasoning content is decryptable only by the deployment that produced it:
+    # every turn after the first fails with invalid_encrypted_content, which
+    # killed this cell on r2, r3 and r4. Measured 2026-08-01 against the live
+    # proxy: bare `gpt-5.6-sol` failed 5 of 5 encrypted-content replays,
+    # `azure_ai/gpt-5.6-sol` passed 5 of 5.
+    model_aliases:
+      gpt-5.6-sol: azure_ai/gpt-5.6-sol
     max_concurrency: 8
   # The case budget is the spend control; these caps only stop a runaway. Sized
   # per CONFIGURATION.md at the same per-case-run rate as the other benchmarks:
@@ -162,14 +178,7 @@ inference_gateway:
   finalization:
     allowed_models: [xai/grok-build-0.1]
     max_requests: 200000
-    # 216 case-runs (36 test x3 attempts, plus rescore_top_k=3 over 36 validation)
-    # at the suite's per-case-run rate of ~5.05M, which officeqa and
-    # browsecomp-plus both use. Was 700M, i.e. 3.24M per case-run -- 36% tighter
-    # than the rest of the suite for no stated reason. Erring low here is the
-    # expensive direction: an exhausted finalization budget surfaces as an
-    # upstream 429 and silently starves held-out scoring, which is exactly how
-    # officeqa lost a re-score. The case budget is the real spend control.
-    max_tokens: 1100000000
+    max_tokens: 700000000  # 36 test cases x3 attempts + rescore headroom
     max_concurrency: 64
 instruct_multifidelity: true
 instruct_exhaust_budget: true

--- a/harness-engineering-bench/terminal-bench/baseline/build.azure.yaml
+++ b/harness-engineering-bench/terminal-bench/baseline/build.azure.yaml
@@ -178,7 +178,14 @@ inference_gateway:
   finalization:
     allowed_models: [xai/grok-build-0.1]
     max_requests: 200000
-    max_tokens: 700000000  # 36 test cases x3 attempts + rescore headroom
+    # 216 case-runs (36 test x3 attempts, plus rescore_top_k=3 over 36 validation)
+    # at the suite's per-case-run rate of ~5.05M, which officeqa and
+    # browsecomp-plus both use. Was 700M, i.e. 3.24M per case-run -- 36% tighter
+    # than the rest of the suite for no stated reason. Erring low here is the
+    # expensive direction: an exhausted finalization budget surfaces as an
+    # upstream 429 and silently starves held-out scoring, which is exactly how
+    # officeqa lost a re-score. The case budget is the real spend control.
+    max_tokens: 1100000000
     max_concurrency: 64
 instruct_multifidelity: true
 instruct_exhaust_budget: true

--- a/harness-engineering-bench/terminal-bench/baseline/build.yaml
+++ b/harness-engineering-bench/terminal-bench/baseline/build.yaml
@@ -162,7 +162,14 @@ inference_gateway:
   finalization:
     allowed_models: [xai/grok-build-0.1]
     max_requests: 200000
-    max_tokens: 700000000  # 36 test cases x3 attempts + rescore headroom
+    # 216 case-runs (36 test x3 attempts, plus rescore_top_k=3 over 36 validation)
+    # at the suite's per-case-run rate of ~5.05M, which officeqa and
+    # browsecomp-plus both use. Was 700M, i.e. 3.24M per case-run -- 36% tighter
+    # than the rest of the suite for no stated reason. Erring low here is the
+    # expensive direction: an exhausted finalization budget surfaces as an
+    # upstream 429 and silently starves held-out scoring, which is exactly how
+    # officeqa lost a re-score. The case budget is the real spend control.
+    max_tokens: 1100000000
     max_concurrency: 64
 instruct_multifidelity: true
 instruct_exhaust_budget: true

--- a/harness-engineering-bench/terminal-bench/baseline/build.yaml
+++ b/harness-engineering-bench/terminal-bench/baseline/build.yaml
@@ -149,6 +149,21 @@ inference_gateway:
   request_log_attribution: true
   producer:
     allowed_models: ["${optimizer_model:-openai/gpt-5.4}"]
+    # Pin gpt-5.6-sol to one Azure deployment. codex reduces a model id to its
+    # last path component, so a codex cell cannot ask for `azure_ai/gpt-5.6-sol`
+    # itself -- the gateway has to do it. Without this, the request lands on the
+    # unqualified load-balanced group, and the Responses API's encrypted
+    # reasoning content is decryptable only by the deployment that produced it:
+    # every turn after the first fails with invalid_encrypted_content, which
+    # killed this cell on r2, r3 and r4. Measured 2026-08-01 against the live
+    # proxy: bare `gpt-5.6-sol` failed 5 of 5 encrypted-content replays,
+    # `azure_ai/gpt-5.6-sol` passed 5 of 5.
+    #
+    # Inert for the other nine cells: an alias only fires for a model the
+    # allow-list already admitted, and their allow-list never contains this key.
+    # The rewrite is recorded as `aliased_from` in the gateway request log.
+    model_aliases:
+      gpt-5.6-sol: azure_ai/gpt-5.6-sol
     max_concurrency: 8
   # The case budget is the spend control; these caps only stop a runaway. Sized
   # per CONFIGURATION.md at the same per-case-run rate as the other benchmarks:

--- a/vero/src/vero/gateway/inference.py
+++ b/vero/src/vero/gateway/inference.py
@@ -44,6 +44,13 @@ class InferenceScopeConfig(StrictModel):
 
     token_sha256: str
     allowed_models: list[str]
+    # Applied AFTER the allow-list check, on the way upstream. Keeps two
+    # concerns apart: allowed_models says what the caller may ask for, and
+    # therefore what a cell's label means; model_aliases says which upstream
+    # deployment serves it. Rewriting before the check would force the aliased
+    # name into allowed_models, and the allow-list would stop describing the
+    # contestant.
+    model_aliases: dict[str, str] = Field(default_factory=dict)
     max_requests: int | None = Field(default=None, ge=1)
     max_tokens: int | None = Field(default=None, ge=1)
     max_concurrency: int = Field(default=8, ge=1)
@@ -858,6 +865,11 @@ def create_inference_gateway_app(
         # Parameters the upstream refused and we retried without. Recorded so a
         # degraded request is auditable rather than a silent behaviour change.
         dropped_params: list[str] = []
+        # Set when scope.model_aliases rewrote the requested model. Same reason:
+        # a substitution the caller cannot see must be visible in the log. Bound
+        # here rather than at the rewrite, because log_request reads it and fires
+        # on the model_denied path before the rewrite is reached.
+        aliased_from: str | None = None
 
         async def log_request(
             *,
@@ -876,6 +888,7 @@ def create_inference_gateway_app(
                 attribution=attribution,
                 endpoint=endpoint,
                 model=value.get("model") if isinstance(value, dict) else None,
+                aliased_from=aliased_from,
                 dropped_params=dropped_params or None,
                 stream=stream,
                 status=status,
@@ -908,6 +921,29 @@ def create_inference_gateway_app(
             return _provider_error(
                 403, "model is not allowed for this scope", "model_denied"
             )
+
+        # Declared model rewrite, applied only now that the allow-list has passed.
+        # Some harnesses cannot put a provider-qualified id on the wire at all --
+        # codex reduces a model id to its last path component -- so a build that
+        # must reach one specific upstream deployment has no client-side way to
+        # ask for it. Aliasing here is the only place that can.
+        #
+        # Why that matters concretely: an unqualified model group is load-balanced
+        # across deployments, and the Responses API's encrypted reasoning content
+        # is decryptable only by the deployment that produced it. Replaying it
+        # against a sibling fails with invalid_encrypted_content on every turn
+        # after the first. Measured 2026-08-01: bare `gpt-5.6-sol` failed 5 of 5
+        # replays, `azure_ai/gpt-5.6-sol` passed 5 of 5.
+        #
+        # Both names are recorded, so the log shows the substitution rather than
+        # quietly reporting only what went upstream.
+        upstream_model = scope.model_aliases.get(model, model)
+        if upstream_model != model:
+            aliased_from = model
+            value["model"] = upstream_model
+            body = json.dumps(value).encode()
+        else:
+            aliased_from = None
         if not attribution or any(
             not (character.isalnum() or character in "_.-") for character in attribution
         ):
@@ -953,7 +989,10 @@ def create_inference_gateway_app(
         # the parameter on nearly every call -- 52 of 66 in a conformance run --
         # so retrying each one would double that traffic against the RPM limit for
         # no new information.
-        refused = app.state.refused_params.get(model, frozenset())
+        # Keyed on the model that will actually serve the request: refusing a
+        # parameter is a property of the upstream deployment, not of the name the
+        # caller used for it.
+        refused = app.state.refused_params.get(upstream_model, frozenset())
         if refused and isinstance(value, dict):
             known = [name for name in refused if name in value]
             if known:
@@ -985,10 +1024,15 @@ def create_inference_gateway_app(
                     # Re-serialize so the request log records what we really sent.
                     body = json.dumps(value).encode()
                     dropped_params.extend(blamed)
-                    # Bounded by allowed_models across scopes, so this cannot grow
-                    # with traffic: an unlisted model is rejected before reaching
-                    # here.
-                    app.state.refused_params[model] = refused.union(blamed)
+                    # Keyed on upstream_model to match the read above: keying the
+                    # write on the requested name would never hit for an aliased
+                    # model, and the cache would re-discover the same refusal on
+                    # every request.
+                    #
+                    # Bounded by allowed_models (and the finite alias map) across
+                    # scopes, so this cannot grow with traffic: an unlisted model
+                    # is rejected before reaching here.
+                    app.state.refused_params[upstream_model] = refused.union(blamed)
                     upstream = await send(body)
         except httpx.HTTPError:
             await asyncio.shield(

--- a/vero/src/vero/harbor/build/specs.py
+++ b/vero/src/vero/harbor/build/specs.py
@@ -126,6 +126,13 @@ class InferenceBudgetSpec(StrictModel):
     Attributes:
         allowed_models: Models this scope may request. A request naming anything
             else is refused with 403 model_denied.
+        model_aliases: Optional rewrite of the requested model, applied *after*
+            the allow-list check on the way upstream. Use it when the model that
+            must serve a request cannot be named by the caller -- codex, for
+            instance, reduces a model id to its last path component, so it can
+            never ask for a provider-qualified deployment. Declared here rather
+            than inferred, so the substitution is auditable in the build config
+            and in the request log.
         max_requests: Cap on proxied requests; unlimited when omitted.
         max_tokens: Cap on cumulative tokens; unlimited when omitted. Checked
             before a request starts, so a single request can overshoot it.
@@ -133,6 +140,7 @@ class InferenceBudgetSpec(StrictModel):
     """
 
     allowed_models: list[str]
+    model_aliases: dict[str, str] = Field(default_factory=dict)
     max_requests: int | None = Field(default=None, ge=1)
     max_tokens: int | None = Field(default=None, ge=1)
     max_concurrency: int = Field(default=8, ge=1)
@@ -145,6 +153,30 @@ class InferenceBudgetSpec(StrictModel):
         if len(value) != len(set(value)):
             raise ValueError("allowed_models must be unique")
         return value
+
+    @field_validator("model_aliases")
+    @classmethod
+    def validate_aliases(cls, value: dict[str, str]) -> dict[str, str]:
+        # Self-aliases are dropped rather than rejected, and keys outside
+        # allowed_models are permitted. Both concessions exist because one build
+        # config is shared by every cell of a grid, with allowed_models templated
+        # per launch: a map that pins the right deployment for one optimizer
+        # necessarily carries keys the other launches never request. Rejecting
+        # those would make the field unusable exactly where it is needed.
+        #
+        # Nothing is lost by allowing them. An alias can only fire for a model
+        # the allow-list already admitted, so an unreachable key is inert, and a
+        # self-alias is a no-op. The failure this field could cause -- a request
+        # served by a model other than the one named -- is bounded by the
+        # allow-list and made visible by the `aliased_from` field in the request
+        # log, not by validation here.
+        cleaned = {}
+        for requested, upstream in value.items():
+            if not requested.strip() or not upstream.strip():
+                raise ValueError("model_aliases names must not be empty")
+            if requested != upstream:
+                cleaned[requested] = upstream
+        return cleaned
 
 
 class InferenceGatewaySpec(StrictModel):

--- a/vero/tests/test_v05_benchmark_configs.py
+++ b/vero/tests/test_v05_benchmark_configs.py
@@ -168,3 +168,48 @@ def test_build_params_override_run_time_knobs_without_rebuild():
     # The rest of the measurement substrate is untemplated and stays fixed.
     assert overridden.model == default.model
     assert overridden.task_source == default.task_source
+
+
+def test_terminal_bench_azure_variant_differs_only_by_the_model_alias():
+    """build.azure.yaml must be build.yaml plus one alias, and nothing else.
+
+    The variant exists only because codex cannot put a provider-qualified model
+    id on the wire, so the gateway has to pin `gpt-5.6-sol` to a single Azure
+    deployment on its behalf. Everything else -- budgets, timeouts, partitions,
+    the pinned baseline -- has to stay identical, or the cell that uses this file
+    stops being comparable to the nine that use build.yaml.
+
+    There is no include/extends mechanism for these YAMLs, so the variant is a
+    183-line copy. That is a drift hazard with no natural alarm: divergence in a
+    timeout or a budget would change results and fail nothing. This test is the
+    alarm. If you deliberately change build.yaml, mirror it here and the test
+    passes again; if you forget, it does not.
+    """
+    baseline = BENCHMARK_ROOT / "terminal-bench" / "baseline"
+    shared = yaml.safe_load((baseline / "build.yaml").read_text(encoding="utf-8"))
+    variant = yaml.safe_load((baseline / "build.azure.yaml").read_text(encoding="utf-8"))
+
+    alias = variant["inference_gateway"]["producer"].pop("model_aliases")
+    assert alias == {"gpt-5.6-sol": "azure_ai/gpt-5.6-sol"}
+    # Compared after popping the alias: the two documents must now be equal.
+    assert variant == shared, (
+        "build.azure.yaml has drifted from build.yaml beyond the model alias; "
+        "mirror the change or the azure cell is no longer comparable"
+    )
+
+    # And the alias must actually reach the gateway for the cell that needs it,
+    # while staying inert for a cell whose optimizer is something else.
+    sol = load_harbor_build_config(
+        baseline / "build.azure.yaml", params={"optimizer_model": "gpt-5.6-sol"}
+    )
+    other = load_harbor_build_config(
+        baseline / "build.azure.yaml", params={"optimizer_model": "claude-opus-5"}
+    )
+    assert sol.inference_gateway.producer.allowed_models == ["gpt-5.6-sol"]
+    assert sol.inference_gateway.producer.model_aliases == {
+        "gpt-5.6-sol": "azure_ai/gpt-5.6-sol"
+    }
+    # Present but unreachable: the allow-list admits only claude-opus-5, and an
+    # alias can fire only for a model the allow-list already passed.
+    assert other.inference_gateway.producer.allowed_models == ["claude-opus-5"]
+    assert "claude-opus-5" not in other.inference_gateway.producer.model_aliases

--- a/vero/tests/test_v05_harbor_build.py
+++ b/vero/tests/test_v05_harbor_build.py
@@ -1400,3 +1400,43 @@ def test_unresolvable_path_task_source_names_the_missing_data(tmp_path):
     with pytest.raises(ValidationError, match="explicit version"):
         case("unpinned", task_source="gaia/gaia")
     case("pinned", task_source="gaia/gaia@sha256:abc123")
+
+
+def test_model_alias_tolerates_keys_a_given_launch_never_requests():
+    """One build config serves every cell of a grid, so the alias map must
+    tolerate keys the current launch cannot request.
+
+    `allowed_models` is templated per launch (``${optimizer_model}``), so a map
+    that pins the right deployment for one optimizer necessarily carries keys the
+    other launches never name. Those entries are inert -- an alias can only fire
+    for a model the allow-list already admitted -- so rejecting them would make
+    the field unusable in exactly the shared-config case it exists for.
+    """
+    spec = InferenceBudgetSpec(
+        allowed_models=["claude-opus-5"],
+        model_aliases={"gpt-5.6-sol": "azure_ai/gpt-5.6-sol"},
+    )
+    assert spec.model_aliases == {"gpt-5.6-sol": "azure_ai/gpt-5.6-sol"}
+
+    # A self-alias is a no-op and is dropped rather than rejected, so a template
+    # that resolves to `{X: X}` when no override is passed still validates.
+    assert (
+        InferenceBudgetSpec(
+            allowed_models=["gpt-producer"],
+            model_aliases={"gpt-producer": "gpt-producer"},
+        ).model_aliases
+        == {}
+    )
+
+    with pytest.raises(ValidationError, match="must not be empty"):
+        InferenceBudgetSpec(
+            allowed_models=["gpt-producer"], model_aliases={"gpt-producer": "  "}
+        )
+
+    # Reaches the gateway via model_dump, which is how the compiler lowers it.
+    assert InferenceBudgetSpec(
+        allowed_models=["gpt-producer"],
+        model_aliases={"gpt-producer": "vendor_x/gpt-producer"},
+    ).model_dump(mode="json")["model_aliases"] == {
+        "gpt-producer": "vendor_x/gpt-producer"
+    }

--- a/vero/tests/test_v05_harbor_inference.py
+++ b/vero/tests/test_v05_harbor_inference.py
@@ -1111,3 +1111,78 @@ def test_gateway_learns_a_refusal_once_instead_of_retrying_every_request(tmp_pat
     # straight through. Retrying per request would have cost ten.
     assert attempts == [True, False, False, False, False, False], attempts
     assert attempts.count(True) == 1, "the refusal must be discovered only once"
+
+
+def test_model_alias_rewrites_upstream_after_the_allow_list(tmp_path):
+    """A declared alias changes which deployment serves the request, not what the
+    caller may ask for.
+
+    The distinction is the point. `allowed_models` is what makes "this cell ran
+    gpt-test" a true statement, so the alias is applied only once that check has
+    passed: the caller still cannot reach an unlisted model by naming its alias
+    key, and the log records both names.
+    """
+    observed: list[dict] = []
+
+    def upstream(request: httpx.Request):
+        observed.append(json.loads(request.content))
+        return httpx.Response(200, json={"id": "response", "usage": {}})
+
+    config = InferenceGatewayConfig(
+        state_path=str(tmp_path / "usage.json"),
+        request_log=InferenceRequestLogConfig(directory=str(tmp_path / "log")),
+        scopes={
+            "producer": InferenceScopeConfig(
+                token_sha256=token_digest("scoped-token"),
+                allowed_models=["gpt-test", "plain"],
+                model_aliases={"gpt-test": "vendor_x/gpt-test"},
+                max_concurrency=1,
+            )
+        },
+    )
+    app = create_inference_gateway_app(
+        config=config,
+        upstream_api_key="upstream-secret",
+        upstream_base_url="https://provider.example/v1",
+        transport=httpx.MockTransport(upstream),
+    )
+    with TestClient(app) as client:
+        aliased = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "gpt-test", "input": "hello"},
+        )
+        untouched = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "plain", "input": "hello"},
+        )
+        # The alias TARGET is not itself allow-listed, so naming it directly is
+        # still refused. An alias must not become a second way in.
+        target_direct = client.post(
+            "/scopes/producer/optimizer/v1/responses",
+            headers={"Authorization": "Bearer scoped-token"},
+            json={"model": "vendor_x/gpt-test", "input": "hello"},
+        )
+
+    assert aliased.status_code == 200
+    assert untouched.status_code == 200
+    assert target_direct.status_code == 403
+    assert target_direct.json()["error"]["code"] == "model_denied"
+
+    # Rewritten on the way upstream; the unaliased model passes through as-is.
+    assert [payload["model"] for payload in observed] == [
+        "vendor_x/gpt-test",
+        "plain",
+    ]
+
+    records = [
+        json.loads(line)
+        for path in sorted((tmp_path / "log").glob("requests-*.jsonl"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    proxied = [record for record in records if record["status"] == 200]
+    assert [(r["model"], r.get("aliased_from")) for r in proxied] == [
+        ("vendor_x/gpt-test", "gpt-test"),
+        ("plain", None),
+    ]


### PR DESCRIPTION
## Why

A contestant cell in the harness-engineering-bench study, `gpt-5.6-sol × codex`, failed
on terminal-bench and nowhere else. It ships real candidates on officeqa r1/r2/r3 and
browsecomp-plus r1/r2/r3, so it is not a routing problem with the contestant.

The fault is `invalid_encrypted_content`, and it is deterministic rather than
load-dependent. An unqualified model group is load-balanced across upstream
deployments, and the Responses API's encrypted reasoning content is decryptable only by
the deployment that produced it. Replaying it against a sibling deployment fails on
every turn after the first.

Reproduced against the upstream proxy directly, with no gateway and no codex in the
path:

| model id | replays passed |
|---|---|
| `gpt-5.6-sol` (bare group) | 0 of 8 |
| `azure_ai/gpt-5.6-sol` (pinned deployment) | 5 of 5 |

Asking for the pinned deployment fixes it — but **codex cannot express that request.**
It reduces a model id to its last path component before putting it on the wire, so
`azure_ai/gpt-5.6-sol` arrives as `gpt-5.6-sol` and we are back where we started. There
is no client-side fix available for this harness.

## What this does

Adds `model_aliases` to an inference-gateway scope: a declared map from the name a
caller may request to the upstream deployment that serves it.

The ordering is the whole design, and it is deliberate:

```python
upstream_model = scope.model_aliases.get(model, model)
```

This runs **after** the allow-list check, not before. `allowed_models` continues to
govern what the optimizer may ask for — and therefore what a cell's label means —
while `model_aliases` decides only which deployment answers. Rewriting before the
check would force the aliased name into `allowed_models`, and the allow-list would stop
describing the contestant.

Both names are recorded in the request log via a new `aliased_from` field, so a
substitution the caller cannot see is still visible to whoever reads the log later.

`refused_params` is keyed on `upstream_model` for both its read and its write, since
refusing a parameter is a property of the deployment rather than of the name used for
it. Keying the write on the requested name would never hit on the read path for an
aliased model, and the cache would re-discover the same refusal on every request.

## Where it is configured

In `terminal-bench/baseline/build.azure.yaml`, in the **producer** scope only. The
evaluation and finalization scopes are untouched — they target grok, which was never
affected.

That file is a copy of `build.yaml` rather than an overlay, and it differs from it by
exactly the two alias lines. **Edits to `build.yaml` must be mirrored**, which is not
hypothetical: the first version of this change missed the finalization budget and
needed a follow-up commit to bring it back into line.

Also included, from the same investigation: terminal-bench's finalization budget is
sized like the rest of the suite.

## Verification

- Full suite green: **496 passed, 8 skipped**.
- New tests cover the alias reaching the gateway through `model_dump`, self-aliases
  being dropped rather than rejected, empty targets being refused, and — the case that
  matters for a shared grid config — alias keys that a given launch can never request,
  since `allowed_models` is templated per cell while the alias map is not.
- Live: two `gpt-5.6-sol × codex` terminal-bench cells have been running on this config
  for 25 and 18 minutes with **zero `invalid_encrypted_content` and zero 403s**, where
  the old failures crashed within minutes.

## Note on scope

This is a workaround at the right layer, not the root fix. The upstream remedy is
`encrypted_content_affinity` in the proxy's `router_settings`, exactly as the error text
prescribes. This change lets the study close its last gap without waiting on that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-scope model aliases to pin caller-visible model names to specific upstream deployments.
- Applies aliases only after the requested model passes the scope allow-list.
- Preserves aliases while compiling build specifications into gateway configuration.
- Records requested and upstream model names and keys parameter-refusal caching by upstream deployment.
- Adds an Azure-specific Terminal-Bench configuration and aligns its finalization budget with the shared configuration.
- Adds validation and tests for alias serialization, routing, logging, and configuration parity.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the alias preserved through compilation and applied only after the existing model allow-list check.

The changed routing path retains scope authorization, rewrites only admitted model names, forwards the effective deployment consistently, and has focused coverage for configuration propagation and runtime behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vero/src/vero/gateway/inference.py | Applies model aliases after authorization, forwards the rewritten payload, records alias attribution, and associates refused parameters with the effective upstream model. |
| vero/src/vero/harbor/build/specs.py | Adds validated model-alias configuration while permitting inert aliases required by templated grid configurations. |
| harness-engineering-bench/terminal-bench/baseline/build.azure.yaml | Introduces an Azure-pinned Terminal-Bench variant whose only intended behavioral difference is the producer model alias. |
| harness-engineering-bench/terminal-bench/baseline/build.yaml | Raises the finalization token budget to cover the configured test and validation rescoring workload. |
| vero/tests/test_v05_harbor_inference.py | Verifies post-allow-list alias routing, direct-target denial, pass-through behavior, and request-log attribution. |
| vero/tests/test_v05_benchmark_configs.py | Ensures the Azure build variant remains identical to the shared configuration except for its declared alias. |
| vero/tests/test_v05_harbor_build.py | Covers alias validation, self-alias normalization, unreachable keys, and serialization into gateway configuration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Caller requests model] --> B{Allowed by scope?}
    B -- No --> C[Return model_denied]
    B -- Yes --> D[Resolve model_aliases]
    D --> E[Apply cached refused parameters]
    E --> F[Send to pinned upstream deployment]
    F --> G[Record upstream model and aliased_from]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Ignore Codex CLI local state"](https://github.com/scaleapi/vero/commit/29bdb92f0b23597bd55cc36759ac890be35d98a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49343680)</sub>

<!-- /greptile_comment -->